### PR TITLE
AuthnContextDeclRef and AuthnContextDecl

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -33,7 +33,7 @@
 
     <target name="composer-run-install" depends="composer-update">
         <exec executable="php" failonerror="true">
-            <arg line="composer.phar install --dev"/>
+            <arg line="composer.phar install --dev --prefer-source"/>
         </exec>
     </target>
 

--- a/tests/SAML2/AssertionTest.php
+++ b/tests/SAML2/AssertionTest.php
@@ -46,10 +46,9 @@ class SAML2_AssertionTest extends \PHPUnit_Framework_TestCase
         $document = new \DOMDocument();
         $document->loadXML(<<<XML
 <saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
-                xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
                 ID="_593e33ddf86449ce4d4c22b60ac48e067d98a0b2bf"
                 Version="2.0"
-                 IssueInstant="2010-03-05T13:34:28Z"
+                IssueInstant="2010-03-05T13:34:28Z"
 >
   <saml:Issuer>testIssuer</saml:Issuer>
   <saml:Conditions>
@@ -81,6 +80,192 @@ XML
         $this->assertCount(2, $assertionAuthenticatingAuthorities);
         $this->assertEquals('someIdP1', $assertionAuthenticatingAuthorities[0]);
         $this->assertEquals('someIdP2', $assertionAuthenticatingAuthorities[1]);
+    }
+
+    public function testAuthnContextDeclAndClassRef()
+    {
+        // Try with unmarshalling
+        $document = new DOMDocument();
+        $document->loadXML(<<<XML
+<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                ID="_593e33ddf86449ce4d4c22b60ac48e067d98a0b2bf"
+                Version="2.0"
+                 IssueInstant="2010-03-05T13:34:28Z"
+>
+  <saml:Issuer>testIssuer</saml:Issuer>
+  <saml:AuthnStatement AuthnInstant="2010-03-05T13:34:28Z">
+    <saml:AuthnContext>
+      <saml:AuthnContextClassRef>someAuthnContext</saml:AuthnContextClassRef>
+      <saml:AuthnContextDecl>
+        <samlac:AuthenticationContextDeclaration xmlns:samlac="urn:oasis:names:tc:SAML:2.0:ac">
+        </samlac:AuthenticationContextDeclaration>
+      </saml:AuthnContextDecl>
+    </saml:AuthnContext>
+  </saml:AuthnStatement>
+</saml:Assertion>
+XML
+        );
+
+
+        $assertion = new \SAML2_Assertion($document->documentElement);
+        $authnContextDecl = $assertion->getAuthnContextDecl();
+        $this->assertNotEmpty($authnContextDecl);
+        $this->assertEquals('AuthnContextDecl', $authnContextDecl->localName);
+        $childLocalName = $authnContextDecl->getXML()->childNodes->item(1)->localName;
+        $this->assertEquals('AuthenticationContextDeclaration', $childLocalName);
+
+        $this->assertEquals('someAuthnContext', $assertion->getAuthnContextClassRef());
+    }
+
+    public function testAuthnContextDeclRefAndClassRef()
+    {
+        // Try with unmarshalling
+        $document = new DOMDocument();
+        $document->loadXML(<<<XML
+<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                ID="_593e33ddf86449ce4d4c22b60ac48e067d98a0b2bf"
+                Version="2.0"
+                 IssueInstant="2010-03-05T13:34:28Z"
+>
+  <saml:Issuer>testIssuer</saml:Issuer>
+  <saml:AuthnStatement AuthnInstant="2010-03-05T13:34:28Z">
+    <saml:AuthnContext>
+      <saml:AuthnContextClassRef>someAuthnContext</saml:AuthnContextClassRef>
+      <saml:AuthnContextDeclRef>/relative/path/to/document.xml</saml:AuthnContextDeclRef>
+    </saml:AuthnContext>
+  </saml:AuthnStatement>
+</saml:Assertion>
+XML
+        );
+
+
+        $assertion = new \SAML2_Assertion($document->documentElement);
+        $this->assertEquals('/relative/path/to/document.xml', $assertion->getAuthnContextDeclRef());
+        $this->assertEquals('someAuthnContext', $assertion->getAuthnContextClassRef());
+    }
+
+    public function testAuthnContextDeclAndRefConstraint()
+    {
+        $document = new DOMDocument();
+        $document->loadXML(<<<XML
+<samlac:AuthenticationContextDeclaration xmlns:samlac="urn:oasis:names:tc:SAML:2.0:ac">
+</samlac:AuthenticationContextDeclaration>
+XML
+    );
+
+        $assertion = new \SAML2_Assertion();
+
+        $e = null;
+        try {
+            $assertion->setAuthnContextDecl(new SAML2_XML_Chunk($document->documentElement));
+            $assertion->setAuthnContextDeclRef('/relative/path/to/document.xml');
+        }
+        catch (Exception $e) {}
+        $this->assertNotEmpty($e);
+
+        // Try again in reverse order for good measure.
+        $assertion = new \SAML2_Assertion();
+
+        $e = null;
+        try {
+            $assertion->setAuthnContextDeclRef('/relative/path/to/document.xml');
+            $assertion->setAuthnContextDecl(new SAML2_XML_Chunk($document->documentElement));
+        }
+        catch (Exception $e) {}
+        $this->assertNotEmpty($e);
+
+        // Try with unmarshalling
+        $document = new DOMDocument();
+        $document->loadXML(<<<XML
+<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                ID="_593e33ddf86449ce4d4c22b60ac48e067d98a0b2bf"
+                Version="2.0"
+                 IssueInstant="2010-03-05T13:34:28Z"
+>
+  <saml:Issuer>testIssuer</saml:Issuer>
+  <saml:AuthnStatement AuthnInstant="2010-03-05T13:34:28Z">
+    <saml:AuthnContext>
+      <saml:AuthnContextDecl>
+        <samlac:AuthenticationContextDeclaration xmlns:samlac="urn:oasis:names:tc:SAML:2.0:ac">
+        </samlac:AuthenticationContextDeclaration>
+      </saml:AuthnContextDecl>
+      <saml:AuthnContextDeclRef>/relative/path/to/document.xml</saml:AuthnContextDeclRef>
+    </saml:AuthnContext>
+  </saml:AuthnStatement>
+</saml:Assertion>
+XML
+        );
+
+        $e = null;
+        try {
+            new \SAML2_Assertion($document->documentElement);
+        }
+        catch (Exception $e) {}
+        $this->assertNotEmpty($e);
+    }
+
+    public function testMustHaveClassRefOrDeclOrDeclRef()
+    {
+        // Unmarshall an assertion
+        $document = new \DOMDocument();
+        $document->loadXML(<<<XML
+<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                ID="_593e33ddf86449ce4d4c22b60ac48e067d98a0b2bf"
+                Version="2.0"
+                IssueInstant="2010-03-05T13:34:28Z"
+>
+  <saml:Issuer>testIssuer</saml:Issuer>
+  <saml:AuthnStatement AuthnInstant="2010-03-05T13:34:28Z">
+    <saml:AuthnContext>
+      <saml:AuthenticatingAuthority>someIdP1</saml:AuthenticatingAuthority>
+      <saml:AuthenticatingAuthority>someIdP2</saml:AuthenticatingAuthority>
+    </saml:AuthnContext>
+  </saml:AuthnStatement>
+</saml:Assertion>
+XML
+        );
+        $e = null;
+        try {
+            $assertion = new \SAML2_Assertion($document->firstChild);
+        }
+        catch (Exception $e) {
+        }
+        $this->assertNotEmpty($e);
+    }
+
+    /**
+     * Tests that AuthnContextDeclRef is not mistaken for AuthnContextClassRef.
+     *
+     * This tests against reintroduction of removed behavior.
+     */
+    public function testNoAuthnContextDeclRefFallback()
+    {
+        $authnContextDeclRef = 'relative/url/to/authcontext.xml';
+
+        // Unmarshall an assertion
+        $document = new \DOMDocument();
+        $document->loadXML(<<<XML
+<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                ID="_593e33ddf86449ce4d4c22b60ac48e067d98a0b2bf"
+                Version="2.0"
+                 IssueInstant="2010-03-05T13:34:28Z"
+>
+  <saml:Issuer>testIssuer</saml:Issuer>
+  <saml:AuthnStatement AuthnInstant="2010-03-05T13:34:28Z">
+    <saml:AuthnContext>
+      <saml:AuthnContextDeclRef>$authnContextDeclRef</saml:AuthnContextDeclRef>
+    </saml:AuthnContext>
+  </saml:AuthnStatement>
+</saml:Assertion>
+XML
+        );
+        $assertion = new \SAML2_Assertion($document->firstChild);
+        $this->assertEmpty($assertion->getAuthnContextClassRef());
+        $this->assertEquals($authnContextDeclRef, $assertion->getAuthnContextDeclRef());
     }
 }
 


### PR DESCRIPTION
- Added ability to set, get, marshall, unmarshall AuthnContextDecl and AuthnContextDeclRef
- Deprecated set/getAuthnContext in favor of set/getAuthnContextClassRef
- Removed fallback from AuthnContextDeclRef to AuthnContextClassRef
- Refactored some short variables.
