### PR TITLE
Function libxml_disable_entity_loader is used to prevent XXE attacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,6 @@ Example:
 Security
 --------
 
-* **Ensure that before calling any code from this library you have called** `libxml_disable_entity_loader(true);`
-  this is required to prevent the [XXE Processing Vulnerability](https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing),
-  see also [this websec.io page](http://websec.io/2012/08/27/Preventing-XEE-in-PHP.html)
-
 * Should you need to create a DOMDocument instance, use the `SAML2_DOMDocumentFactory` to create DOMDocuments from
   either a string (`SAML2_DOMDocumentFactory::fromString($theXmlAsString)`), a file (`SAML2_DOMDocumentFactory::fromFile($pathToTheFile)`)
   or just a new instance (`SAML2_DOMDocumentFactory::create()`)

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -594,7 +594,7 @@ class SAML2_AuthnRequest extends SAML2_Request
     public function encryptNameId(XMLSecurityKey $key)
     {
         /* First create a XML representation of the NameID. */
-        $doc  = new DOMDocument();
+        $doc  = SAML2_DOMDocumentFactory::create();
         $root = $doc->createElement('root');
         $doc->appendChild($root);
         SAML2_Utils::addNameId($root, $this->nameId);

--- a/src/SAML2/DOMDocumentFactory.php
+++ b/src/SAML2/DOMDocumentFactory.php
@@ -22,10 +22,10 @@ final class SAML2_DOMDocumentFactory
             );
         }
 
-        $entityLoader = libxml_disable_entity_loader(true);
+        $entityLoader = libxml_disable_entity_loader(TRUE);
         // some parts of the library rely on error-suppression to be able to throw an exception. We do the same here
         // to ensure backwards compatibility
-        $internalErrors = libxml_use_internal_errors(true);
+        $internalErrors = libxml_use_internal_errors(TRUE);
         libxml_clear_errors();
 
         $domDocument = new DOMDocument();
@@ -67,7 +67,7 @@ final class SAML2_DOMDocumentFactory
             ));
         }
 
-        // libxml_disable_entity_loader(true) disables DOMDocument::load() method, so we need to read the content
+        // libxml_disable_entity_loader(TRUE) disables DOMDocument::load() method, so we need to read the content
         // and use DOMDocument::loadXML()
         $xml = @file_get_contents($file);
         if ('' === trim($xml)) {
@@ -91,7 +91,7 @@ final class SAML2_DOMDocumentFactory
     protected static function parseXmlErrors($internalErrors)
     {
         $errors = array();
-        foreach(libxml_get_errors() as $error) {
+        foreach (libxml_get_errors() as $error) {
             $errors[] = sprintf(
                 'SAML2_DomDocumentFactory::parseXmlErrors error: [%s %s] "%s" in "%s"[%s]',
                 $error->level === LIBXML_ERR_WARNING ? 'WARNING' : 'ERROR',

--- a/src/SAML2/DOMDocumentFactory.php
+++ b/src/SAML2/DOMDocumentFactory.php
@@ -13,10 +13,7 @@ final class SAML2_DOMDocumentFactory
     public static function fromString($xml)
     {
         if (!is_string($xml)) {
-            throw new SAML2_Exception_InvalidArgumentException(sprintf(
-                'SAML2_DomDocumentFactory::fromString expects a string as argument, got "%s"',
-                (is_object($xml) ? 'instance of ' . get_class($xml) : gettype($xml) )
-            ));
+            throw SAML2_Exception_InvalidArgumentException::invalidType('string', $xml);
         }
 
         if ('' === trim($xml)) {
@@ -60,10 +57,7 @@ final class SAML2_DOMDocumentFactory
     public static function fromFile($file)
     {
         if (!is_string($file)) {
-            throw new SAML2_Exception_InvalidArgumentException(sprintf(
-                'SAML2_DomDocumentFactory::fromFile expects a string as argument, got "%s"',
-                (is_object($file) ? 'instance of ' . get_class($file) : gettype($file))
-            ));
+            throw SAML2_Exception_InvalidArgumentException::invalidType('string', $file);
         }
 
         if (!is_file($file)) {

--- a/tests/SAML2/DOMDocumentFactoryTest.php
+++ b/tests/SAML2/DOMDocumentFactoryTest.php
@@ -9,7 +9,7 @@ class SAML2_DOMDocumentFactoryTest extends PHPUnit_Framework_TestCase
      * @dataProvider nonStringProvider
      * @expectedException SAML2_Exception_InvalidArgumentException
      */
-    public function testOnlyAStringIsAcceptedByFronString($argument)
+    public function testOnlyAStringIsAcceptedByFromString($argument)
     {
         SAML2_DOMDocumentFactory::fromString($argument);
     }
@@ -80,6 +80,52 @@ class SAML2_DOMDocumentFactoryTest extends PHPUnit_Framework_TestCase
         $document = SAML2_DOMDocumentFactory::fromFile($file);
 
         $this->assertXmlStringEqualsXmlFile($file, $document->saveXML());
+    }
+
+    /**
+     * @group domdocument
+     * @expectedException SAML2_Exception_RuntimeException
+     * @expectedExceptionMessage Document type is not allowed
+     */
+    public function testFileThatContainsDocTypeIsNotAccepted()
+    {
+        $file = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'domdocument_doctype.xml';
+
+        SAML2_DOMDocumentFactory::fromFile($file);
+    }
+
+    /**
+     * @group domdocument
+     * @expectedException SAML2_Exception_RuntimeException
+     * @expectedExceptionMessage Document type is not allowed
+     */
+    public function testStringThatContainsDocTypeIsNotAccepted()
+    {
+        $xml = '<!DOCTYPE foo [<!ELEMENT foo ANY > <!ENTITY xxe SYSTEM "file:///dev/random" >]><foo />';
+
+        SAML2_DOMDocumentFactory::fromString($xml);
+    }
+
+    /**
+     * @group domdocument
+     * @expectedException SAML2_Exception_InvalidArgumentException
+     * @expectedExceptionMessage Empty file supplied as input
+     */
+    public function testEmptyFileIsNotValid()
+    {
+        $file = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'domdocument_empty.xml';
+
+        SAML2_DOMDocumentFactory::fromFile($file);
+    }
+
+    /**
+     * @group domdocument
+     * @expectedException SAML2_Exception_InvalidArgumentException
+     * @expectedExceptionMessage Empty string supplied as input
+     */
+    public function testEmptyStringIsNotValid()
+    {
+        SAML2_DOMDocumentFactory::fromString("");
     }
 
     /**

--- a/tests/SAML2/domdocument_doctype.xml
+++ b/tests/SAML2/domdocument_doctype.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE foo [<!ELEMENT foo ANY > <!ENTITY xxe SYSTEM "file:///dev/random" >]>
+<foo>&xxe;</foo>


### PR DESCRIPTION
This PR is related with PR #45 and with simplesamlphp/simplesamlphp#241 issue. Now ```libxml_disable_entity_loader``` is enabled before to read XML data instead of leaving this responsibility to the user.

This PR fix a issue with ```SAML2_DOMDocumentFactory::fromFile()``` method, because if the entity loader is disabled the method ```DOMDocument::load``` is disabled too, launching an exception.
