### PR TITLE
ENHANCEMENT: Add ability to specify SoapClient proxy_host and proxy_port

### DIFF
--- a/src/SAML2/SOAPClient.php
+++ b/src/SAML2/SOAPClient.php
@@ -91,6 +91,14 @@ class SAML2_SOAPClient
             'stream_context' => $context,
         );
 
+        if ($srcMetadata->hasValue('saml.SOAPClient.proxyhost')) {
+            $options['proxy_host'] = $srcMetadata->getValue('saml.SOAPClient.proxyhost');
+        }
+
+        if ($srcMetadata->hasValue('saml.SOAPClient.proxyport')) {
+            $options['proxy_port'] = $srcMetadata->getValue('saml.SOAPClient.proxyport');
+        }
+
         $x = new SoapClient(NULL, $options);
 
         // Add soap-envelopes


### PR DESCRIPTION
When using SimpleSAMLphp, this allows you to specify `saml.SOAPClient.proxyhost` and `saml.SOAPClient.proxyport` in your `authsources.php` configuration, and these will be passed through to the underlying `SOAPClient` object that is created, allowing PHP to use a proxy for making SOAP calls.

This is essential in locked-down environments that need to make all external API calls via a proxy, rather than directly accessing the internet - the rest of the SAML flow works fine because we just redirect the user's browser, but this call will otherwise fail.