### PR TITLE
Modified the xsDateTime regex

### DIFF
--- a/src/SAML2/Utils.php
+++ b/src/SAML2/Utils.php
@@ -683,7 +683,7 @@ class SAML2_Utils
         $matches = array();
 
         // We use a very strict regex to parse the timestamp.
-        $regex = '/^(\\d\\d\\d\\d)-(\\d\\d)-(\\d\\d)T(\\d\\d):(\\d\\d):(\\d\\d)(?:\\.\\d+)?Z$/D';
+        $regex = '/^(\\d\\d\\d\\d)-(\\d\\d)-(\\d\\d)T(\\d\\d):(\\d\\d):(\\d\\d)(?:\\.\\d+)?Z?$/D';
         if (preg_match($regex, $time, $matches) == 0) {
             throw new Exception(
                 'Invalid SAML2 timestamp passed to xsDateTimeToTimestamp: ' . $time

--- a/tests/SAML2/UtilsTest.php
+++ b/tests/SAML2/UtilsTest.php
@@ -179,4 +179,34 @@ class SAML2_UtilsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('value (en)', $localizedStringValues["en"]);
         $this->assertEquals('value (no)', $localizedStringValues["no"]);
     }
+
+    /**
+     * Test xsDateTime format validity
+     *
+     * @dataProvider xsDateTimes
+     */
+    public function testXsDateTimeToTimestamp($shouldPass, $time, $expectedTs = null)
+    {
+        try {
+            $ts = SAML2_Utils::xsDateTimeToTimestamp($time);
+            $this->assertTrue($shouldPass);
+            $this->assertEquals($expectedTs, $ts);
+        } catch (Exception $e) {
+            $this->assertFalse($shouldPass);
+        }
+    }
+
+    public function xsDateTimes()
+    {
+        return array(
+            array(true, '2015-01-01T00:00:00Z', 1420070400),
+            array(true, '2015-01-01T00:00:00.0Z', 1420070400),
+            array(true, '2015-01-01T00:00:00.1Z', 1420070400),
+            array(true, '2015-01-01T00:00:00', 1420070400),
+            array(true, '2015-01-01T00:00:00.0', 1420070400),
+            array(false, 'junk'),
+            array(false, '2015-01-01T00:00:00-04:00'),
+            array(false, '2015-01-01T00:00:00.0-04:00'),
+        );
+    }
 }


### PR DESCRIPTION
according to SAML v2.0 core specification's paragraph 1.3.3 and xmlschema-2#dateTime I think the Z can be omitted