### PR TITLE
Handle EPTI attribute parsing correctly

### DIFF
--- a/src/SAML2/Assertion.php
+++ b/src/SAML2/Assertion.php
@@ -153,10 +153,21 @@ class Assertion implements SignedElement
     private $AuthenticatingAuthority;
 
     /**
-     * The attributes, as an associative array.
+     * The attributes, as an associative array, indexed by attribute name
      *
-     * @var array multi-dimensional array, indexed by attribute name with each value representing the attribute value
-     *            of that attribute. This value is an array of \DOMNodeList|string|int
+     * To ease handling, all attribute values are represented as an array of values, also for values with a multiplicity
+     * of single. There are 4 possible variants of datatypes for the values: a string, an integer, an array or
+     * a DOMNodeList
+     *
+     * If the attribute is an eduPersonTargetedID, the values will be arrays that are created by @see Utils::parseNameId
+     *    and compatible with @see Utils::addNameID
+     * If the attribute value has an type-definition (xsi:string or xsi:int), the values will be of that type.
+     * If the attribute value contains a nested XML structure, the values will be a DOMNodeList
+     * In all other cases the values are treated as strings
+     *
+     * **WARNING** a DOMNodeList cannot be serialized without data-loss and should be handled explicitly
+     *
+     * @var array multi-dimensional array of \DOMNodeList|string|int|array
      */
     private $attributes;
 

--- a/src/SAML2/Assertion.php
+++ b/src/SAML2/Assertion.php
@@ -4,6 +4,7 @@ namespace SAML2;
 
 use RobRichards\XMLSecLibs\XMLSecEnc;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
+use SAML2\Exception\RuntimeException;
 use SAML2\Utilities\Temporal;
 use SAML2\XML\Chunk;
 use SAML2\XML\saml\SubjectConfirmation;
@@ -511,7 +512,27 @@ class Assertion implements SignedElement
      */
     private function parseAttributeValue($attribute, $attributeName)
     {
+        /** @var \DOMElement[] $values */
         $values = Utils::xpQuery($attribute, './saml_assertion:AttributeValue');
+
+        if ($attributeName === Constants::EPTI_URN_MACE || $attributeName === Constants::EPTI_URN_OID) {
+            foreach ($values as $index => $eptiAttributeValue) {
+                $eptiNameId = Utils::xpQuery($eptiAttributeValue, './saml:NameID');
+
+                if (count($eptiNameId) !== 1) {
+                    throw new RuntimeException(sprintf(
+                        'A "%s" (EPTI) attribute value must be a NameID, none found for value no. "%d"',
+                        $attributeName,
+                        $index
+                    ));
+                }
+
+                $this->attributes[$attributeName][] = Utils::parseNameId($eptiNameId[0]);
+            }
+
+            return;
+        }
+
         foreach ($values as $value) {
             $hasNonTextChildElements = false;
             foreach ($value->childNodes as $childNode) {
@@ -1466,6 +1487,16 @@ class Assertion implements SignedElement
 
             if ($this->nameFormat !== Constants::NAMEFORMAT_UNSPECIFIED) {
                 $attribute->setAttribute('NameFormat', $this->nameFormat);
+            }
+
+            if ($name === Constants::EPTI_URN_MACE || $name === Constants::EPTI_URN_OID) {
+                foreach ($values as $eptiValue) {
+                    $attributeValue = $document->createElementNS(Constants::NS_SAML, 'saml:AttributeValue');
+                    $attribute->appendChild($attributeValue);
+                    Utils::addNameId($attributeValue, $eptiValue);
+                }
+
+                continue;
             }
 
             foreach ($values as $value) {

--- a/src/SAML2/Constants.php
+++ b/src/SAML2/Constants.php
@@ -53,7 +53,7 @@ class Constants
     * Holder-of-Key subject confirmation method.
     */
     const CM_HOK = 'urn:oasis:names:tc:SAML:2.0:cm:holder-of-key';
-    
+
     /**
      * Vouches subject confirmation method.
      */
@@ -125,6 +125,10 @@ class Constants
      * Indicates that the issuer of the message does not believe that they need to obtain or report consent.
      */
     const CONSENT_INAPPLICABLE = 'urn:oasis:names:tc:SAML:2.0:consent:inapplicable';
+
+    const EPTI_URN_MACE = 'urn:mace:dir:attribute-def:eduPersonTargetedID';
+
+    const EPTI_URN_OID = 'urn:oid:1.3.6.1.4.1.5923.1.1.1.10';
 
     /**
      * The interpretation of the attribute name is left to individual implementations.

--- a/tests/SAML2/AssertionTest.php
+++ b/tests/SAML2/AssertionTest.php
@@ -497,7 +497,7 @@ XML
 
     }
 
-    public function testAttributeValuesWithComplexTypeValuesAreParsedCorrectly()
+    public function testEptiAttributeValuesAreParsedCorrectly()
     {
         $xml = <<<XML
             <saml:Assertion
@@ -531,9 +531,166 @@ XML;
         $assertion = new Assertion(DOMDocumentFactory::fromString($xml)->firstChild);
 
         $attributes = $assertion->getAttributes();
+
+        $maceValue = $attributes['urn:mace:dir:attribute-def:eduPersonTargetedID'][0];
+        $oidValue = $attributes['urn:oid:1.3.6.1.4.1.5923.1.1.1.10'][0];
+
+        $this->assertEquals(
+            array(
+                'Value'  => 'abcd-some-value-xyz',
+                'Format' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
+            ),
+            $maceValue,
+            'Parsing the EPTI attribute named with urn:mace did not result in the correct value'
+        );
+        $this->assertEquals(
+            array(
+                'Value'  => 'abcd-some-value-xyz',
+                'Format' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
+            ),
+            $oidValue,
+            'Parsing the EPTI attribute named with urn:oid did not result in the correct value'
+        );
+
+        $this->assertXmlStringEqualsXmlString($xml, $assertion->toXML()->ownerDocument->saveXML());
+    }
+
+    public function testEptiAttributeValuesMustBeANameID()
+    {
+        $xml = <<<XML
+            <saml:Assertion
+                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    Version="2.0"
+                    ID="_93af655219464fb403b34436cfb0c5cb1d9a5502"
+                    IssueInstant="1970-01-01T01:33:31Z">
+      <saml:Issuer>Provider</saml:Issuer>
+      <saml:Conditions/>
+      <saml:AttributeStatement>
+        <saml:Attribute Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>
+            <saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">abcd-some-value-xyz</saml:NameID>
+          </saml:AttributeValue>
+        </saml:Attribute>
+        <saml:Attribute Name="urn:mace:dir:attribute-def:eduPersonTargetedID" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue>
+            <saml:Attribute Name="urn:some:custom:nested:element">
+              <saml:AttributeValue>abcd-some-value-xyz</saml:AttributeValue>
+            </saml:Attribute>
+          </saml:AttributeValue>
+        </saml:Attribute>
+        <saml:Attribute Name="urn:EntityConcernedSubID" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue xsi:type="xs:string">string</saml:AttributeValue>
+        </saml:Attribute>
+      </saml:AttributeStatement>
+    </saml:Assertion>
+XML;
+
+        $this->setExpectedException(
+            'SAML2\Exception\RuntimeException',
+            'A "urn:mace:dir:attribute-def:eduPersonTargetedID" (EPTI) attribute value must be a NameID, '
+            . 'none found for value no. "0"'
+        );
+        new Assertion(DOMDocumentFactory::fromString($xml)->firstChild);
+    }
+
+    /**
+     * as per http://software.internet2.edu/eduperson/internet2-mace-dir-eduperson-201310.html#eduPersonTargetedID
+     * it is multivalued
+     */
+    public function testEptiAttributeParsingSupportsMultipleValues()
+    {
+        $xml
+            = <<<XML
+            <saml:Assertion
+                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    Version="2.0"
+                    ID="_93af655219464fb403b34436cfb0c5cb1d9a5502"
+                    IssueInstant="1970-01-01T01:33:31Z">
+      <saml:Issuer>Provider</saml:Issuer>
+      <saml:Conditions/>
+      <saml:AttributeStatement>
+        <saml:Attribute Name="urn:mace:dir:attribute-def:eduPersonTargetedID" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+            <saml:AttributeValue>
+                <saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">abcd-some-value-xyz</saml:NameID>
+            </saml:AttributeValue>
+            <saml:AttributeValue>
+                <saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">xyz-some-value-abcd</saml:NameID>
+            </saml:AttributeValue>
+        </saml:Attribute>
+        <saml:Attribute Name="urn:EntityConcernedSubID" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+            <saml:AttributeValue xsi:type="xs:string">string</saml:AttributeValue>
+        </saml:Attribute>
+      </saml:AttributeStatement>
+    </saml:Assertion>
+XML;
+
+        $assertion = new Assertion(DOMDocumentFactory::fromString($xml)->firstChild);
+
+        $attributes = $assertion->getAttributes();
+
+        $maceFirstValue = $attributes['urn:mace:dir:attribute-def:eduPersonTargetedID'][0];
+        $maceSecondValue = $attributes['urn:mace:dir:attribute-def:eduPersonTargetedID'][1];
+
+        $this->assertEquals(
+            array(
+                'Value'  => 'abcd-some-value-xyz',
+                'Format' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
+            ),
+            $maceFirstValue,
+            'Parsing the EPTI attribute with multiple values resulted in an incorrect first value'
+        );
+        $this->assertEquals(
+            array(
+                'Value'  => 'xyz-some-value-abcd',
+                'Format' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
+            ),
+            $maceSecondValue,
+            'Parsing the EPTI attribute with multiple values resulted in an incorrect second value'
+        );
+
+        $this->assertXmlStringEqualsXmlString($xml, $assertion->toXML()->ownerDocument->saveXML());
+    }
+
+    public function testAttributeValuesWithComplexTypesAreParsedCorrectly()
+    {
+        $xml = <<<XML
+            <saml:Assertion
+                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    Version="2.0"
+                    ID="_93af655219464fb403b34436cfb0c5cb1d9a5502"
+                    IssueInstant="1970-01-01T01:33:31Z">
+            <saml:Issuer>Provider</saml:Issuer>
+            <saml:Conditions/>
+            <saml:AttributeStatement>
+              <saml:Attribute Name="urn:some:custom:outer:element" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                <saml:AttributeValue>
+                  <saml:Attribute Name="urn:some:custom:nested:element">
+                    <saml:AttributeValue>abcd-some-value-xyz</saml:AttributeValue>
+                  </saml:Attribute>
+                </saml:AttributeValue>
+              </saml:Attribute>
+              <saml:Attribute Name="urn:EntityConcernedSubID" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                <saml:AttributeValue xsi:type="xs:string">string</saml:AttributeValue>
+              </saml:Attribute>
+            </saml:AttributeStatement>
+            </saml:Assertion>
+XML;
+
+        $assertion = new Assertion(DOMDocumentFactory::fromString($xml)->firstChild);
+
+        $attributes = $assertion->getAttributes();
         $this->assertInstanceOf(
             '\DOMNodeList',
-            $attributes['urn:mace:dir:attribute-def:eduPersonTargetedID'][0]
+            $attributes['urn:some:custom:outer:element'][0]
         );
         $this->assertXmlStringEqualsXmlString($xml, $assertion->toXML()->ownerDocument->saveXML());
     }
@@ -584,14 +741,11 @@ XML;
       <saml:Issuer>Provider</saml:Issuer>
       <saml:Conditions/>
       <saml:AttributeStatement>
-        <saml:Attribute Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml:Attribute Name="urn:some:custom:outer:element" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
             <saml:AttributeValue>
-                <saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">abcd-some-value-xyz</saml:NameID>
-            </saml:AttributeValue>
-        </saml:Attribute>
-        <saml:Attribute Name="urn:mace:dir:attribute-def:eduPersonTargetedID" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
-            <saml:AttributeValue>
-                <saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">abcd-some-value-xyz</saml:NameID>
+                <saml:Attribute Name="urn:some:custom:nested:element">
+                    <saml:AttributeValue>abcd-some-value-xyz</saml:AttributeValue>
+                </saml:Attribute>
             </saml:AttributeValue>
         </saml:Attribute>
         <saml:Attribute Name="urn:EntityConcernedSubID" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
@@ -619,7 +773,7 @@ XML;
         $attributes = $assertionToVerify->getAttributes();
         $this->assertInstanceOf(
             '\DOMNodeList',
-            $attributes['urn:mace:dir:attribute-def:eduPersonTargetedID'][0]
+            $attributes['urn:some:custom:outer:element'][0]
         );
         $this->assertXmlStringEqualsXmlString($xml, $assertionToVerify->toXML()->ownerDocument->saveXML());
     }
@@ -1347,7 +1501,7 @@ XML
       <saml:Issuer>Provider</saml:Issuer>
       <saml:Conditions/>
       <saml:AttributeStatement>
-        <saml:Attribute Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml:Attribute Name="1.3.6.1.4.1.25178.1.2.9" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
             <saml:AttributeValue xsi:type="xs:string">string</saml:AttributeValue>
         </saml:Attribute>
         <saml:Attribute Name="urn:EntityConcernedSubID" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
@@ -1359,8 +1513,8 @@ XML;
 
         $assertion = new Assertion(DOMDocumentFactory::fromString($xml)->firstChild);
 
-        $namefmt = $assertion->getAttributeNameFormat();
-        $this->assertEquals('urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified', $namefmt);
+        $nameFormat = $assertion->getAttributeNameFormat();
+        $this->assertEquals('urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified', $nameFormat);
     }
 
     /**


### PR DESCRIPTION
As an eduPersonTargetedID is [specified as always containing a NameID][1], we can detect and handle that case by treating the attribute values as NameID. This also resolves the issue of an EPTI attribute not being serializeable, as reported [here][2] and discussed in #60.

Do note that this is a BC break and therefor should result in the release of a new major, albeit it arguably can be treated as a bugfix. It the latter case it could be released in the 2.x range.

[1]: http://software.internet2.edu/eduperson/internet2-mace-dir-eduperson-201310.html#eduPersonTargetedID
[2]: https://groups.google.com/forum/#!msg/simplesamlphp/Zn9KFqflUjU/6yhjPPOeBQAJ