### PR TITLE
Fix SOAPClient peer name verification when using a proxy

### DIFF
--- a/src/SAML2/SOAPClient.php
+++ b/src/SAML2/SOAPClient.php
@@ -88,6 +88,10 @@ class SOAPClient
             $ctxOpts['ssl']['cafile'] = $peerCertFile;
         }
 
+        if ($srcMetadata->hasValue('saml.SOAPClient.stream_context.ssl.peer_name')) {
+            $ctxOpts['ssl']['peer_name'] = $srcMetadata->getString('saml.SOAPClient.stream_context.ssl.peer_name');
+        }
+
         $context = stream_context_create($ctxOpts);
         if ($context === null) {
             throw new \Exception('Unable to create SSL stream context');


### PR DESCRIPTION
Since PHP 5.6.x some openssl changes were introduced
which amongst others enable peer verification by default for all
encrypted client streams.
See: http://php.net/manual/en/migration56.openssl.php

There is a bug in Soapclient when used with a proxy it will verify
the wrong peer (the proxy) instead of the real destination.
See: https://bugs.php.net/bug.php?id=69137

This fix will allow a user to specify the correct peer_name of
the SoapClients stream_context in authsources.php
so the peer verification will be correct.