### PR TITLE
Allow self-signed certificate at SOAP server

### DIFF
--- a/src/SAML2/SOAPClient.php
+++ b/src/SAML2/SOAPClient.php
@@ -34,6 +34,7 @@ class SOAPClient
         $ctxOpts = array(
             'ssl' => array(
                 'capture_peer_cert' => true,
+                'allow_self_signed' => true
             ),
         );
 


### PR DESCRIPTION
In PHP 5.6 there has been a [change](http://php.net/manual/en/context.ssl.php) in `SSL context options`: default value of `verify_peer` became `true`, but `allow_self_signed` remained `false`. It results that `SOAPClient` cannot connect to SOAP Server if that has self-signed certificate. For an AttributeAuthority it is supposed to use self-signed certificates, so without this PR a simpleSAMLphp SP on a fresh (PHP 5.6) system would not be able to connect to the AA. 