### PR TITLE
Always add the scoping element to the AuthnRequest.

### DIFF
--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -728,6 +728,7 @@ class SAML2_AuthnRequest extends SAML2_Request
 
         if ($this->ProxyCount !== NULL || count($this->IDPList) > 0 || count($this->RequesterID) > 0) {
             $scoping = $this->document->createElementNS(SAML2_Const::NS_SAMLP, 'Scoping');
+            $root->appendChild($scoping);
             if ($this->ProxyCount !== NULL) {
                 $scoping->setAttribute('ProxyCount', $this->ProxyCount);
             }
@@ -751,7 +752,6 @@ class SAML2_AuthnRequest extends SAML2_Request
                     $idplist->appendChild($idpEntry);
                 }
                 $scoping->appendChild($idplist);
-                $root->appendChild($scoping);
             }
             if (count($this->RequesterID) > 0) {
                 SAML2_Utils::addStrings($scoping, SAML2_Const::NS_SAMLP, 'RequesterID', FALSE, $this->RequesterID);

--- a/tests/SAML2/AuthnRequestTest.php
+++ b/tests/SAML2/AuthnRequestTest.php
@@ -283,4 +283,42 @@ AUTHNREQUEST
 
         $this->assertEqualXMLStructure($expectedStructure, $requestStructure);
     }
+
+    /**
+     * Test setting a requesterID.
+     */
+    public function testRequesterId()
+    {
+        // basic AuthnRequest
+        $request = new SAML2_AuthnRequest();
+        $request->setIssuer('https://gateway.example.org/saml20/sp/metadata');
+        $request->setDestination('https://tiqr.example.org/idp/profile/saml2/Redirect/SSO');
+        $request->setRequesterID(array(
+            'https://engine.demo.openconext.org/authentication/sp/metadata',
+            'https://shib.example.edu/SSO/Metadata',
+        ));
+
+        $expectedStructureDocument = new DOMDocument();
+        $expectedStructureDocument->loadXML(<<<AUTHNREQUEST
+<samlp:AuthnRequest
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    ID=""
+    Version=""
+    IssueInstant=""
+    Destination="">
+    <saml:Issuer></saml:Issuer>
+    <samlp:Scoping>
+        <samlp:RequesterID>https://engine.demo.openconext.org/authentication/sp/metadata</samlp:RequesterID>
+        <samlp:RequesterID>https://shib.example.edu/SSO/Metadata</samlp:RequesterID>
+    </samlp:Scoping>
+</samlp:AuthnRequest>
+AUTHNREQUEST
+        );
+
+        $expectedStructure = $expectedStructureDocument->documentElement;
+        $requestStructure = $request->toUnsignedXML();
+
+        $this->assertEqualXMLStructure($expectedStructure, $requestStructure);
+    }
 }


### PR DESCRIPTION
Adding just a RequesterID would cause the Scoping element to not get added.
Reverses commit 0a936e9494969addbbe9317bfa29984d8390a3da by @reinier-vegter from PR #44.