### PR TITLE
Fix unable to set "NameQualifier" and "Format" attributes for saml:Issuer #67

### DIFF
--- a/src/SAML2/BaseID.php
+++ b/src/SAML2/BaseID.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace SAML2;
+
+/**
+ * Base class for BaseID element.
+ *
+ * @package SimpleSAMLphp
+ */
+abstract class BaseID {
+
+    /**
+     * The security or administrative domain that qualifies the identifier.
+     * This attribute provides a means to federate identifiers from disparate user stores without collision.
+     * 
+     * @var string|null
+     */
+    private $nameQualifier;
+
+    /**
+     * Further qualifies an identifier with the name of a service provider or affiliation of providers. 
+     * This attribute provides an additional means to federate identifiers on the basis of the relying party or parties.
+     * 
+     * @var string|null
+     */
+    private $spNameQualifier;
+
+    /**
+     * Represent an entity by a string-valued
+     * 
+     * @var string
+     */
+    private $entity;
+
+    /**
+     * Constructor for SAML 2 BaseID.
+     *
+     * @param string          $$entity The $entity name.
+     */
+    protected function __construct($entity) {
+
+        $this->setEntity($entity);
+    }
+
+    /**
+     * Retrieve the entity name.
+     *
+     * @return string The entity name.
+     */
+    public function getEntity() {
+        return $this->$entity;
+    }
+
+    /**
+     * Set the the entity name.
+     *
+     * @param string $entity The entity name.
+     */
+    public function setEntity($entity) {
+        assert('is_string($entity)');
+
+        $this->entity = $entity;
+    }
+
+    /**
+     * Retrieve the name qualifier.
+     *
+     * @return string The name qualifier.
+     */
+    public function getNameQualifier() {
+        return $this->nameQualifier;
+    }
+
+    /**
+     * Set the name qualifier.
+     *
+     * @param string $namequalifier The name qualifier.
+     */
+    public function setNameQualifier($namequalifier) {
+        assert('is_string($namequalifier) || is_null($namequalifier)');
+
+        $this->nameQualifier = $namequalifier;
+    }
+
+    /**
+     * Retrieve the service provider name qualifier·
+     *
+     * @return string The service provider name qualifier.
+     */
+    public function getSPNameQualifier() {
+        return $this->spNameQualifier;
+    }
+
+    /**
+     * Set the service provider name qualifier.
+     *
+     * @param string $spnamequalifier The service provider name qualifier.
+     */
+    public function setSPNameQualifier($spnamequalifier) {
+        assert('is_string($spnamequalifier) || is_null($spnamequalifier)');
+
+        $this->spNameQualifier = $spnamequalifier;
+    }
+
+    public function __toString() {
+        return $this->entity;
+    }
+
+}

--- a/src/SAML2/Issuer.php
+++ b/src/SAML2/Issuer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SAML2;
+
+/**
+ * Base class for NameID element.
+ *
+ * @package SimpleSAMLphp
+ */
+class Issuer extends NameIDType {
+
+    public function __construct($entity) {
+        parent::__construct($entity);
+    }
+
+}

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -65,7 +65,7 @@ abstract class Message implements SignedElement
     /**
      * The entity id of the issuer of this message, or null if unknown.
      *
-     * @var string|null
+     * @var string|object|null
      */
     private $issuer;
 
@@ -358,12 +358,12 @@ abstract class Message implements SignedElement
     /**
      * Set the issuer of this message.
      *
-     * @param string|null $issuer The new issuer of this message.
+     * @param string|object|null $issuer The new issuer of this message.
      */
     public function setIssuer($issuer)
     {
-        assert('is_string($issuer) || is_null($issuer)');
-
+        assert('is_string($issuer) || is_object($issuer) || is_null($issuer)');
+        
         $this->issuer = $issuer;
     }
 
@@ -429,7 +429,24 @@ abstract class Message implements SignedElement
         }
 
         if ($this->issuer !== null) {
-            Utils::addString($root, Constants::NS_SAML, 'saml:Issuer', $this->issuer);
+            if (is_string($this->issuer)){
+                \SAML2_Utils::addString($root, \SAML2_Const::NS_SAML, 'saml:Issuer', $this->issuer);
+            }elseif (is_object($this->issuer)){
+                \SAML2_Utils::addString($root, \SAML2_Const::NS_SAML, 'saml:Issuer', $this->issuer->__toString());
+                $issuer = \SAML2_Utils::xpQuery($root, './saml_assertion:Issuer');
+                if ($this->issuer->getNameQualifier()){
+                    $issuer[0]->setAttribute('NameQualifier', $this->issuer->getNameQualifier());
+                }
+                if ($this->issuer->getFormat()){
+                    $issuer[0]->setAttribute('Format', $this->issuer->getFormat());
+                }
+                if ($this->issuer->getSPNameQualifier()){
+                    $issuer[0]->setAttribute('SPNameQualifier', $this->issuer->getSPNameQualifier());
+                }
+                if ($this->issuer->getSPProvidedID()){
+                    $issuer[0]->setAttribute('SPProvidedID', $this->issuer->getSPProvidedID());
+                }
+            }
         }
 
         if (!empty($this->extensions)) {
@@ -450,7 +467,7 @@ abstract class Message implements SignedElement
     public function toSignedXML()
     {
         $root = $this->toUnsignedXML();
-
+        
         if ($this->signatureKey === null) {
             /* We don't have a key to sign it with. */
 

--- a/src/SAML2/NameID.php
+++ b/src/SAML2/NameID.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SAML2;
+
+/**
+ * Base class for NameID element.
+ *
+ * @package SimpleSAMLphp
+ */
+class NameID extends NameIDType {
+
+    public function __construct($entity) {
+        parent::__construct($entity);
+    }
+
+}

--- a/src/SAML2/NameIDType.php
+++ b/src/SAML2/NameIDType.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace SAML2;
+
+/**
+ * Base class for NameIDType element.
+ *
+ * @package SimpleSAMLphp
+ */
+abstract class NameIDType extends BaseID {
+
+    /**
+     * A URI reference representing the classification of string-based identifier information.
+     * 
+     * @var string|null
+     */
+    private $format;
+
+    /**
+     * A A name identifier established by a service provider or affiliation of providers for the entity.
+     * 
+     * @var string|null
+     */
+    private $spProvidedID;
+
+    /**
+     * Retrieve the name identifier established by a service provider or affiliation of providers for the entity.
+     *
+     * @return string name identifier established by a service provider or affiliation of providers for the entity.
+     */
+    public function getSPProvidedID() {
+        return $this->spProvidedID;
+    }
+
+    /**
+     * Set the name identifier established by a service provider or affiliation of providers for the entity.
+     *
+     * @param string $spProvidedID name identifier established by a service provider or affiliation of providers for the entity.
+     */
+    public function setSPProvidedID($spProvidedID) {
+        assert('is_string($spProvidedID) || is_null($spProvidedID)');
+
+        $this->spProvidedID = $spProvidedID;
+    }
+
+    /**
+     * Retrieve the format.
+     *
+     * @return string format.
+     */
+    public function getFormat() {
+        return $this->format;
+    }
+
+    /**
+     * Set the format.
+     *
+     * @param string $format format for the entity.
+     */
+    public function setFormat($format) {
+        assert('is_string($format) || is_null($format)');
+
+        $this->format = $format;
+    }
+    
+
+}


### PR DESCRIPTION
Introducing an Issuer class that is accepted by setIssuer as well as a string (for backwards compatibility)

to fix https://github.com/simplesamlphp/saml2/issues/67
This is my first contribution on github, I hope I have done well