### PR TITLE
Scoping: idplist attributes configurable

### DIFF
--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -731,7 +731,14 @@ class SAML2_AuthnRequest extends SAML2_Request
                 $idplist = $this->document->createElementNS(SAML2_Const::NS_SAMLP, 'IDPList');
                 foreach ($this->IDPList as $provider) {
                     $idpEntry = $this->document->createElementNS(SAML2_Const::NS_SAMLP, 'IDPEntry');
-                    $idpEntry->setAttribute('ProviderID', $provider);
+                    if (is_string($provider)) {
+                        $idpEntry->setAttribute('ProviderID', $provider);
+                    }
+                    elseif (is_array($provider)) {
+                        foreach ($provider as $attribute => $value) {
+                            $idpEntry->setAttribute($attribute, $value);
+                        }
+                    }
                     $idplist->appendChild($idpEntry);
                 }
                 $scoping->appendChild($idplist);

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -733,8 +733,7 @@ class SAML2_AuthnRequest extends SAML2_Request
                     $idpEntry = $this->document->createElementNS(SAML2_Const::NS_SAMLP, 'IDPEntry');
                     if (is_string($provider)) {
                         $idpEntry->setAttribute('ProviderID', $provider);
-                    }
-                    elseif (is_array($provider)) {
+                    } elseif (is_array($provider)) {
                         foreach ($provider as $attribute => $value) {
                             $idpEntry->setAttribute($attribute, $value);
                         }

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -723,7 +723,6 @@ class SAML2_AuthnRequest extends SAML2_Request
 
         if ($this->ProxyCount !== NULL || count($this->IDPList) > 0 || count($this->RequesterID) > 0) {
             $scoping = $this->document->createElementNS(SAML2_Const::NS_SAMLP, 'Scoping');
-            $root->appendChild($scoping);
             if ($this->ProxyCount !== NULL) {
                 $scoping->setAttribute('ProxyCount', $this->ProxyCount);
             }
@@ -741,6 +740,7 @@ class SAML2_AuthnRequest extends SAML2_Request
                     $idplist->appendChild($idpEntry);
                 }
                 $scoping->appendChild($idplist);
+                $root->appendChild($scoping);
             }
             if (count($this->RequesterID) > 0) {
                 SAML2_Utils::addStrings($scoping, SAML2_Const::NS_SAMLP, 'RequesterID', FALSE, $this->RequesterID);

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -391,7 +391,9 @@ class SAML2_AuthnRequest extends SAML2_Request
      *
      * Each idpEntries consists of an array, containing
      * keys (mapped to attributes) and corresponding values.
-     * For backwards compatibility, an idpEntries can also
+     * Allowed attributes: Loc, Name, ProviderID.
+     *
+     * For backward compatibility, an idpEntries can also
      * be a string instead of an array, where each string
      * is mapped to the value of attribute ProviderID.
      */
@@ -737,7 +739,13 @@ class SAML2_AuthnRequest extends SAML2_Request
                         $idpEntry->setAttribute('ProviderID', $provider);
                     } elseif (is_array($provider)) {
                         foreach ($provider as $attribute => $value) {
-                            $idpEntry->setAttribute($attribute, $value);
+                            if (in_array($attribute, array(
+                                'ProviderID',
+                                'Loc',
+                                'Name'
+                            ))) {
+                                $idpEntry->setAttribute($attribute, $value);
+                            }
                         }
                     }
                     $idplist->appendChild($idpEntry);

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -385,12 +385,15 @@ class SAML2_AuthnRequest extends SAML2_Request
 
 
     /**
-     * This function sets the scoping for the request
-     * See Core 3.4.1.2 for the definition of scoping
-     * Currently we only support an IDPList of idpEntries
-     * and only the required ProviderID in an IDPEntry
-     * $providerIDs is an array of Entity Identifiers
+     * This function sets the scoping for the request.
+     * See Core 3.4.1.2 for the definition of scoping.
+     * Currently we support an IDPList of idpEntries.
      *
+     * Each idpEntries consists of an array, containing
+     * keys (mapped to attributes) and corresponding values.
+     * For backwards compatibility, an idpEntries can also
+     * be a string instead of an array, where each string
+     * is mapped to the value of attribute ProviderID.
      */
     public function setIDPList($IDPList)
     {


### PR DESCRIPTION
At this moment we're not able to set custom attributes on samlp:IDPEntry, sometimes needed to implement IDP scoping.
This change is backwards compatible, and gives possibility to provide attributes per IDPEntity (see https://simplesamlphp.org/docs/stable/simplesamlphp-scoping).

Please accept the pull request.
Thx.

Reinier