### PR TITLE
Scoping: idplist attributes configurable

### DIFF
--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -531,7 +531,14 @@ class SAML2_AuthnRequest extends SAML2_Request
                 $idplist = $this->document->createElementNS(SAML2_Const::NS_SAMLP, 'IDPList');
                 foreach ($this->IDPList as $provider) {
                     $idpEntry = $this->document->createElementNS(SAML2_Const::NS_SAMLP, 'IDPEntry');
-                    $idpEntry->setAttribute('ProviderID', $provider);
+                    if (is_string($provider)) {
+                        $idpEntry->setAttribute('ProviderID', $provider);
+                    }
+                    elseif (is_array($provider)) {
+                        foreach ($provider as $attribute => $value) {
+                            $idpEntry->setAttribute($attribute, $value);
+                        }
+                    }
                     $idplist->appendChild($idpEntry);
                 }
                 $scoping->appendChild($idplist);


### PR DESCRIPTION
At this moment we're not able to set custom attributes on samlp:IDPEntry, sometimes needed to implement IDP scoping.
This change is backwards compatible, and gives possibility to provide attributes per IDPEntity (see https://simplesamlphp.org/docs/stable/simplesamlphp-scoping).

Please accept the pull request.
Thx.
    
Reinier
