### PR TITLE
Allow Optional <saml:Subject> in AuthnRequest

### DIFF
--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -172,7 +172,7 @@ class SAML2_AuthnRequest extends SAML2_Request
         }
 
         if (count($subject) > 1) {
-            throw new Exception('More than one <saml:Subject> in <saml:Assertion>.');
+            throw new Exception('More than one <saml:Subject> in <saml:AuthnRequest>.');
         }
         $subject = $subject[0];
 

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -101,6 +101,20 @@ class SAML2_AuthnRequest extends SAML2_Request
      */
     private $requestedAuthnContext;
 
+    /**
+     * @var SAML2_XML_saml_SubjectConfirmation[]
+     */
+    private $SubjectConfirmation = array();
+
+    /**
+     * @var string
+     */
+    private $encryptedNameId;
+
+    /**
+     * @var string
+     */
+    private $nameId;
 
     /**
      * Constructor for SAML 2 authentication request messages.
@@ -139,8 +153,60 @@ class SAML2_AuthnRequest extends SAML2_Request
             $this->assertionConsumerServiceIndex = (int) $xml->getAttribute('AssertionConsumerServiceIndex');
         }
 
-        $nameIdPolicy = SAML2_Utils::xpQuery($xml, './saml_protocol:NameIDPolicy');
+        $this->parseSubject($xml);
+        $this->parseNameIdPolicy($xml);
+        $this->parseRequestedAuthnContext($xml);
+        $this->parseScoping($xml);
+    }
 
+    /**
+     * @param $xml
+     *
+     * @throws Exception
+     */
+    private function parseSubject(DOMElement $xml)
+    {
+        $subject = SAML2_Utils::xpQuery($xml, './saml_assertion:Subject');
+        if (empty($subject)) {
+            return;
+        }
+
+        if (count($subject) > 1) {
+            throw new Exception('More than one <saml:Subject> in <saml:Assertion>.');
+        }
+        $subject = $subject[0];
+
+        $nameId = SAML2_Utils::xpQuery(
+            $subject,
+            './saml_assertion:NameID | ./saml_assertion:EncryptedID/xenc:EncryptedData'
+        );
+        if (empty($nameId)) {
+            throw new Exception('Missing <saml:NameID> or <saml:EncryptedID> in <saml:Subject>.');
+        } elseif (count($nameId) > 1) {
+            throw new Exception('More than one <saml:NameID> or <saml:EncryptedD> in <saml:Subject>.');
+        }
+        $nameId = $nameId[0];
+        if ($nameId->localName === 'EncryptedData') {
+            /* The NameID element is encrypted. */
+            $this->encryptedNameId = $nameId;
+        } else {
+            $this->nameId = SAML2_Utils::parseNameId($nameId);
+        }
+
+        $subjectConfirmation = SAML2_Utils::xpQuery($subject, './saml_assertion:SubjectConfirmation');
+        foreach ($subjectConfirmation as $sc) {
+            $this->SubjectConfirmation[] = new SAML2_XML_saml_SubjectConfirmation($sc);
+        }
+    }
+
+    /**
+     * @param DOMElement $xml
+     *
+     * @throws Exception
+     */
+    protected function parseNameIdPolicy(DOMElement $xml)
+    {
+        $nameIdPolicy = SAML2_Utils::xpQuery($xml, './saml_protocol:NameIDPolicy');
         if (!empty($nameIdPolicy)) {
             $nameIdPolicy = $nameIdPolicy[0];
             if ($nameIdPolicy->hasAttribute('Format')) {
@@ -153,14 +219,20 @@ class SAML2_AuthnRequest extends SAML2_Request
                 $this->nameIdPolicy['AllowCreate'] = SAML2_Utils::parseBoolean($nameIdPolicy, 'AllowCreate', FALSE);
             }
         }
+    }
 
+    /**
+     * @param DOMElement $xml
+     */
+    protected function parseRequestedAuthnContext(DOMElement $xml)
+    {
         $requestedAuthnContext = SAML2_Utils::xpQuery($xml, './saml_protocol:RequestedAuthnContext');
         if (!empty($requestedAuthnContext)) {
             $requestedAuthnContext = $requestedAuthnContext[0];
 
             $rac = array(
                 'AuthnContextClassRef' => array(),
-                'Comparison' => 'exact',
+                'Comparison'           => 'exact',
             );
 
             $accr = SAML2_Utils::xpQuery($requestedAuthnContext, './saml_assertion:AuthnContextClassRef');
@@ -174,13 +246,21 @@ class SAML2_AuthnRequest extends SAML2_Request
 
             $this->requestedAuthnContext = $rac;
         }
+    }
 
+    /**
+     * @param DOMElement $xml
+     *
+     * @throws Exception
+     */
+    protected function parseScoping(DOMElement $xml)
+    {
         $scoping = SAML2_Utils::xpQuery($xml, './saml_protocol:Scoping');
         if (!empty($scoping)) {
-            $scoping =$scoping[0];
+            $scoping = $scoping[0];
 
             if ($scoping->hasAttribute('ProxyCount')) {
-                $this->ProxyCount = (int) $scoping->getAttribute('ProxyCount');
+                $this->ProxyCount = (int)$scoping->getAttribute('ProxyCount');
             }
             $idpEntries = SAML2_Utils::xpQuery($scoping, './saml_protocol:IDPList/saml_protocol:IDPEntry');
 
@@ -198,7 +278,6 @@ class SAML2_AuthnRequest extends SAML2_Request
 
         }
     }
-
 
     /**
      * Retrieve the NameIdPolicy.
@@ -457,6 +536,111 @@ class SAML2_AuthnRequest extends SAML2_Request
         $this->requestedAuthnContext = $requestedAuthnContext;
     }
 
+    /**
+     * Retrieve the NameId of the subject in the assertion.
+     *
+     * The returned NameId is in the format used by SAML2_Utils::addNameId().
+     *
+     * @see SAML2_Utils::addNameId()
+     * @return array|NULL The name identifier of the assertion.
+     * @throws Exception
+     */
+    public function getNameId()
+    {
+        if ($this->encryptedNameId !== NULL) {
+            throw new Exception('Attempted to retrieve encrypted NameID without decrypting it first.');
+        }
+
+        return $this->nameId;
+    }
+
+    /**
+     * Set the NameId of the subject in the assertion.
+     *
+     * The NameId must be in the format accepted by SAML2_Utils::addNameId().
+     *
+     * @see SAML2_Utils::addNameId()
+     *
+     * @param array|NULL $nameId The name identifier of the assertion.
+     */
+    public function setNameId($nameId)
+    {
+        assert('is_array($nameId) || is_null($nameId)');
+
+        $this->nameId = $nameId;
+    }
+
+    /**
+     * Encrypt the NameID in the Assertion.
+     *
+     * @param XMLSecurityKey $key The encryption key.
+     */
+    public function encryptNameId(XMLSecurityKey $key)
+    {
+        /* First create a XML representation of the NameID. */
+        $doc  = new DOMDocument();
+        $root = $doc->createElement('root');
+        $doc->appendChild($root);
+        SAML2_Utils::addNameId($root, $this->nameId);
+        $nameId = $root->firstChild;
+
+        SAML2_Utils::getContainer()->debugMessage($nameId, 'encrypt');
+
+        /* Encrypt the NameID. */
+        $enc = new XMLSecEnc();
+        $enc->setNode($nameId);
+        // @codingStandardsIgnoreStart
+        $enc->type = XMLSecEnc::Element;
+        // @codingStandardsIgnoreEnd
+
+        $symmetricKey = new XMLSecurityKey(XMLSecurityKey::AES128_CBC);
+        $symmetricKey->generateSessionKey();
+        $enc->encryptKey($key, $symmetricKey);
+
+        $this->encryptedNameId = $enc->encryptNode($symmetricKey);
+        $this->nameId          = NULL;
+    }
+
+    /**
+     * Decrypt the NameId of the subject in the assertion.
+     *
+     * @param XMLSecurityKey $key       The decryption key.
+     * @param array          $blacklist Blacklisted decryption algorithms.
+     */
+    public function decryptNameId(XMLSecurityKey $key, array $blacklist = array())
+    {
+        if ($this->encryptedNameId === NULL) {
+            /* No NameID to decrypt. */
+
+            return;
+        }
+
+        $nameId = SAML2_Utils::decryptElement($this->encryptedNameId, $key, $blacklist);
+        SAML2_Utils::getContainer()->debugMessage($nameId, 'decrypt');
+        $this->nameId = SAML2_Utils::parseNameId($nameId);
+
+        $this->encryptedNameId = NULL;
+    }
+
+    /**
+     * Retrieve the SubjectConfirmation elements we have in our Subject element.
+     *
+     * @return SAML2_XML_saml_SubjectConfirmation[]
+     */
+    public function getSubjectConfirmation()
+    {
+        return $this->SubjectConfirmation;
+    }
+
+    /**
+     * Set the SubjectConfirmation elements that should be included in the assertion.
+     *
+     * @param array SAML2_XML_saml_SubjectConfirmation[]
+     */
+    public function setSubjectConfirmation(array $SubjectConfirmation)
+    {
+        $this->SubjectConfirmation = $SubjectConfirmation;
+    }
 
     /**
      * Convert this authentication request to an XML element.
@@ -494,6 +678,8 @@ class SAML2_AuthnRequest extends SAML2_Request
         if ($this->attributeConsumingServiceIndex !== NULL) {
             $root->setAttribute('AttributeConsumingServiceIndex', $this->attributeConsumingServiceIndex);
         }
+
+        $this->addSubject($root);
 
         if (!empty($this->nameIdPolicy)) {
             $nameIdPolicy = $this->document->createElementNS(SAML2_Const::NS_SAMLP, 'NameIDPolicy');
@@ -544,4 +730,31 @@ class SAML2_AuthnRequest extends SAML2_Request
         return $root;
     }
 
+    /**
+     * Add a Subject-node to the assertion.
+     *
+     * @param DOMElement $root The assertion element we should add the subject to.
+     */
+    private function addSubject(DOMElement $root)
+    {
+        // If there is no nameId (encrypted or not) there is nothing to create a subject for
+        if ($this->nameId === NULL && $this->encryptedNameId === NULL) {
+            return;
+        }
+
+        $subject = $root->ownerDocument->createElementNS(SAML2_Const::NS_SAML, 'saml:Subject');
+        $root->appendChild($subject);
+
+        if ($this->encryptedNameId === NULL) {
+            SAML2_Utils::addNameId($subject, $this->nameId);
+        } else {
+            $eid = $subject->ownerDocument->createElementNS(SAML2_Const::NS_SAML, 'saml:EncryptedID');
+            $subject->appendChild($eid);
+            $eid->appendChild($subject->ownerDocument->importNode($this->encryptedNameId, TRUE));
+        }
+
+        foreach ($this->SubjectConfirmation as $sc) {
+            $sc->toXML($subject);
+        }
+    }
 }

--- a/src/SAML2/Const.php
+++ b/src/SAML2/Const.php
@@ -53,6 +53,33 @@ class SAML2_Const
     const CM_HOK = 'urn:oasis:names:tc:SAML:2.0:cm:holder-of-key';
 
     /**
+     * Request Authentication Context Comparison indicating that  the resulting authentication context in the
+     * authentication statement MUST be stronger (as deemed by the responder) than any one of the authentication
+     * contexts specified
+     */
+    const COMPARISON_BETTER = 'better';
+
+    /**
+     * Request Authentication Context Comparison indicating that the resulting authentication context in the
+     * authentication statement MUST be the exact match of at least one of the authentication contexts specified
+     */
+    const COMPARISON_EXACT = 'exact';
+
+    /**
+     * Request Authentication Context Comparison indicating that the resulting authentication context in the
+     * authentication statement MUST be as strong as possible (as deemed by the responder) without exceeding the
+     * strength of at least one of the authentication contexts specified.
+     */
+    const COMPARISON_MAXIMUM = 'maximum';
+
+    /**
+     * Request Authentication Context Comparison indicating that he resulting authentication context in the
+     * authentication statement MUST be at least as strong (as deemed by the responder) as one of the authentication
+     * contexts specified.
+     */
+    const COMPARISON_MINIMUM = 'minimum';
+
+    /**
      * No claim as to principal consent is being made.
      */
     const CONSENT_UNSPECIFIED = 'urn:oasis:names:tc:SAML:2.0:consent:unspecified';

--- a/tests/SAML2/AuthnRequestTest.php
+++ b/tests/SAML2/AuthnRequestTest.php
@@ -36,6 +36,37 @@ class SAML2_AuthnRequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('accr2', $authnContextClassRefElements[1]->textContent);
     }
 
+    public function testMarshallingOfSimpleRequest()
+    {
+        $document = new DOMDocument();
+        $document->loadXML(<<<AUTHNREQUEST
+<samlp:AuthnRequest
+  xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+  xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+  ID="_306f8ec5b618f361c70b6ffb1480eade"
+  Version="2.0"
+  IssueInstant="2004-12-05T09:21:59Z"
+  Destination="https://idp.example.org/SAML2/SSO/Artifact"
+  ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact"
+  AssertionConsumerServiceURL="https://sp.example.com/SAML2/SSO/Artifact">
+    <saml:Issuer>https://sp.example.com/SAML2</saml:Issuer>
+</samlp:AuthnRequest>
+AUTHNREQUEST
+        );
+
+        $authnRequest = new SAML2_AuthnRequest($document->documentElement);
+
+        $expectedIssueInstant = SAML2_Utils::xsDateTimeToTimestamp('2004-12-05T09:21:59Z');
+        $this->assertEquals($expectedIssueInstant, $authnRequest->getIssueInstant());
+        $this->assertEquals('https://idp.example.org/SAML2/SSO/Artifact', $authnRequest->getDestination());
+        $this->assertEquals('urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact', $authnRequest->getProtocolBinding());
+        $this->assertEquals(
+            'https://sp.example.com/SAML2/SSO/Artifact',
+            $authnRequest->getAssertionConsumerServiceURL()
+        );
+        $this->assertEquals('https://sp.example.com/SAML2', $authnRequest->getIssuer());
+    }
+
     /**
      * Test unmarshalling / marshalling of XML with Extensions element
      */
@@ -108,5 +139,107 @@ AUTHNREQUEST
         $requestAsXML = $request->toUnsignedXML()->ownerDocument->saveXML();
         $expected = '<saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">user@example.org</saml:NameID></saml:Subject>';
         $this->assertContains($expected, $requestAsXML);
+    }
+
+    public function testThatAnEncryptedNameIdCanBeDecrypted()
+    {
+        $document = new DOMDocument();
+        $document->loadXML(<<<AUTHNREQUEST
+<samlp:AuthnRequest
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    ID="123"
+    Version="2.0"
+    IssueInstant="2015-05-11T09:02:36Z"
+    Destination="https://tiqr.stepup.org/idp/profile/saml2/Redirect/SSO">
+    <saml:Issuer>https://gateway.stepup.org/saml20/sp/metadata</saml:Issuer>
+    <saml:Subject>
+        <saml:EncryptedID xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+            <xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" Type="http://www.w3.org/2001/04/xmlenc#Element">
+                <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
+                <dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+                    <xenc:EncryptedKey>
+                        <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+                        <xenc:CipherData>
+                            <xenc:CipherValue>Kzb231F/6iLrDG9KP99h1C08eV2WfRqasU0c3y9AG+nb0JFdQgqip5+5FN+ypi1zPz4FIdoPufXdQDIRi4tm1UMyaiA5MBHjk2GOw5GDc6idnzFAoy4uWlofELeeT2ftcP4c6ETDsu++iANi5XUU1A+WPxxel2NMss6F6MjOuCg=</xenc:CipherValue>
+                        </xenc:CipherData>
+                    </xenc:EncryptedKey>
+                </dsig:KeyInfo>
+                <xenc:CipherData>
+                    <xenc:CipherValue>EHj4x8ZwXvxIHFo4uenQcXZsUnS0VPyhevIMwE6YfejFwW0V3vUImCVKfdEtMJgNS/suukvc/HmF2wHptBqk3yjwbRfdFX2axO7UPqyThiGkVTkccOpIv7RzN8mkiDe9cjOztIQYd1DfKrjgh+FFL10o08W+HSZFgp4XQGOAruLj+JVyoDlx6FMyTIRgeLxlW4K2G1++Xmp8wyLyoMCccdDRzX3KT/Ph2RVIDpE/XLznpQd19sgwaEguUerqdHwo</xenc:CipherValue>
+                </xenc:CipherData>
+            </xenc:EncryptedData>
+        </saml:EncryptedID>
+    </saml:Subject>
+</samlp:AuthnRequest>
+AUTHNREQUEST
+        );
+
+        $authnRequest = new SAML2_AuthnRequest($document->documentElement);
+
+        $key = SAML2_CertificatesMock::getPrivateKey();
+        $authnRequest->decryptNameId($key);
+
+        $expectedNameId = array('Value' => md5('Arthur Dent'), 'Format' => SAML2_Const::NAMEID_ENCRYPTED);
+
+        $this->assertEquals($expectedNameId, $authnRequest->getNameId());
+    }
+
+    /**
+     * Due to the fact that the symmetric key is generated each time, we cannot test whether or not the resulting XML
+     * matches a specific XML, but we can test whether or not the resulting structure is actually correct, conveying
+     * all information required to decrypt the NameId.
+     */
+    public function testThatAnEncryptedNameIdResultsInTheCorrectXmlStructure()
+    {
+        // the NameID we're going to encrypt
+        $nameId = array('Value' => md5('Arthur Dent'), 'Format' => SAML2_Const::NAMEID_ENCRYPTED);
+
+        // basic AuthnRequest
+        $request = new SAML2_AuthnRequest();
+        $request->setIssuer('https://gateway.stepup.org/saml20/sp/metadata');
+        $request->setDestination('https://tiqr.stepup.org/idp/profile/saml2/Redirect/SSO');
+        $request->setNameId($nameId);
+
+        // encrypt the NameID
+        $key = SAML2_CertificatesMock::getPublicKey();
+        $request->encryptNameId($key);
+
+        $expectedStructureDocument = new DOMDocument();
+        $expectedStructureDocument->loadXML(<<<AUTHNREQUEST
+<samlp:AuthnRequest
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    ID=""
+    Version=""
+    IssueInstant=""
+    Destination="">
+    <saml:Issuer></saml:Issuer>
+    <saml:Subject>
+        <saml:EncryptedID xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+            <xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" Type="http://www.w3.org/2001/04/xmlenc#Element">
+                <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
+                <dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+                    <xenc:EncryptedKey>
+                        <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+                        <xenc:CipherData>
+                            <xenc:CipherValue></xenc:CipherValue>
+                        </xenc:CipherData>
+                    </xenc:EncryptedKey>
+                </dsig:KeyInfo>
+                <xenc:CipherData>
+                    <xenc:CipherValue></xenc:CipherValue>
+                </xenc:CipherData>
+            </xenc:EncryptedData>
+        </saml:EncryptedID>
+    </saml:Subject>
+</samlp:AuthnRequest>
+AUTHNREQUEST
+        );
+
+        $expectedStructure = $expectedStructureDocument->documentElement;
+        $requestStructure = $request->toUnsignedXML();
+
+        $this->assertEqualXMLStructure($expectedStructure, $requestStructure);
     }
 }


### PR DESCRIPTION
As per https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf section 3.4.1, allow the optional <saml:Subject> in an AuthnRequest. 

Furthermore the excessive parsing logic in the constructor has been split out into various methods for consistency and readability.

This change is already in use in a production like environment where we request the authentication of a specific Subject from an IdP. 
