### PR TITLE
Fix unable to set "NameQualifier" and "Format" attributes for saml:Issuer #67

### DIFF
--- a/src/SAML2/BaseID.php
+++ b/src/SAML2/BaseID.php
@@ -33,7 +33,7 @@ abstract class BaseID
     /**
      * Constructor for SAML 2 BaseID.
      *
-     * @param string $$entity The $entity name
+     * @param string $entity The entity name
      */
     protected function __construct($entity)
     {

--- a/src/SAML2/BaseID.php
+++ b/src/SAML2/BaseID.php
@@ -48,7 +48,7 @@ abstract class BaseID {
      * @return string The entity name.
      */
     public function getEntity() {
-        return $this->$entity;
+        return $this->entity;
     }
 
     /**

--- a/src/SAML2/BaseID.php
+++ b/src/SAML2/BaseID.php
@@ -4,30 +4,28 @@ namespace SAML2;
 
 /**
  * Base class for BaseID element.
- *
- * @package SimpleSAMLphp
  */
-abstract class BaseID {
-
+abstract class BaseID
+{
     /**
      * The security or administrative domain that qualifies the identifier.
      * This attribute provides a means to federate identifiers from disparate user stores without collision.
-     * 
+     *
      * @var string|null
      */
     private $nameQualifier;
 
     /**
-     * Further qualifies an identifier with the name of a service provider or affiliation of providers. 
+     * Further qualifies an identifier with the name of a service provider or affiliation of providers.
      * This attribute provides an additional means to federate identifiers on the basis of the relying party or parties.
-     * 
+     *
      * @var string|null
      */
     private $spNameQualifier;
 
     /**
-     * Represent an entity by a string-valued
-     * 
+     * Represent an entity by a string-valued.
+     *
      * @var string
      */
     private $entity;
@@ -35,28 +33,30 @@ abstract class BaseID {
     /**
      * Constructor for SAML 2 BaseID.
      *
-     * @param string          $$entity The $entity name.
+     * @param string $$entity The $entity name
      */
-    protected function __construct($entity) {
-
+    protected function __construct($entity)
+    {
         $this->setEntity($entity);
     }
 
     /**
      * Retrieve the entity name.
      *
-     * @return string The entity name.
+     * @return string The entity name
      */
-    public function getEntity() {
+    public function getEntity()
+    {
         return $this->entity;
     }
 
     /**
      * Set the the entity name.
      *
-     * @param string $entity The entity name.
+     * @param string $entity The entity name
      */
-    public function setEntity($entity) {
+    public function setEntity($entity)
+    {
         assert('is_string($entity)');
 
         $this->entity = $entity;
@@ -65,45 +65,49 @@ abstract class BaseID {
     /**
      * Retrieve the name qualifier.
      *
-     * @return string The name qualifier.
+     * @return string The name qualifier
      */
-    public function getNameQualifier() {
+    public function getNameQualifier()
+    {
         return $this->nameQualifier;
     }
 
     /**
      * Set the name qualifier.
      *
-     * @param string $namequalifier The name qualifier.
+     * @param string $namequalifier The name qualifier
      */
-    public function setNameQualifier($namequalifier) {
+    public function setNameQualifier($namequalifier)
+    {
         assert('is_string($namequalifier) || is_null($namequalifier)');
 
         $this->nameQualifier = $namequalifier;
     }
 
     /**
-     * Retrieve the service provider name qualifier·
+     * Retrieve the service provider name qualifier·.
      *
-     * @return string The service provider name qualifier.
+     * @return string The service provider name qualifier
      */
-    public function getSPNameQualifier() {
+    public function getSPNameQualifier()
+    {
         return $this->spNameQualifier;
     }
 
     /**
      * Set the service provider name qualifier.
      *
-     * @param string $spnamequalifier The service provider name qualifier.
+     * @param string $spnamequalifier The service provider name qualifier
      */
-    public function setSPNameQualifier($spnamequalifier) {
+    public function setSPNameQualifier($spnamequalifier)
+    {
         assert('is_string($spnamequalifier) || is_null($spnamequalifier)');
 
         $this->spNameQualifier = $spnamequalifier;
     }
 
-    public function __toString() {
+    public function __toString()
+    {
         return $this->entity;
     }
-
 }

--- a/src/SAML2/BaseID.php
+++ b/src/SAML2/BaseID.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace SAML2;
+
+/**
+ * Base class for BaseID element.
+ *
+ * @package SimpleSAMLphp
+ */
+abstract class BaseID {
+
+    /**
+     * The security or administrative domain that qualifies the identifier.
+     * This attribute provides a means to federate identifiers from disparate user stores without collision.
+     * 
+     * @var string|null
+     */
+    private $nameQualifier;
+
+    /**
+     * Further qualifies an identifier with the name of a service provider or affiliation of providers. 
+     * This attribute provides an additional means to federate identifiers on the basis of the relying party or parties.
+     * 
+     * @var string|null
+     */
+    private $spNameQualifier;
+
+    /**
+     * Represent an entity by a string-valued
+     * 
+     * @var string
+     */
+    private $entity;
+
+    /**
+     * Constructor for SAML 2 BaseID.
+     *
+     * @param string          $$entity The $entity name.
+     */
+    protected function __construct($entity) {
+
+        $this->setEntity($entity);
+    }
+
+    /**
+     * Retrieve the entity name.
+     *
+     * @return string The entity name.
+     */
+    public function getEntity() {
+        return $this->$entity;
+    }
+
+    /**
+     * Set the the entity name.
+     *
+     * @param string $entity The entity name.
+     */
+    public function setEntity($entity) {
+        assert('is_string($entity)');
+
+        $this->entity = $entity;
+    }
+
+    /**
+     * Retrieve the name qualifier.
+     *
+     * @return string The name qualifier.
+     */
+    public function getNameQualifier() {
+        return $this->nameQualifier;
+    }
+
+    /**
+     * Set the name qualifier.
+     *
+     * @param string $namequalifier The name qualifier.
+     */
+    public function setNameQualifier($namequalifier) {
+        assert('is_string($namequalifier) || is_null($namequalifier)');
+
+        $this->nameQualifier = $namequalifier;
+    }
+
+    /**
+     * Retrieve the service provider name qualifier·
+     *
+     * @return string The service provider name qualifier.
+     */
+    public function getSPNameQualifier() {
+        return $this->spNameQualifier;
+    }
+
+    /**
+     * Set the service provider name qualifier.
+     *
+     * @param string $spnamequalifier The service provider name qualifier.
+     */
+    public function setSPNameQualifier($spnamequalifier) {
+        assert('is_string($spnamequalifier) || is_null($spnamequalifier)');
+
+        $this->spNameQualifier = $spnamequalifier;
+    }
+
+    public function __toString() {
+        return $this->entity;
+    }
+
+}

--- a/src/SAML2/Issuer.php
+++ b/src/SAML2/Issuer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SAML2;
+
+/**
+ * Base class for NameID element.
+ *
+ * @package SimpleSAMLphp
+ */
+class Issuer extends NameIDType {
+
+    public function __construct($entity) {
+        parent::__construct($entity);
+    }
+
+}

--- a/src/SAML2/Issuer.php
+++ b/src/SAML2/Issuer.php
@@ -4,13 +4,11 @@ namespace SAML2;
 
 /**
  * Base class for NameID element.
- *
- * @package SimpleSAMLphp
  */
-class Issuer extends NameIDType {
-
-    public function __construct($entity) {
+class Issuer extends NameIDType
+{
+    public function __construct($entity)
+    {
         parent::__construct($entity);
     }
-
 }

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -65,7 +65,7 @@ abstract class Message implements SignedElement
     /**
      * The entity id of the issuer of this message, or null if unknown.
      *
-     * @var string|null
+     * @var string|object|null
      */
     private $issuer;
 
@@ -358,11 +358,11 @@ abstract class Message implements SignedElement
     /**
      * Set the issuer of this message.
      *
-     * @param string|null $issuer The new issuer of this message.
+     * @param string|object|null $issuer The new issuer of this message.
      */
     public function setIssuer($issuer)
     {
-        assert('is_string($issuer) || is_null($issuer)');
+        assert('is_string($issuer) || is_object($issuer) || is_null($issuer)');
 
         $this->issuer = $issuer;
     }
@@ -429,7 +429,24 @@ abstract class Message implements SignedElement
         }
 
         if ($this->issuer !== null) {
-            Utils::addString($root, Constants::NS_SAML, 'saml:Issuer', $this->issuer);
+            if (is_string($this->issuer)){
+                Utils::addString($root, \SAML2_Const::NS_SAML, 'saml:Issuer', $this->issuer);
+            }elseif (is_object($this->issuer)){
+                Utils::addString($root, \SAML2_Const::NS_SAML, 'saml:Issuer', $this->issuer->__toString());
+                $issuer = \SAML2_Utils::xpQuery($root, './saml_assertion:Issuer');
+                if ($this->issuer->getNameQualifier()){
+                    $issuer[0]->setAttribute('NameQualifier', $this->issuer->getNameQualifier());
+                }
+                if ($this->issuer->getFormat()){
+                    $issuer[0]->setAttribute('Format', $this->issuer->getFormat());
+                }
+                if ($this->issuer->getSPNameQualifier()){
+                    $issuer[0]->setAttribute('SPNameQualifier', $this->issuer->getSPNameQualifier());
+                }
+                if ($this->issuer->getSPProvidedID()){
+                    $issuer[0]->setAttribute('SPProvidedID', $this->issuer->getSPProvidedID());
+                }
+            }
         }
 
         if (!empty($this->extensions)) {

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -354,7 +354,7 @@ abstract class Message implements SignedElement
     {
         if (is_string($this->issuer)) {
             return $this->issuer;
-        }elseif (is_object($this->issuer)) {
+        } elseif (is_object($this->issuer)) {
             return $this->issuer->__toString();
         }
     }
@@ -451,7 +451,7 @@ abstract class Message implements SignedElement
      * Set attribute for Issuer if is an object.
      *
      */
-    private function setIssuerAttribute($root) 
+    private function setIssuerAttribute($root)
     {
         Utils::addString($root, \SAML2_Const::NS_SAML, 'saml:Issuer', $this->issuer->__toString());
         $issuer = \SAML2_Utils::xpQuery($root, './saml_assertion:Issuer');

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -12,7 +12,6 @@ use SAML2\XML\samlp\Extensions;
  * Implements what is common between the samlp:RequestAbstractType and
  * samlp:StatusResponseType element types.
  *
- * @package SimpleSAMLphp
  *
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
@@ -129,8 +128,9 @@ abstract class Message implements SignedElement
      * If no XML element is given, the message is initialized with suitable
      * default values.
      *
-     * @param string          $tagName The tag name of the root element.
-     * @param \DOMElement|null $xml     The input message.
+     * @param string           $tagName The tag name of the root element
+     * @param \DOMElement|null $xml     The input message
+     *
      * @throws \Exception
      */
     protected function __construct($tagName, \DOMElement $xml = null)
@@ -154,7 +154,7 @@ abstract class Message implements SignedElement
 
         if ($xml->getAttribute('Version') !== '2.0') {
             /* Currently a very strict check. */
-            throw new \Exception('Unsupported version: ' . $xml->getAttribute('Version'));
+            throw new \Exception('Unsupported version: '.$xml->getAttribute('Version'));
         }
 
         $this->issueInstant = Utils::xsDateTimeToTimestamp($xml->getAttribute('IssueInstant'));
@@ -185,7 +185,7 @@ abstract class Message implements SignedElement
                 $this->validators[] = array(
                     'Function' => array('\SAML2\Utils', 'validateSignature'),
                     'Data' => $sig,
-                    );
+                );
                 $this->signatureMethod = $signatureMethod[0]->value;
             }
         } catch (\Exception $e) {
@@ -201,8 +201,8 @@ abstract class Message implements SignedElement
      * This function is used by the HTTP-Redirect binding, to make it possible to
      * check the signature against the one included in the query string.
      *
-     * @param callback $function The function which should be called.
-     * @param mixed    $data     The data that should be included as the first parameter to the function.
+     * @param callback $function The function which should be called
+     * @param mixed    $data     The data that should be included as the first parameter to the function
      */
     public function addValidator($function, $data)
     {
@@ -211,7 +211,7 @@ abstract class Message implements SignedElement
         $this->validators[] = array(
             'Function' => $function,
             'Data' => $data,
-            );
+        );
     }
 
     /**
@@ -221,8 +221,10 @@ abstract class Message implements SignedElement
      * signature we can validate. An exception is thrown if the signature
      * validation fails.
      *
-     * @param  XMLSecurityKey $key The key we should check against.
-     * @return boolean        true on success, false when we don't have a signature.
+     * @param XMLSecurityKey $key The key we should check against
+     *
+     * @return bool true on success, false when we don't have a signature
+     *
      * @throws \Exception
      */
     public function validate(XMLSecurityKey $key)
@@ -254,7 +256,7 @@ abstract class Message implements SignedElement
     /**
      * Retrieve the identifier of this message.
      *
-     * @return string The identifier of this message.
+     * @return string The identifier of this message
      */
     public function getId()
     {
@@ -264,7 +266,7 @@ abstract class Message implements SignedElement
     /**
      * Set the identifier of this message.
      *
-     * @param string $id The new identifier of this message.
+     * @param string $id The new identifier of this message
      */
     public function setId($id)
     {
@@ -276,7 +278,7 @@ abstract class Message implements SignedElement
     /**
      * Retrieve the issue timestamp of this message.
      *
-     * @return int The issue timestamp of this message, as an UNIX timestamp.
+     * @return int The issue timestamp of this message, as an UNIX timestamp
      */
     public function getIssueInstant()
     {
@@ -286,7 +288,7 @@ abstract class Message implements SignedElement
     /**
      * Set the issue timestamp of this message.
      *
-     * @param int $issueInstant The new issue timestamp of this message, as an UNIX timestamp.
+     * @param int $issueInstant The new issue timestamp of this message, as an UNIX timestamp
      */
     public function setIssueInstant($issueInstant)
     {
@@ -298,7 +300,7 @@ abstract class Message implements SignedElement
     /**
      * Retrieve the destination of this message.
      *
-     * @return string|null The destination of this message, or NULL if no destination is given.
+     * @return string|null The destination of this message, or NULL if no destination is given
      */
     public function getDestination()
     {
@@ -308,7 +310,7 @@ abstract class Message implements SignedElement
     /**
      * Set the destination of this message.
      *
-     * @param string|null $destination The new destination of this message.
+     * @param string|null $destination The new destination of this message
      */
     public function setDestination($destination)
     {
@@ -321,6 +323,7 @@ abstract class Message implements SignedElement
      * Set the given consent for this message.
      *
      * Most likely (though not required) a value of rn:oasis:names:tc:SAML:2.0:consent.
+     *
      * @see \SAML2\Constants
      *
      * @param string $consent
@@ -336,6 +339,7 @@ abstract class Message implements SignedElement
      * Set the given consent for this message.
      *
      * Most likely (though not required) a value of rn:oasis:names:tc:SAML:2.0:consent.
+     *
      * @see \SAML2\Constants
      *
      * @return string Consent
@@ -348,7 +352,7 @@ abstract class Message implements SignedElement
     /**
      * Retrieve the issuer if this message.
      *
-     * @return string|object|null The issuer of this message, or NULL if no issuer is given.
+     * @return string|object|null The issuer of this message, or NULL if no issuer is given
      */
     public function getIssuer()
     {
@@ -357,14 +361,14 @@ abstract class Message implements SignedElement
         } elseif (is_object($this->issuer)) {
             return $this->issuer->__toString();
         } else {
-			return null;
-		}
+            return null;
+        }
     }
 
     /**
      * Set the issuer of this message.
      *
-     * @param string|object|null $issuer The new issuer of this message.
+     * @param string|object|null $issuer The new issuer of this message
      */
     public function setIssuer($issuer)
     {
@@ -386,7 +390,7 @@ abstract class Message implements SignedElement
     /**
      * Retrieve the RelayState associated with this message.
      *
-     * @return string|null The RelayState, or NULL if no RelayState is given.
+     * @return string|null The RelayState, or NULL if no RelayState is given
      */
     public function getRelayState()
     {
@@ -396,7 +400,7 @@ abstract class Message implements SignedElement
     /**
      * Set the RelayState associated with this message.
      *
-     * @param string|null $relayState The new RelayState.
+     * @param string|null $relayState The new RelayState
      */
     public function setRelayState($relayState)
     {
@@ -410,13 +414,13 @@ abstract class Message implements SignedElement
      *
      * This method does not sign the resulting XML document.
      *
-     * @return \DOMElement The root element of the DOM tree.
+     * @return \DOMElement The root element of the DOM tree
      */
     public function toUnsignedXML()
     {
         $this->document = DOMDocumentFactory::create();
 
-        $root = $this->document->createElementNS(Constants::NS_SAMLP, 'samlp:' . $this->tagName);
+        $root = $this->document->createElementNS(Constants::NS_SAMLP, 'samlp:'.$this->tagName);
         $this->document->appendChild($root);
 
         /* Ugly hack to add another namespace declaration to the root element. */
@@ -448,10 +452,9 @@ abstract class Message implements SignedElement
 
         return $root;
     }
-    
+
     /**
      * Set attribute for Issuer if is an object.
-     *
      */
     private function setIssuerAttribute($root)
     {
@@ -477,7 +480,7 @@ abstract class Message implements SignedElement
      * This method sign the resulting XML document if the private key for
      * the signature is set.
      *
-     * @return \DOMElement The root element of the DOM tree.
+     * @return \DOMElement The root element of the DOM tree
      */
     public function toSignedXML()
     {
@@ -488,7 +491,6 @@ abstract class Message implements SignedElement
 
             return $root;
         }
-
 
         /* Find the position we should insert the signature node at. */
         if ($this->issuer !== null) {
@@ -503,23 +505,20 @@ abstract class Message implements SignedElement
             $insertBefore = $root->firstChild;
         }
 
-
         Utils::insertSignature($this->signatureKey, $this->certificates, $root, $insertBefore);
 
         return $root;
     }
 
-
     /**
      * Retrieve the private key we should use to sign the message.
      *
-     * @return XMLSecurityKey|null The key, or NULL if no key is specified.
+     * @return XMLSecurityKey|null The key, or NULL if no key is specified
      */
     public function getSignatureKey()
     {
         return $this->signatureKey;
     }
-
 
     /**
      * Set the private key we should use to sign the message.
@@ -533,42 +532,41 @@ abstract class Message implements SignedElement
         $this->signatureKey = $signatureKey;
     }
 
-
     /**
      * Set the certificates that should be included in the message.
      *
      * The certificates should be strings with the PEM encoded data.
      *
-     * @param array $certificates An array of certificates.
+     * @param array $certificates An array of certificates
      */
     public function setCertificates(array $certificates)
     {
         $this->certificates = $certificates;
     }
 
-
     /**
      * Retrieve the certificates that are included in the message.
      *
-     * @return array An array of certificates.
+     * @return array An array of certificates
      */
     public function getCertificates()
     {
         return $this->certificates;
     }
 
-
     /**
      * Convert an XML element into a message.
      *
-     * @param  \DOMElement    $xml The root XML element.
-     * @return \SAML2\Message The message.
+     * @param \DOMElement $xml The root XML element
+     *
+     * @return \SAML2\Message The message
+     *
      * @throws \Exception
      */
     public static function fromXML(\DOMElement $xml)
     {
         if ($xml->namespaceURI !== Constants::NS_SAMLP) {
-            throw new \Exception('Unknown namespace of SAML message: ' . var_export($xml->namespaceURI, true));
+            throw new \Exception('Unknown namespace of SAML message: '.var_export($xml->namespaceURI, true));
         }
 
         switch ($xml->localName) {
@@ -587,14 +585,14 @@ abstract class Message implements SignedElement
             case 'ArtifactResolve':
                 return new ArtifactResolve($xml);
             default:
-                throw new \Exception('Unknown SAML message: ' . var_export($xml->localName, true));
+                throw new \Exception('Unknown SAML message: '.var_export($xml->localName, true));
         }
     }
 
     /**
      * Retrieve the Extensions.
      *
-     * @return \SAML2\XML\samlp\Extensions.
+     * @return \SAML2\XML\samlp\Extensions
      */
     public function getExtensions()
     {
@@ -604,7 +602,7 @@ abstract class Message implements SignedElement
     /**
      * Set the Extensions.
      *
-     * @param array|null $extensions The Extensions.
+     * @param array|null $extensions The Extensions
      */
     public function setExtensions($extensions)
     {

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -432,20 +432,7 @@ abstract class Message implements SignedElement
             if (is_string($this->issuer)){
                 Utils::addString($root, \SAML2_Const::NS_SAML, 'saml:Issuer', $this->issuer);
             }elseif (is_object($this->issuer)){
-                Utils::addString($root, \SAML2_Const::NS_SAML, 'saml:Issuer', $this->issuer->__toString());
-                $issuer = \SAML2_Utils::xpQuery($root, './saml_assertion:Issuer');
-                if ($this->issuer->getNameQualifier()){
-                    $issuer[0]->setAttribute('NameQualifier', $this->issuer->getNameQualifier());
-                }
-                if ($this->issuer->getFormat()){
-                    $issuer[0]->setAttribute('Format', $this->issuer->getFormat());
-                }
-                if ($this->issuer->getSPNameQualifier()){
-                    $issuer[0]->setAttribute('SPNameQualifier', $this->issuer->getSPNameQualifier());
-                }
-                if ($this->issuer->getSPProvidedID()){
-                    $issuer[0]->setAttribute('SPProvidedID', $this->issuer->getSPProvidedID());
-                }
+                $this->setIssuerAttribute($root);
             }
         }
 
@@ -454,6 +441,27 @@ abstract class Message implements SignedElement
         }
 
         return $root;
+    }
+    
+    /**
+     * Set attribute for Issuer if is an object.
+     *
+     */
+    private function setIssuerAttribute($root) {
+        Utils::addString($root, \SAML2_Const::NS_SAML, 'saml:Issuer', $this->issuer->__toString());
+        $issuer = \SAML2_Utils::xpQuery($root, './saml_assertion:Issuer');
+        if ($this->issuer->getNameQualifier()){
+            $issuer[0]->setAttribute('NameQualifier', $this->issuer->getNameQualifier());
+        }
+        if ($this->issuer->getFormat()){
+            $issuer[0]->setAttribute('Format', $this->issuer->getFormat());
+        }
+        if ($this->issuer->getSPNameQualifier()){
+            $issuer[0]->setAttribute('SPNameQualifier', $this->issuer->getSPNameQualifier());
+        }
+        if ($this->issuer->getSPProvidedID()){
+            $issuer[0]->setAttribute('SPProvidedID', $this->issuer->getSPProvidedID());
+        }
     }
 
     /**

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -356,7 +356,9 @@ abstract class Message implements SignedElement
             return $this->issuer;
         } elseif (is_object($this->issuer)) {
             return $this->issuer->__toString();
-        }
+        } else {
+			return null;
+		}
     }
 
     /**

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -431,7 +431,7 @@ abstract class Message implements SignedElement
         if ($this->issuer !== null) {
             if (is_string($this->issuer)){
                 Utils::addString($root, \SAML2_Const::NS_SAML, 'saml:Issuer', $this->issuer);
-            }elseif (is_object($this->issuer)){
+            }elseif (is_object($this->issuer)) {
                 $this->setIssuerAttribute($root);
             }
         }
@@ -450,16 +450,16 @@ abstract class Message implements SignedElement
     private function setIssuerAttribute($root) {
         Utils::addString($root, \SAML2_Const::NS_SAML, 'saml:Issuer', $this->issuer->__toString());
         $issuer = \SAML2_Utils::xpQuery($root, './saml_assertion:Issuer');
-        if ($this->issuer->getNameQualifier()){
+        if ($this->issuer->getNameQualifier()) {
             $issuer[0]->setAttribute('NameQualifier', $this->issuer->getNameQualifier());
         }
-        if ($this->issuer->getFormat()){
+        if ($this->issuer->getFormat()) {
             $issuer[0]->setAttribute('Format', $this->issuer->getFormat());
         }
-        if ($this->issuer->getSPNameQualifier()){
+        if ($this->issuer->getSPNameQualifier()) {
             $issuer[0]->setAttribute('SPNameQualifier', $this->issuer->getSPNameQualifier());
         }
-        if ($this->issuer->getSPProvidedID()){
+        if ($this->issuer->getSPProvidedID()) {
             $issuer[0]->setAttribute('SPProvidedID', $this->issuer->getSPProvidedID());
         }
     }

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -348,11 +348,15 @@ abstract class Message implements SignedElement
     /**
      * Retrieve the issuer if this message.
      *
-     * @return string|null The issuer of this message, or NULL if no issuer is given.
+     * @return string|object|null The issuer of this message, or NULL if no issuer is given.
      */
     public function getIssuer()
     {
-        return $this->issuer;
+        if (is_string($this->issuer)){
+            return $this->issuer;
+        }elseif (is_object($this->issuer)){
+            return $this->issuer->__toString();
+        }
     }
 
     /**
@@ -429,7 +433,7 @@ abstract class Message implements SignedElement
         }
 
         if ($this->issuer !== null) {
-            if (is_string($this->issuer)){
+            if (is_string($this->issuer)) {
                 Utils::addString($root, \SAML2_Const::NS_SAML, 'saml:Issuer', $this->issuer);
             }elseif (is_object($this->issuer)) {
                 $this->setIssuerAttribute($root);

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -361,7 +361,7 @@ abstract class Message implements SignedElement
         } elseif (is_object($this->issuer)) {
             return $this->issuer->__toString();
         } else {
-            return "";
+            return null;
         }
     }
 

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -352,9 +352,9 @@ abstract class Message implements SignedElement
      */
     public function getIssuer()
     {
-        if (is_string($this->issuer)){
+        if (is_string($this->issuer)) {
             return $this->issuer;
-        }elseif (is_object($this->issuer)){
+        }elseif (is_object($this->issuer)) {
             return $this->issuer->__toString();
         }
     }
@@ -435,7 +435,7 @@ abstract class Message implements SignedElement
         if ($this->issuer !== null) {
             if (is_string($this->issuer)) {
                 Utils::addString($root, \SAML2_Const::NS_SAML, 'saml:Issuer', $this->issuer);
-            }elseif (is_object($this->issuer)) {
+            } elseif (is_object($this->issuer)) {
                 $this->setIssuerAttribute($root);
             }
         }
@@ -451,7 +451,8 @@ abstract class Message implements SignedElement
      * Set attribute for Issuer if is an object.
      *
      */
-    private function setIssuerAttribute($root) {
+    private function setIssuerAttribute($root) 
+    {
         Utils::addString($root, \SAML2_Const::NS_SAML, 'saml:Issuer', $this->issuer->__toString());
         $issuer = \SAML2_Utils::xpQuery($root, './saml_assertion:Issuer');
         if ($this->issuer->getNameQualifier()) {

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -361,7 +361,7 @@ abstract class Message implements SignedElement
         } elseif (is_object($this->issuer)) {
             return $this->issuer->__toString();
         } else {
-            return null;
+            return "";
         }
     }
 

--- a/src/SAML2/NameID.php
+++ b/src/SAML2/NameID.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SAML2;
+
+/**
+ * Base class for NameID element.
+ *
+ * @package SimpleSAMLphp
+ */
+class NameID extends NameIDType {
+
+    public function __construct($entity) {
+        parent::__construct($entity);
+    }
+
+}

--- a/src/SAML2/NameID.php
+++ b/src/SAML2/NameID.php
@@ -4,13 +4,11 @@ namespace SAML2;
 
 /**
  * Base class for NameID element.
- *
- * @package SimpleSAMLphp
  */
-class NameID extends NameIDType {
-
-    public function __construct($entity) {
+class NameID extends NameIDType
+{
+    public function __construct($entity)
+    {
         parent::__construct($entity);
     }
-
 }

--- a/src/SAML2/NameIDType.php
+++ b/src/SAML2/NameIDType.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace SAML2;
+
+/**
+ * Base class for NameIDType element.
+ *
+ * @package SimpleSAMLphp
+ */
+abstract class NameIDType extends BaseID {
+
+    /**
+     * A URI reference representing the classification of string-based identifier information.
+     * 
+     * @var string|null
+     */
+    private $format;
+
+    /**
+     * A A name identifier established by a service provider or affiliation of providers for the entity.
+     * 
+     * @var string|null
+     */
+    private $spProvidedID;
+
+    /**
+     * Retrieve the name identifier established by a service provider or affiliation of providers for the entity.
+     *
+     * @return string name identifier established by a service provider or affiliation of providers for the entity.
+     */
+    public function getSPProvidedID() {
+        return $this->spProvidedID;
+    }
+
+    /**
+     * Set the name identifier established by a service provider or affiliation of providers for the entity.
+     *
+     * @param string $spProvidedID name identifier established by a service provider or affiliation of providers for the entity.
+     */
+    public function setSPProvidedID($spProvidedID) {
+        assert('is_string($spProvidedID) || is_null($spProvidedID)');
+
+        $this->spProvidedID = $spProvidedID;
+    }
+
+    /**
+     * Retrieve the format.
+     *
+     * @return string format.
+     */
+    public function getFormat() {
+        return $this->format;
+    }
+
+    /**
+     * Set the format.
+     *
+     * @param string $format format for the entity.
+     */
+    public function setFormat($format) {
+        assert('is_string($format) || is_null($format)');
+
+        $this->format = $format;
+    }
+    
+
+}

--- a/src/SAML2/NameIDType.php
+++ b/src/SAML2/NameIDType.php
@@ -4,21 +4,19 @@ namespace SAML2;
 
 /**
  * Base class for NameIDType element.
- *
- * @package SimpleSAMLphp
  */
-abstract class NameIDType extends BaseID {
-
+abstract class NameIDType extends BaseID
+{
     /**
      * A URI reference representing the classification of string-based identifier information.
-     * 
+     *
      * @var string|null
      */
     private $format;
 
     /**
      * A A name identifier established by a service provider or affiliation of providers for the entity.
-     * 
+     *
      * @var string|null
      */
     private $spProvidedID;
@@ -26,18 +24,20 @@ abstract class NameIDType extends BaseID {
     /**
      * Retrieve the name identifier established by a service provider or affiliation of providers for the entity.
      *
-     * @return string name identifier established by a service provider or affiliation of providers for the entity.
+     * @return string name identifier established by a service provider or affiliation of providers for the entity
      */
-    public function getSPProvidedID() {
+    public function getSPProvidedID()
+    {
         return $this->spProvidedID;
     }
 
     /**
      * Set the name identifier established by a service provider or affiliation of providers for the entity.
      *
-     * @param string $spProvidedID name identifier established by a service provider or affiliation of providers for the entity.
+     * @param string $spProvidedID name identifier established by a service provider or affiliation of providers for the entity
      */
-    public function setSPProvidedID($spProvidedID) {
+    public function setSPProvidedID($spProvidedID)
+    {
         assert('is_string($spProvidedID) || is_null($spProvidedID)');
 
         $this->spProvidedID = $spProvidedID;
@@ -46,22 +46,22 @@ abstract class NameIDType extends BaseID {
     /**
      * Retrieve the format.
      *
-     * @return string format.
+     * @return string format
      */
-    public function getFormat() {
+    public function getFormat()
+    {
         return $this->format;
     }
 
     /**
      * Set the format.
      *
-     * @param string $format format for the entity.
+     * @param string $format format for the entity
      */
-    public function setFormat($format) {
+    public function setFormat($format)
+    {
         assert('is_string($format) || is_null($format)');
 
         $this->format = $format;
     }
-    
-
 }

--- a/tests/SAML2/MessageTest.php
+++ b/tests/SAML2/MessageTest.php
@@ -123,8 +123,6 @@ AUTHNREQUEST
         $this->assertEquals($nameIDObject->getEntity(), $url);
         $this->assertEquals($nameIDObject->getNameQualifier(), $url);
         $this->assertEquals($unsignedMessage->getIssuer(), $nameIDObject);
-        $nameIDObject = new NameID(null);
-        $this->assertEquals($nameIDObject, null);
     }
 
     /**
@@ -158,11 +156,10 @@ AUTHNREQUEST
         $unsignedMessage = Message::fromXML($authnRequest->documentElement);
         $unsignedMessage->setSignatureKey($privateKey);
         $unsignedMessage->setCertificates(array(CertificatesMock::PUBLIC_KEY_PEM));
-        $nameIDObject = new NameID(null);
-        $unsignedMessage->setIssuer($nameIDObject);
+        $unsignedMessage->setIssuer('');
         $signedMessage = Message::fromXML($unsignedMessage->toSignedXML());
 
-        $this->assertEquals($unsignedMessage->getIssuer(), null);
+        $this->assertEquals($unsignedMessage->getIssuer(), '');
     }
 
     /**

--- a/tests/SAML2/MessageTest.php
+++ b/tests/SAML2/MessageTest.php
@@ -156,10 +156,10 @@ AUTHNREQUEST
         $unsignedMessage = Message::fromXML($authnRequest->documentElement);
         $unsignedMessage->setSignatureKey($privateKey);
         $unsignedMessage->setCertificates(array(CertificatesMock::PUBLIC_KEY_PEM));
-        $unsignedMessage->setIssuer('');
+        $unsignedMessage->setIssuer(null);
         $signedMessage = Message::fromXML($unsignedMessage->toSignedXML());
 
-        $this->assertEquals($unsignedMessage->getIssuer(), '');
+        $this->assertEquals($unsignedMessage->getIssuer(), null);
     }
 
     /**

--- a/tests/SAML2/MessageTest.php
+++ b/tests/SAML2/MessageTest.php
@@ -4,12 +4,13 @@ namespace SAML2;
 
 use PHPUnit_Framework_TestCase as TestCase;
 
-class MessageTest extends TestCase {
-
+class MessageTest extends TestCase
+{
     /**
      * @group Message
      */
-    public function testCorrectSignatureMethodCanBeExtractedFromAuthnRequest() {
+    public function testCorrectSignatureMethodCanBeExtractedFromAuthnRequest()
+    {
         $authnRequest = new \DOMDocument();
         $authnRequest->loadXML(<<<'AUTHNREQUEST'
 <samlp:AuthnRequest
@@ -42,7 +43,8 @@ AUTHNREQUEST
     /**
      * @group Message
      */
-    public function testCorrectSignatureMethodCanBeExtractedFromWithIssuerObjectAuthnRequest() {
+    public function testCorrectSignatureMethodCanBeExtractedFromWithIssuerObjectAuthnRequest()
+    {
         $authnRequest = new \DOMDocument();
         $authnRequest->loadXML(<<<'AUTHNREQUEST'
 <samlp:AuthnRequest
@@ -79,7 +81,8 @@ AUTHNREQUEST
     /**
      * @group Message
      */
-    public function testCorrectSignatureMethodCanBeExtractedFromWithNameIDAuthnRequest() {
+    public function testCorrectSignatureMethodCanBeExtractedFromWithNameIDAuthnRequest()
+    {
         $authnRequest = new \DOMDocument();
         $authnRequest->loadXML(<<<'AUTHNREQUEST'
 <samlp:AuthnRequest
@@ -102,7 +105,7 @@ AUTHNREQUEST
         $privateKey = CertificatesMock::getPrivateKey();
 
         $url = 'https://gateway.stepup.org/saml20/sp/metadata';
-        $sp = "MyServiceProvider";
+        $sp = 'MyServiceProvider';
         $unsignedMessage = Message::fromXML($authnRequest->documentElement);
         $unsignedMessage->setSignatureKey($privateKey);
         $unsignedMessage->setCertificates(array(CertificatesMock::PUBLIC_KEY_PEM));
@@ -121,16 +124,54 @@ AUTHNREQUEST
         $this->assertEquals($nameIDObject->getNameQualifier(), $url);
         $this->assertEquals($unsignedMessage->getIssuer(), $nameIDObject);
         $nameIDObject = new NameID(null);
-        $this->assertEquals($unsignedMessage->getIssuer(), null);
-        
+        $this->assertEquals($nameIDObject, null);
     }
 
     /**
      * @group Message
      */
-    public function testCorrectSignatureMethodCanBeExtractedFromResponse() {
+    public function testCorrectSignatureMethodCanBeExtractedFromWithNameIDNullAuthnRequest()
+    {
+        $authnRequest = new \DOMDocument();
+        $authnRequest->loadXML(<<<'AUTHNREQUEST'
+<samlp:AuthnRequest
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    AssertionConsumerServiceIndex="1"
+    Destination="https://tiqr.stepup.org/idp/profile/saml2/Redirect/SSO"
+    ID="_2b0226190ca1c22de6f66e85f5c95158"
+    IssueInstant="2014-09-22T13:42:00Z"
+    Version="2.0">
+  <saml:Issuer NameQualifier="https://gateway.stepup.org/saml20/sp/metadata"
+                 Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">https://gateway.stepup.org/saml20/sp/metadata</saml:Issuer>
+  <saml:Subject>
+        <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">user@example.org</saml:NameID>
+  </saml:Subject>
+</samlp:AuthnRequest>
+AUTHNREQUEST
+        );
+
+        $privateKey = CertificatesMock::getPrivateKey();
+
+        $url = 'https://gateway.stepup.org/saml20/sp/metadata';
+        $sp = 'MyServiceProvider';
+        $unsignedMessage = Message::fromXML($authnRequest->documentElement);
+        $unsignedMessage->setSignatureKey($privateKey);
+        $unsignedMessage->setCertificates(array(CertificatesMock::PUBLIC_KEY_PEM));
+        $nameIDObject = new NameID(null);
+        $unsignedMessage->setIssuer($nameIDObject);
+        $signedMessage = Message::fromXML($unsignedMessage->toSignedXML());
+
+        $this->assertEquals($unsignedMessage->getIssuer(), null);
+    }
+
+    /**
+     * @group Message
+     */
+    public function testCorrectSignatureMethodCanBeExtractedFromResponse()
+    {
         $response = new \DOMDocument();
-        $response->load(__DIR__ . '/Response/response.xml');
+        $response->load(__DIR__.'/Response/response.xml');
 
         $privateKey = CertificatesMock::getPrivateKey();
 
@@ -142,5 +183,4 @@ AUTHNREQUEST
 
         $this->assertEquals($privateKey->getAlgorith(), $signedMessage->getSignatureMethod());
     }
-
 }

--- a/tests/SAML2/MessageTest.php
+++ b/tests/SAML2/MessageTest.php
@@ -119,6 +119,8 @@ AUTHNREQUEST
         $this->assertEquals($nameIDObject->getSPProvidedID(), $sp);
         $this->assertEquals($nameIDObject->getEntity(), $url);
         $this->assertEquals($nameIDObject->getNameQualifier(), $url);
+        $this->assertEquals($unsignedMessage->getIssuer(), $nameIDObject);
+        
     }
 
     /**

--- a/tests/SAML2/MessageTest.php
+++ b/tests/SAML2/MessageTest.php
@@ -120,6 +120,8 @@ AUTHNREQUEST
         $this->assertEquals($nameIDObject->getEntity(), $url);
         $this->assertEquals($nameIDObject->getNameQualifier(), $url);
         $this->assertEquals($unsignedMessage->getIssuer(), $nameIDObject);
+        $nameIDObject = new NameID(null);
+        $this->assertEquals($unsignedMessage->getIssuer(), null);
         
     }
 

--- a/tests/SAML2/MessageTest.php
+++ b/tests/SAML2/MessageTest.php
@@ -12,7 +12,7 @@ class MessageTest extends TestCase
     public function testCorrectSignatureMethodCanBeExtractedFromAuthnRequest()
     {
         $authnRequest = new \DOMDocument();
-        $authnRequest->loadXML(<<<AUTHNREQUEST
+        $authnRequest->loadXML(<<<'AUTHNREQUEST'
 <samlp:AuthnRequest
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
@@ -43,10 +43,86 @@ AUTHNREQUEST
     /**
      * @group Message
      */
+    public function testCorrectSignatureMethodCanBeExtractedFromWithIssuerObjectAuthnRequest()
+    {
+        $authnRequest = new \DOMDocument();
+        $authnRequest->loadXML(<<<'AUTHNREQUEST'
+<samlp:AuthnRequest
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    AssertionConsumerServiceIndex="1"
+    Destination="https://tiqr.stepup.org/idp/profile/saml2/Redirect/SSO"
+    ID="_2b0226190ca1c22de6f66e85f5c95158"
+    IssueInstant="2014-09-22T13:42:00Z"
+    Version="2.0">
+  <saml:Issuer NameQualifier="https://gateway.stepup.org/saml20/sp/metadata"
+                 Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">https://gateway.stepup.org/saml20/sp/metadata</saml:Issuer>
+  <saml:Subject>
+        <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">user@example.org</saml:NameID>
+  </saml:Subject>
+</samlp:AuthnRequest>
+AUTHNREQUEST
+        );
+
+        $privateKey = CertificatesMock::getPrivateKey();
+
+        $unsignedMessage = Message::fromXML($authnRequest->documentElement);
+        $unsignedMessage->setSignatureKey($privateKey);
+        $unsignedMessage->setCertificates(array(CertificatesMock::PUBLIC_KEY_PEM));
+        $issuerObject = new Issuer($unsignedMessage->getIssuer());
+        $issuerObject->setNameQualifier('https://gateway.stepup.org/saml20/sp/metadata');
+        $issuerObject->setFormat('urn:oasis:names:tc:SAML:2.0:nameid-format:entity');
+        $unsignedMessage->setIssuer($issuerObject);
+        $signedMessage = Message::fromXML($unsignedMessage->toSignedXML());
+
+        $this->assertEquals($privateKey->getAlgorith(), $signedMessage->getSignatureMethod());
+    }
+
+    /**
+     * @group Message
+     */
+    public function testCorrectSignatureMethodCanBeExtractedFromWithNameIDAuthnRequest()
+    {
+        $authnRequest = new \DOMDocument();
+        $authnRequest->loadXML(<<<'AUTHNREQUEST'
+<samlp:AuthnRequest
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    AssertionConsumerServiceIndex="1"
+    Destination="https://tiqr.stepup.org/idp/profile/saml2/Redirect/SSO"
+    ID="_2b0226190ca1c22de6f66e85f5c95158"
+    IssueInstant="2014-09-22T13:42:00Z"
+    Version="2.0">
+  <saml:Issuer NameQualifier="https://gateway.stepup.org/saml20/sp/metadata"
+                 Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">https://gateway.stepup.org/saml20/sp/metadata</saml:Issuer>
+  <saml:Subject>
+        <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">user@example.org</saml:NameID>
+  </saml:Subject>
+</samlp:AuthnRequest>
+AUTHNREQUEST
+        );
+
+        $privateKey = CertificatesMock::getPrivateKey();
+
+        $unsignedMessage = Message::fromXML($authnRequest->documentElement);
+        $unsignedMessage->setSignatureKey($privateKey);
+        $unsignedMessage->setCertificates(array(CertificatesMock::PUBLIC_KEY_PEM));
+        $nameIDObject = new NameID($unsignedMessage->getIssuer());
+        $nameIDObject->setNameQualifier('https://gateway.stepup.org/saml20/sp/metadata');
+        $nameIDObject->setFormat('urn:oasis:names:tc:SAML:2.0:nameid-format:entity');
+        $unsignedMessage->setIssuer($nameIDObject);
+        $signedMessage = Message::fromXML($unsignedMessage->toSignedXML());
+
+        $this->assertEquals($privateKey->getAlgorith(), $signedMessage->getSignatureMethod());
+    }
+
+    /**
+     * @group Message
+     */
     public function testCorrectSignatureMethodCanBeExtractedFromResponse()
     {
         $response = new \DOMDocument();
-        $response->load(__DIR__ . '/Response/response.xml');
+        $response->load(__DIR__.'/Response/response.xml');
 
         $privateKey = CertificatesMock::getPrivateKey();
 


### PR DESCRIPTION
Introducing an Issuer class that is accepted by setIssuer as well as a string (for backwards compatibility)

to fix #67
This is my first contribution on github, I hope I have done well
