### PR TITLE
Fix 'Undefined namespace prefix' error

### DIFF
--- a/src/SAML2/Assertion.php
+++ b/src/SAML2/Assertion.php
@@ -533,7 +533,7 @@ class Assertion implements SignedElement
 
         if ($attributeName === Constants::EPTI_URN_MACE || $attributeName === Constants::EPTI_URN_OID) {
             foreach ($values as $index => $eptiAttributeValue) {
-                $eptiNameId = Utils::xpQuery($eptiAttributeValue, './saml:NameID');
+                $eptiNameId = Utils::xpQuery($eptiAttributeValue, './saml_assertion:NameID');
 
                 if (count($eptiNameId) !== 1) {
                     throw new RuntimeException(sprintf(


### PR DESCRIPTION
I was trying to parse a SAML packet that had `saml2` as the SAML namespace prefix rather than `saml`. This caused a 'Undefined namespace prefix' error. 

It looks like the SAML namespace is declared by ssp as as 'saml_assertion' but for some reason it was not used with this Xpath. Changing it removes the error. 