### PR TITLE
shibmd:scope regexp attribute should default to false and be always explicit

### DIFF
--- a/src/SAML2/XML/shibmd/Scope.php
+++ b/src/SAML2/XML/shibmd/Scope.php
@@ -27,9 +27,9 @@ class Scope
     /**
      * Whether this is a regexp scope.
      *
-     * @var bool|null
+     * @var bool
      */
-    public $regexp = null;
+    public $regexp = false;
 
     /**
      * Create a Scope.
@@ -43,7 +43,7 @@ class Scope
         }
 
         $this->scope = $xml->textContent;
-        $this->regexp = Utils::parseBoolean($xml, 'regexp', null);
+        $this->regexp = Utils::parseBoolean($xml, 'regexp', false);
     }
 
     /**
@@ -66,7 +66,7 @@ class Scope
 
         if ($this->regexp === true) {
             $e->setAttribute('regexp', 'true');
-        } elseif ($this->regexp === false) {
+        } else {
             $e->setAttribute('regexp', 'false');
         }
 

--- a/tests/SAML2/XML/shibmd/ScopeTest.php
+++ b/tests/SAML2/XML/shibmd/ScopeTest.php
@@ -12,6 +12,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
 {
     public function testMarshalling()
     {
+        // In literal, non-regexp form
         $scope = new Scope();
         $scope->scope = "example.org";
         $scope->regexp = FALSE;
@@ -27,6 +28,22 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('urn:mace:shibboleth:metadata:1.0', $scopeElement->namespaceURI);
         $this->assertEquals('false', $scopeElement->getAttribute('regexp'));
 
+        // Without explicit regexp: should yield explicit 'false'
+        $scope = new Scope();
+        $scope->scope = "example.org";
+
+        $document = DOMDocumentFactory::fromString('<root />');
+        $scopeElement = $scope->toXML($document->firstChild);
+
+        $scopeElements = Utils::xpQuery($scopeElement, '/root/shibmd:Scope');
+        $this->assertCount(1, $scopeElements);
+        $scopeElement = $scopeElements[0];
+
+        $this->assertEquals('example.org', $scopeElement->nodeValue);
+        $this->assertEquals('urn:mace:shibboleth:metadata:1.0', $scopeElement->namespaceURI);
+        $this->assertEquals('false', $scopeElement->getAttribute('regexp'));
+
+        // In regexp form
         $scope = new Scope();
         $scope->scope = "^(.*\.)?example\.edu$";
         $scope->regexp = TRUE;
@@ -48,6 +65,16 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
         $document = DOMDocumentFactory::fromString(
 <<<XML
 <shibmd:Scope regexp="false">example.org</shibmd:Scope>
+XML
+        );
+        $scope = new Scope($document->firstChild);
+
+        $this->assertEquals('example.org', $scope->scope);
+        $this->assertFalse($scope->regexp);
+
+        $document = DOMDocumentFactory::fromString(
+<<<XML
+<shibmd:Scope>example.org</shibmd:Scope>
 XML
         );
         $scope = new Scope($document->firstChild);


### PR DESCRIPTION
The regexp attribute of a Scope used to default to null when not set explicitly.

According to the spec, when omitted this should be interpreted as it being false. Therefore, I think the null default is not correct to have.

Also, we should always output an explicit regexp attribute, as recommended by the spec for document signing reasons: https://wiki.shibboleth.net/confluence/display/SC/ShibMetaExt+V1.0