### PR TITLE
Allow setting dynamic value for AllowCreate in NameIdPolicy 

### DIFF
--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -714,8 +714,8 @@ class AuthnRequest extends Request
             if (array_key_exists('SPNameQualifier', $this->nameIdPolicy)) {
                 $nameIdPolicy->setAttribute('SPNameQualifier', $this->nameIdPolicy['SPNameQualifier']);
             }
-            if (array_key_exists('AllowCreate', $this->nameIdPolicy) && $this->nameIdPolicy['AllowCreate']) {
-                $nameIdPolicy->setAttribute('AllowCreate', 'true');
+            if (array_key_exists('AllowCreate', $this->nameIdPolicy) && $this->nameIdPolicy['AllowCreate'] === TRUE || $this->nameIdPolicy['AllowCreate'] === FALSE) {
+                $nameIdPolicy->setAttribute('AllowCreate', var_export($this->nameIdPolicy['AllowCreate'], TRUE) );
             }
             $root->appendChild($nameIdPolicy);
         }

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -714,8 +714,9 @@ class AuthnRequest extends Request
             if (array_key_exists('SPNameQualifier', $this->nameIdPolicy)) {
                 $nameIdPolicy->setAttribute('SPNameQualifier', $this->nameIdPolicy['SPNameQualifier']);
             }
-            if (array_key_exists('AllowCreate', $this->nameIdPolicy) && $this->nameIdPolicy['AllowCreate'] === TRUE || $this->nameIdPolicy['AllowCreate'] === FALSE) {
-                $nameIdPolicy->setAttribute('AllowCreate', var_export($this->nameIdPolicy['AllowCreate'], TRUE) );
+            if (array_key_exists('AllowCreate', $this->nameIdPolicy) && $this->nameIdPolicy['AllowCreate'] === true
+                || $this->nameIdPolicy['AllowCreate'] === false) {
+                $nameIdPolicy->setAttribute('AllowCreate', var_export($this->nameIdPolicy['AllowCreate'], true));
             }
             $root->appendChild($nameIdPolicy);
         }


### PR DESCRIPTION
This is a use case I faced while implementing SSO for the [SPNEGO](https://en.wikipedia.org/wiki/SPNEGO) Identity Provider. 

Due the SPNEGO's specification you cannot logout a SPNEGO user gracefully **and** when trying to login again(after the user logs out) the user will get an exception. Therefore, you need to send “allowcreate=false” in the SAML request token in order to let the SPNEGO IdP know that it is 'OK' to not refresh/try to authenticate the user in every SAML insertion.

I don't know any other IdP with these specifications but definitely it is a valid use case. 

This PR allows to set AllowCreate as a 'True' or 'False' in the toUnsignedXML method.