### PR TITLE
Allow setting dynamic value for AllowCreate in NameIdPolicy in 1.x

### DIFF
--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -708,8 +708,9 @@ class SAML2_AuthnRequest extends SAML2_Request
             if (array_key_exists('SPNameQualifier', $this->nameIdPolicy)) {
                 $nameIdPolicy->setAttribute('SPNameQualifier', $this->nameIdPolicy['SPNameQualifier']);
             }
-            if (array_key_exists('AllowCreate', $this->nameIdPolicy) && $this->nameIdPolicy['AllowCreate']) {
-                $nameIdPolicy->setAttribute('AllowCreate', 'true');
+            if (array_key_exists('AllowCreate', $this->nameIdPolicy) && $this->nameIdPolicy['AllowCreate'] === TRUE
+                || $this->nameIdPolicy['AllowCreate'] === FALSE) {
+                $nameIdPolicy->setAttribute('AllowCreate', var_export($this->nameIdPolicy['AllowCreate'], TRUE));
             }
             $root->appendChild($nameIdPolicy);
         }


### PR DESCRIPTION
@jaimeperez. Related to [pull#63](https://github.com/simplesamlphp/saml2/pull/63). This is for the 1.x branch. Let me know if it is ok to create two PRs for this. 