### PR TITLE
Make explicit that AllowCreate must be bool

### DIFF
--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -5,6 +5,7 @@ namespace SAML2;
 use RobRichards\XMLSecLibs\XMLSecEnc;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\XML\saml\SubjectConfirmation;
+use SAML2\Exception\InvalidArgumentException;
 
 /**
  * Class for SAML 2 authentication request messages.
@@ -306,14 +307,24 @@ class AuthnRequest extends Request
      * Set the NameIDPolicy.
      *
      * This function accepts an array with the following options:
-     *  - 'Format'
-     *  - 'SPNameQualifier'
-     *  - 'AllowCreate'
+     *  - 'Format' (string)
+     *  - 'SPNameQualifier' (string)
+     *  - 'AllowCreate' (bool)
      *
      * @param array $nameIdPolicy The NameIDPolicy.
      */
     public function setNameIdPolicy(array $nameIdPolicy)
     {
+        if (isset($nameIdPolicy['Format']) && !is_string($nameIdPolicy['Format'])) {
+            throw InvalidArgumentException::invalidType('string', $nameIdPolicy['Format']);
+        }
+        if (isset($nameIdPolicy['SPNameQualifier']) && !is_string($nameIdPolicy['SPNameQualifier'])) {
+            throw InvalidArgumentException::invalidType('string', $nameIdPolicy['SPNameQualifier']);
+        }
+        if (isset($nameIdPolicy['AllowCreate']) && !is_bool($nameIdPolicy['AllowCreate'])) {
+            throw InvalidArgumentException::invalidType('bool', $nameIdPolicy['AllowCreate']);
+        }
+
         $this->nameIdPolicy = $nameIdPolicy;
     }
 
@@ -714,7 +725,7 @@ class AuthnRequest extends Request
             if (array_key_exists('SPNameQualifier', $this->nameIdPolicy)) {
                 $nameIdPolicy->setAttribute('SPNameQualifier', $this->nameIdPolicy['SPNameQualifier']);
             }
-            if (array_key_exists('AllowCreate', $this->nameIdPolicy) && is_bool($this->nameIdPolicy['AllowCreate'])) {
+            if (array_key_exists('AllowCreate', $this->nameIdPolicy)) {
                 $nameIdPolicy->setAttribute('AllowCreate', ($this->nameIdPolicy['AllowCreate']) ? 'true' : 'false');
             }
             $root->appendChild($nameIdPolicy);


### PR DESCRIPTION
This is a followup to #63 and #64.

In those PR's, a new test was added on whether AllowCreate is a boolean, if not, it would be silently ignored. Making the typing more strict is a good thing, but in my opinion silently ignoring it if it has a different type is not right, and also not that it happens when building the request, not directly when using the setter. Also, it was never documented explicitly what the lib expected to get.

There's precedent for using `assert()` to enforce incoming variable types, but I believe throwing an exception is better. YMMV.

@jaimeperez @pmeulen @arothuis