### PR TITLE
* Add possibility to set `verify_peer` and `verify_peer_name` for the…

### DIFF
--- a/src/SAML2/SOAPClient.php
+++ b/src/SAML2/SOAPClient.php
@@ -38,6 +38,14 @@ class SOAPClient
             ),
         );
 
+        if ($srcMetadata->hasValue('saml.SOAPClient.verify_peer')) {
+            $ctxOpts['ssl']['verify_peer'] = $srcMetadata->getBoolean('saml.SOAPClient.verify_peer');
+        }
+
+        if ($srcMetadata->hasValue('saml.SOAPClient.verify_peer_name')) {
+            $ctxOpts['ssl']['verify_peer_name'] = $srcMetadata->getBoolean('saml.SOAPClient.verify_peer_name');
+        }
+
         // Determine if we are going to do a MutualSSL connection between the IdP and SP  - Shoaib
         if ($srcMetadata->hasValue('saml.SOAPClient.certificate')) {
             $cert = $srcMetadata->getValue('saml.SOAPClient.certificate');


### PR DESCRIPTION
… SOAPClient via authsource config (useful for development)

We need this really for development context when working with untrusted https certs.
