### PR TITLE
Security update for signature validation

### DIFF
--- a/src/SAML2/Utils.php
+++ b/src/SAML2/Utils.php
@@ -165,7 +165,7 @@ class Utils
         }
 
         /* Check the signature. */
-        if (! $objXMLSecDSig->verify($key)) {
+        if ($objXMLSecDSig->verify($key) !== 1) {
             throw new \Exception("Unable to validate Signature");
         }
     }


### PR DESCRIPTION
The underlying function "openssl_verify" returns -1 on error, which may happen (as happened for me while doing security checks) when the identity provider certificate is tampered with (for example when I substituted it with a DSA key)
In that case, -1 being true, well...