### PR TITLE
Add signature method to assertion and message

### DIFF
--- a/src/SAML2/Assertion.php
+++ b/src/SAML2/Assertion.php
@@ -212,6 +212,11 @@ class Assertion implements SignedElement
     protected $wasSignedAtConstruction = false;
 
     /**
+     * @var string|null
+     */
+    private $signatureMethod;
+
+    /**
      * Constructor for SAML 2 assertions.
      *
      * @param \DOMElement|null $xml The input assertion.
@@ -523,12 +528,16 @@ class Assertion implements SignedElement
      */
     private function parseSignature(\DOMElement $xml)
     {
+        /** @var null|\DOMAttr $signatureMethod */
+        $signatureMethod = Utils::xpQuery($xml, './ds:Signature/ds:SignedInfo/ds:SignatureMethod/@Algorithm');
+
         /* Validate the signature element of the message. */
         $sig = Utils::validateElement($xml);
         if ($sig !== false) {
             $this->wasSignedAtConstruction = true;
             $this->certificates = $sig['Certificates'];
             $this->signatureData = $sig;
+            $this->signatureMethod = $signatureMethod[0]->value;
         }
     }
 
@@ -1227,6 +1236,14 @@ class Assertion implements SignedElement
     public function getWasSignedAtConstruction()
     {
         return $this->wasSignedAtConstruction;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getSignatureMethod()
+    {
+        return $this->signatureMethod;
     }
 
     /**

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -115,6 +115,11 @@ abstract class Message implements SignedElement
     private $validators;
 
     /**
+     * @var null|string
+     */
+    private $signatureMethod;
+
+    /**
      * Initialize a message.
      *
      * This constructor takes an optional parameter with a \DOMElement. If this
@@ -169,6 +174,9 @@ abstract class Message implements SignedElement
 
         /* Validate the signature element of the message. */
         try {
+            /** @var null|\DOMAttr $signatureMethod */
+            $signatureMethod = Utils::xpQuery($xml, './ds:Signature/ds:SignedInfo/ds:SignatureMethod/@Algorithm');
+
             $sig = Utils::validateElement($xml);
 
             if ($sig !== false) {
@@ -178,6 +186,7 @@ abstract class Message implements SignedElement
                     'Function' => array('\SAML2\Utils', 'validateSignature'),
                     'Data' => $sig,
                     );
+                $this->signatureMethod = $signatureMethod[0]->value;
             }
         } catch (\Exception $e) {
             /* Ignore signature validation errors. */
@@ -570,5 +579,13 @@ abstract class Message implements SignedElement
         assert('is_array($extensions) || is_null($extensions)');
 
         $this->extensions = $extensions;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getSignatureMethod()
+    {
+        return $this->signatureMethod;
     }
 }

--- a/tests/SAML2/AssertionTest.php
+++ b/tests/SAML2/AssertionTest.php
@@ -326,4 +326,61 @@ XML
         $assertion = new Assertion($document->firstChild);
         $this->assertTrue($assertion->hasEncryptedAttributes());
     }
+
+    /**
+     * @group Assertion
+     */
+    public function testCorrectSignatureMethodCanBeExtracted()
+    {
+        $document = new \DOMDocument();
+        $document->loadXML(<<<XML
+    <saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    Version="2.0"
+                    ID="_93af655219464fb403b34436cfb0c5cb1d9a5502"
+                    IssueInstant="1970-01-01T01:33:31Z">
+      <saml:Issuer>Provider</saml:Issuer>
+      <saml:Subject>
+        <saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">s00000000:123456789</saml:NameID>
+        <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+          <saml:SubjectConfirmationData NotOnOrAfter="2011-08-31T08:51:05Z" Recipient="https://sp.example.com/assertion_consumer" InResponseTo="_13603a6565a69297e9809175b052d115965121c8" />
+        </saml:SubjectConfirmation>
+      </saml:Subject>
+      <saml:Conditions NotOnOrAfter="2011-08-31T08:51:05Z" NotBefore="2011-08-31T08:51:05Z">
+        <saml:AudienceRestriction>
+          <saml:Audience>ServiceProvider</saml:Audience>
+        </saml:AudienceRestriction>
+      </saml:Conditions>
+      <saml:AuthnStatement AuthnInstant="2011-08-31T08:51:05Z" SessionIndex="_93af655219464fb403b34436cfb0c5cb1d9a5502">
+        <saml:AuthnContext>
+          <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
+        </saml:AuthnContext>
+        <saml:SubjectLocality Address="127.0.0.1"/>
+      </saml:AuthnStatement>
+      <saml:AttributeStatement>
+        <saml:Attribute Name="urn:ServiceID">
+          <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">1</saml:AttributeValue>
+        </saml:Attribute>
+        <saml:Attribute Name="urn:EntityConcernedID">
+          <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">1</saml:AttributeValue>
+        </saml:Attribute>
+        <saml:Attribute Name="urn:EntityConcernedSubID">
+          <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">1</saml:AttributeValue>
+        </saml:Attribute>
+      </saml:AttributeStatement>
+    </saml:Assertion>
+XML
+        );
+
+        $privateKey = CertificatesMock::getPrivateKey();
+
+        $unsignedAssertion = new Assertion($document->firstChild);
+        $unsignedAssertion->setSignatureKey($privateKey);
+        $unsignedAssertion->setCertificates(array(CertificatesMock::PUBLIC_KEY_PEM));
+
+        $signedAssertion = new Assertion($unsignedAssertion->toXML());
+
+        $signatureMethod = $signedAssertion->getSignatureMethod();
+
+        $this->assertEquals($privateKey->getAlgorith(), $signatureMethod);
+    }
 }

--- a/tests/SAML2/MessageTest.php
+++ b/tests/SAML2/MessageTest.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SAML2;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+class Test extends TestCase
+{
+
+}

--- a/tests/SAML2/MessageTest.php
+++ b/tests/SAML2/MessageTest.php
@@ -4,7 +4,58 @@ namespace SAML2;
 
 use PHPUnit_Framework_TestCase as TestCase;
 
-class Test extends TestCase
+class MessageTest extends TestCase
 {
+    /**
+     * @group Message
+     */
+    public function testCorrectSignatureMethodCanBeExtractedFromAuthnRequest()
+    {
+        $authnRequest = new \DOMDocument();
+        $authnRequest->loadXML(<<<AUTHNREQUEST
+<samlp:AuthnRequest
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    AssertionConsumerServiceIndex="1"
+    Destination="https://tiqr.stepup.org/idp/profile/saml2/Redirect/SSO"
+    ID="_2b0226190ca1c22de6f66e85f5c95158"
+    IssueInstant="2014-09-22T13:42:00Z"
+    Version="2.0">
+  <saml:Issuer>https://gateway.stepup.org/saml20/sp/metadata</saml:Issuer>
+  <saml:Subject>
+        <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">user@example.org</saml:NameID>
+  </saml:Subject>
+</samlp:AuthnRequest>
+AUTHNREQUEST
+        );
 
+        $privateKey = CertificatesMock::getPrivateKey();
+
+        $unsignedMessage = Message::fromXML($authnRequest->documentElement);
+        $unsignedMessage->setSignatureKey($privateKey);
+        $unsignedMessage->setCertificates(array(CertificatesMock::PUBLIC_KEY_PEM));
+
+        $signedMessage = Message::fromXML($unsignedMessage->toSignedXML());
+
+        $this->assertEquals($privateKey->getAlgorith(), $signedMessage->getSignatureMethod());
+    }
+
+    /**
+     * @group Message
+     */
+    public function testCorrectSignatureMethodCanBeExtractedFromResponse()
+    {
+        $response = new \DOMDocument();
+        $response->load(__DIR__ . '/Response/response.xml');
+
+        $privateKey = CertificatesMock::getPrivateKey();
+
+        $unsignedMessage = Message::fromXML($response->documentElement);
+        $unsignedMessage->setSignatureKey($privateKey);
+        $unsignedMessage->setCertificates(array(CertificatesMock::PUBLIC_KEY_PEM));
+
+        $signedMessage = Message::fromXML($unsignedMessage->toSignedXML());
+
+        $this->assertEquals($privateKey->getAlgorith(), $signedMessage->getSignatureMethod());
+    }
 }


### PR DESCRIPTION
This PR adds the signature method to Assertion and Message to, for instance, allow checking, validation or logging of the algorithm used.