### PR TITLE
Use semver for psr/log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,8 @@
         "ext-openssl": "*",
         "ext-dom": "*",
         "ext-mcrypt": "*",
-        
         "simplesamlphp/xmlseclibs": "~1.3.1",
-        "psr/log": "1.0.0"
+        "psr/log": "~1.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "~1.4",


### PR DESCRIPTION
some frameworks that needed a version of PSR/log greater that 1.0.0

When it was set to 1.0.0 I had trouble integrating the library in to Laravel 5 even though it worked fine with Laravel 4.

Now it works fine with both.
