### PR TITLE
Fix KeyLoader::loadKeys

### DIFF
--- a/src/SAML2/Certificate/KeyLoader.php
+++ b/src/SAML2/Certificate/KeyLoader.php
@@ -90,7 +90,7 @@ class KeyLoader
     public function loadKeys(array $configuredKeys, $usage)
     {
         foreach ($configuredKeys as $keyData) {
-            if (isset($key['X509Certificate'])) {
+            if (isset($keyData['X509Certificate'])) {
                 $key = new X509($keyData);
             } else {
                 $key = new Key($keyData);

--- a/tests/SAML2/Certificate/KeyLoaderTest.php
+++ b/tests/SAML2/Certificate/KeyLoaderTest.php
@@ -52,6 +52,24 @@ class KeyLoaderTest extends \PHPUnit_Framework_TestCase
      * @group certificate
      *
      * @test
+     */
+    public function load_keys_constructs_x509_certificate()
+    {
+        $keys = array(array(
+            'X509Certificate' => $this->certificate
+        ));
+
+        $this->keyLoader->loadKeys($keys, null);
+        $loadedKeys = $this->keyLoader->getKeys();
+
+        $this->assertCount(1, $loadedKeys);
+        $this->assertInstanceOf('SAML2\Certificate\X509', $loadedKeys->get(0));
+    }
+
+    /**
+     * @group certificate
+     *
+     * @test
      * @expectedException \SAML2\Exception\InvalidArgumentException
      */
     public function certificate_data_with_invalid_format_throws_an_exception()


### PR DESCRIPTION
This patch fixes a typo in `SAML2\Certificate\KeyLoader`.