### PR TITLE
Additional attributes on ContactPerson Element

### DIFF
--- a/src/SAML2/XML/md/ContactPerson.php
+++ b/src/SAML2/XML/md/ContactPerson.php
@@ -95,7 +95,7 @@ class ContactPerson
         $this->EmailAddress = self::getStringElements($xml, 'EmailAddress');
         $this->TelephoneNumber = self::getStringElements($xml, 'TelephoneNumber');
 
-        foreach($xml->attributes as $attr) {
+        foreach ($xml->attributes as $attr) {
             if ($attr->nodeName == "contactType")
                 continue;
 

--- a/src/SAML2/XML/md/ContactPerson.php
+++ b/src/SAML2/XML/md/ContactPerson.php
@@ -64,6 +64,13 @@ class ContactPerson
     public $TelephoneNumber = array();
 
     /**
+     * Extra attributes on the contact element.
+     *
+     * @var array
+     */
+    public $ContactPersonAttributes = array();
+
+    /**
      * Initialize a ContactPerson element.
      *
      * @param \DOMElement|null $xml The XML element we should load.
@@ -148,6 +155,7 @@ class ContactPerson
         assert('is_null($this->SurName) || is_string($this->SurName)');
         assert('is_array($this->EmailAddress)');
         assert('is_array($this->TelephoneNumber)');
+        assert('is_array($this->ContactPersonAttributes)');
 
         $doc = $parent->ownerDocument;
 
@@ -155,6 +163,10 @@ class ContactPerson
         $parent->appendChild($e);
 
         $e->setAttribute('contactType', $this->contactType);
+
+        foreach ($this->ContactPersonAttributes as $attr => $val) {
+            $e->setAttribute($attr, $val);
+        }
 
         Extensions::addList($e, $this->Extensions);
 

--- a/src/SAML2/XML/md/ContactPerson.php
+++ b/src/SAML2/XML/md/ContactPerson.php
@@ -94,6 +94,13 @@ class ContactPerson
         $this->SurName = self::getStringElement($xml, 'SurName');
         $this->EmailAddress = self::getStringElements($xml, 'EmailAddress');
         $this->TelephoneNumber = self::getStringElements($xml, 'TelephoneNumber');
+
+        foreach($xml->attributes as $attr) {
+            if ($attr->nodeName == "contactType")
+                continue;
+
+            $this->ContactPersonAttributes[$attr->nodeName] = $attr->nodeValue;
+        }
     }
 
     /**

--- a/src/SAML2/XML/md/ContactPerson.php
+++ b/src/SAML2/XML/md/ContactPerson.php
@@ -96,8 +96,9 @@ class ContactPerson
         $this->TelephoneNumber = self::getStringElements($xml, 'TelephoneNumber');
 
         foreach ($xml->attributes as $attr) {
-            if ($attr->nodeName == "contactType")
+            if ($attr->nodeName == "contactType") {
                 continue;
+            }
 
             $this->ContactPersonAttributes[$attr->nodeName] = $attr->nodeValue;
         }

--- a/tests/SAML2/XML/md/ContactPersonTest.php
+++ b/tests/SAML2/XML/md/ContactPersonTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SAML2\XML\md;
+
+use SAML2\Constants;
+use SAML2\DOMDocumentFactory;
+use SAML2\Utils;
+
+/**
+ * Class \SAML2\XML\md\ContactPersonTest
+ */
+class ContactPersonTest extends \PHPUnit_Framework_TestCase {
+    public function testCompleteContact()
+    {
+        $document = DOMDocumentFactory::fromString(
+<<<XML
+<md:Test xmlns:md="{$mdNamespace}" Binding="urn:something" Location="https://whatever/" xmlns:test="urn:test" test:attr="value" />
+XML
+        );
+        $contactPerson = new ContactPerson();
+        $contactPerson->contactType = "other";
+        $contactPerson->Company = "Test Company";
+        $contactPerson->GivenName = "John";
+        $contactPerson->SurName = "Doe";
+        $contactPerson->EmailAddress = array('jdoe@test.company');
+        $contactPerson->TelephoneNumber = array('1-234-567-8901');
+        $contactPerson->ContactPersonAttributes = array('testattr'=>'testval');
+
+        $cp = $contactPerson->toXML($document);
+
+        echo $cp;
+    }
+}

--- a/tests/SAML2/XML/md/ContactPersonTest.php
+++ b/tests/SAML2/XML/md/ContactPersonTest.php
@@ -10,24 +10,84 @@ use SAML2\Utils;
  * Class \SAML2\XML\md\ContactPersonTest
  */
 class ContactPersonTest extends \PHPUnit_Framework_TestCase {
-    public function testCompleteContact()
+    public function testContactPerson()
     {
+        $contactType = "other";
+        $Company = "Test Company";
+        $GivenName = "John";
+        $SurName = "Doe";
+        $EmailAddress = array('jdoe@test.company', 'john.doe@test.company');
+        $TelephoneNumber = array('1-234-567-8901');
+        $ContactPersonAttributes = array('testattr' => 'testval', 'testattr2' => 'testval2');
+
+        $mdNamespace = Constants::NS_MD;
         $document = DOMDocumentFactory::fromString(
 <<<XML
-<md:Test xmlns:md="{$mdNamespace}" Binding="urn:something" Location="https://whatever/" xmlns:test="urn:test" test:attr="value" />
+<md:Test xmlns:md="{$mdNamespace}" Binding="urn:something" Location="https://whatever/" xmlns:test="urn:test" test:attr="value">
+</md:Test>
 XML
         );
         $contactPerson = new ContactPerson();
-        $contactPerson->contactType = "other";
-        $contactPerson->Company = "Test Company";
-        $contactPerson->GivenName = "John";
-        $contactPerson->SurName = "Doe";
-        $contactPerson->EmailAddress = array('jdoe@test.company');
-        $contactPerson->TelephoneNumber = array('1-234-567-8901');
-        $contactPerson->ContactPersonAttributes = array('testattr'=>'testval');
+        $contactPerson->contactType = $contactType;
+        $contactPerson->Company = $Company;
+        $contactPerson->GivenName = $GivenName;
+        $contactPerson->SurName = $SurName;
+        $contactPerson->EmailAddress = $EmailAddress;
+        $contactPerson->TelephoneNumber = $TelephoneNumber;
+        $contactPerson->ContactPersonAttributes = $ContactPersonAttributes;
 
-        $cp = $contactPerson->toXML($document);
+        $contactPerson->toXML($document->firstChild);
 
-        echo $cp;
+        $contactPersonElement = $document->getElementsByTagName('ContactPerson')->item(0);
+
+        $this->assertEquals($contactType, $contactPersonElement->getAttribute('contactType'));
+        $this->assertEquals($Company, $contactPersonElement->getElementsByTagName('Company')->item(0)->nodeValue);
+        $this->assertEquals($GivenName, $contactPersonElement->getElementsByTagName('GivenName')->item(0)->nodeValue);
+        $this->assertEquals($SurName, $contactPersonElement->getElementsByTagName('SurName')->item(0)->nodeValue);
+
+        $this->assertEquals(count($EmailAddress), $contactPersonElement->getElementsByTagName('EmailAddress')->length);
+        foreach ($contactPersonElement->getElementsByTagName('EmailAddress') as $element) {
+            $this->assertTrue(in_array($element->nodeValue, $EmailAddress));
+        }
+
+        $this->assertEquals(count($TelephoneNumber), $contactPersonElement->getElementsByTagName('TelephoneNumber')->length);
+        foreach ($contactPersonElement->getElementsByTagName('TelephoneNumber') as $element) {
+            $this->assertTrue(in_array($element->nodeValue, $TelephoneNumber));
+        }
+
+        foreach ($ContactPersonAttributes as $attr => $val) {
+            $this->assertEquals($val, $contactPersonElement->getAttribute($attr));
+        }
+    }
+
+    public function testContactPersonFromXML()
+    {
+        $mdNamespace = Constants::NS_MD;
+        $document = DOMDocumentFactory::fromString(
+<<<XML
+<?xml version="1.0"?>
+<md:Test xmlns:md="{$mdNamespace}" xmlns:test="urn:test" Binding="urn:something" Location="https://whatever/" test:attr="value">
+    <md:ContactPerson contactType="other" testattr="testval" testattr2="testval2">
+        <md:Company>Test Company</md:Company>
+        <md:GivenName>John</md:GivenName>
+        <md:SurName>Doe</md:SurName>
+        <md:EmailAddress>jdoe@test.company</md:EmailAddress>
+        <md:EmailAddress>john.doe@test.company</md:EmailAddress>
+        <md:TelephoneNumber>1-234-567-8901</md:TelephoneNumber>
+    </md:ContactPerson>
+</md:Test>
+XML
+        );
+
+        $contactPerson = new ContactPerson($document->getElementsByTagName('ContactPerson')->item(0));
+
+        $this->assertEquals('Test Company', $contactPerson->Company);
+        $this->assertEquals('John', $contactPerson->GivenName);
+        $this->assertEquals('Doe', $contactPerson->SurName);
+        $this->assertTrue(in_array('jdoe@test.company', $contactPerson->EmailAddress));
+        $this->assertTrue(in_array('john.doe@test.company', $contactPerson->EmailAddress));
+        $this->assertTrue(in_array('1-234-567-8901', $contactPerson->TelephoneNumber));
+        $this->assertEquals('testval', $contactPerson->ContactPersonAttributes['testattr']);
+        $this->assertEquals('testval2', $contactPerson->ContactPersonAttributes['testattr2']);
     }
 }

--- a/tests/SAML2/XML/md/ContactPersonTest.php
+++ b/tests/SAML2/XML/md/ContactPersonTest.php
@@ -90,4 +90,70 @@ XML
         $this->assertEquals('testval', $contactPerson->ContactPersonAttributes['testattr']);
         $this->assertEquals('testval2', $contactPerson->ContactPersonAttributes['testattr2']);
     }
+
+    public function testMultipleNamesXML()
+    {
+        $mdNamespace = Constants::NS_MD;
+        $document = DOMDocumentFactory::fromString(
+<<<XML
+<?xml version="1.0"?>
+<md:Test xmlns:md="{$mdNamespace}" xmlns:test="urn:test" Binding="urn:something" Location="https://whatever/" test:attr="value">
+    <md:ContactPerson contactType="other" testattr="testval" testattr2="testval2">
+        <md:Company>Test Company</md:Company>
+        <md:GivenName>John</md:GivenName>
+        <md:GivenName>Jonathon</md:GivenName>
+        <md:SurName>Doe</md:SurName>
+        <md:EmailAddress>jdoe@test.company</md:EmailAddress>
+        <md:EmailAddress>john.doe@test.company</md:EmailAddress>
+        <md:TelephoneNumber>1-234-567-8901</md:TelephoneNumber>
+    </md:ContactPerson>
+</md:Test>
+XML
+        );
+
+        $this->setExpectedException('Exception', 'More than one GivenName in md:ContactPerson');
+
+        $contactPerson = new ContactPerson($document->getElementsByTagName('ContactPerson')->item(0));
+    }
+
+    public function testEmptySurNameXML()
+    {
+        $mdNamespace = Constants::NS_MD;
+        $document = DOMDocumentFactory::fromString(
+<<<XML
+<?xml version="1.0"?>
+<md:Test xmlns:md="{$mdNamespace}" xmlns:test="urn:test" Binding="urn:something" Location="https://whatever/" test:attr="value">
+    <md:ContactPerson contactType="other">
+        <md:Company>Test Company</md:Company>
+        <md:GivenName>John</md:GivenName>
+        <md:EmailAddress>jdoe@test.company</md:EmailAddress>
+        <md:EmailAddress>john.doe@test.company</md:EmailAddress>
+        <md:TelephoneNumber>1-234-567-8901</md:TelephoneNumber>
+    </md:ContactPerson>
+</md:Test>
+XML
+        );
+
+        $contactPerson = new ContactPerson($document->getElementsByTagName('ContactPerson')->item(0));
+
+        $this->assertNull($contactPerson->SurName);
+    }
+
+    public function testMissingContactTypeXML()
+    {
+        $mdNamespace = Constants::NS_MD;
+        $document = DOMDocumentFactory::fromString(
+<<<XML
+<?xml version="1.0"?>
+<md:Test xmlns:md="{$mdNamespace}" xmlns:test="urn:test" Binding="urn:something" Location="https://whatever/" test:attr="value">
+    <md:ContactPerson>
+    </md:ContactPerson>
+</md:Test>
+XML
+        );
+
+        $this->setExpectedException('Exception', 'Missing contactType on ContactPerson.');
+
+        $contactPerson = new ContactPerson($document->getElementsByTagName('ContactPerson')->item(0));
+    }
 }


### PR DESCRIPTION
In order for federation participants to claim compliance for [Sirtfi](https://wiki.refeds.org/display/SIRTFI/Guide+for+Federation+Participants), they need to define the security contact for their organization. The contactType of "other" is used, but Sirtfi requires additional attributes, `xmlns:remd` and `remd:contactType`, on the ContactPerson element ([shown here](https://wiki.refeds.org/display/STAN/Security+Contact+Metadata+Extension+Schema)).

Currently, this isn't possible, but this PR adds an associative array, $ContactPersonAttributes, which will add attributes to the ContactPerson element.