### PR TITLE
Add ext-zlib dependency in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "php": ">=5.3.3",
         "ext-openssl": "*",
         "ext-dom": "*",
+        "ext-zlib": "*",
 
         "robrichards/xmlseclibs": "^2.0",
         "psr/log": "~1.0"


### PR DESCRIPTION
zlib is required for `gzinflate()` and `gzdeflate()` in `src/SAML2/HTTPRedirect.php`