### PR TITLE
Add IdP support for ECP profile

### DIFF
--- a/src/SAML2/Binding.php
+++ b/src/SAML2/Binding.php
@@ -38,6 +38,11 @@ abstract class Binding
                 return new HTTPArtifact();
             case Constants::BINDING_HOK_SSO:
                 return new HTTPPost();
+            // ECP ACS is defined with the PAOS binding, but as the IdP, we
+            // talk to the ECP using SOAP -- if support for ECP as an SP is
+            // implemented, this logic may need to change
+            case Constants::BINDING_PAOS:
+                return new SOAP();
             default:
                 throw new \Exception('Unsupported binding: ' . var_export($urn, true));
         }

--- a/src/SAML2/Constants.php
+++ b/src/SAML2/Constants.php
@@ -40,6 +40,11 @@ class Constants
     const BINDING_SOAP = 'urn:oasis:names:tc:SAML:2.0:bindings:SOAP';
 
     /**
+     * The URN for the PAOS binding.
+     */
+    const BINDING_PAOS = 'urn:oasis:names:tc:SAML:2.0:bindings:PAOS';
+
+    /**
      * The URN for the Holder-of-Key Web Browser SSO Profile binding
      */
     const BINDING_HOK_SSO = 'urn:oasis:names:tc:SAML:2.0:profiles:holder-of-key:SSO:browser';
@@ -193,6 +198,11 @@ class Constants
      * Encrypted NameID format.
      */
     const NAMEID_ENCRYPTED = 'urn:oasis:names:tc:SAML:2.0:nameid-format:encrypted';
+
+    /**
+     * The namespace for the ECP protocol.
+     */
+    const NS_ECP = 'urn:oasis:names:tc:SAML:2.0:profiles:SSO:ecp';
 
     /**
      * The namespace for the SOAP protocol.

--- a/src/SAML2/XML/ecp/Response.php
+++ b/src/SAML2/XML/ecp/Response.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace SAML2\XML\ecp;
+
+use DOMElement;
+use InvalidArgumentException;
+
+use SAML2\Constants;
+
+/**
+ * Class representing the ECP Response element.
+ */
+class Response
+{
+    /**
+     * The AssertionConsumerServiceURL.
+     *
+     * @var string
+     */
+    public $AssertionConsumerServiceURL;
+
+    /**
+     * Create a ECP Response element.
+     *
+     * @param DOMElement|null $xml The XML element we should load.
+     */
+    public function __construct(DOMElement $xml = null)
+    {
+        if ($xml === null) {
+            return;
+        }
+
+        if (!$xml->hasAttributeNS(Constants::NS_SOAP, 'mustUnderstand')) {
+            throw new Exception('Missing SOAP-ENV:mustUnderstand attribute in <ecp:Response>.');
+        }
+        if ($xml->getAttributeNS(Constants::NS_SOAP, 'mustUnderstand') !== '1') {
+            throw new Exception('Invalid value of SOAP-ENV:mustUnderstand attribute in <ecp:Response>.');
+        }
+
+        if (!$xml->hasAttributeNS(Constants::NS_SOAP, 'actor')) {
+            throw new Exception('Missing SOAP-ENV:actor attribute in <ecp:Response>.');
+        }
+        if ($xml->getAttributeNS(Constants::NS_SOAP, 'actor') !== 'http://schemas.xmlsoap.org/soap/actor/next') {
+            throw new Exception('Invalid value of SOAP-ENV:actor attribute in <ecp:Response>.');
+        }
+
+        if (!$xml->hasAttribute('AssertionConsumerServiceURL')) {
+            throw new Exception('Missing AssertionConsumerServiceURL attribute in <ecp:Response>.');
+        }
+
+        $this->AssertionConsumerServiceURL = $xml->getAttribute('AssertionConsumerServiceURL');
+    }
+    /**
+     * Convert this ECP Response to XML.
+     *
+     * @param DOMElement $parent The element we should append this element to.
+     */
+    public function toXML(DOMElement $parent)
+    {
+        if (!is_string($this->AssertionConsumerServiceURL)) {
+            throw new InvalidArgumentException("AssertionConsumerServiceURL must be a string");
+        }
+
+        $doc = $parent->ownerDocument;
+        $response = $doc->createElementNS(Constants::NS_ECP, 'ecp:Response');
+
+        $parent->appendChild($response);
+
+        $response->setAttributeNS(Constants::NS_SOAP, 'SOAP-ENV:mustUnderstand', '1');
+        $response->setAttributeNS(Constants::NS_SOAP, 'SOAP-ENV:actor', 'http://schemas.xmlsoap.org/soap/actor/next');
+        $response->setAttribute('AssertionConsumerServiceURL', $this->AssertionConsumerServiceURL);
+
+        return $response;
+    }
+}

--- a/tests/SAML2/BindingTest.php
+++ b/tests/SAML2/BindingTest.php
@@ -19,6 +19,8 @@ class BindingTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('SAML2\HTTPArtifact', $bind);
         $bind = Binding::getBinding(Constants::BINDING_HOK_SSO);
         $this->assertInstanceOf('SAML2\HTTPPost', $bind);
+        $bind = Binding::getBinding(Constants::BINDING_PAOS);
+        $this->assertInstanceOf('SAML2\SOAP', $bind);
 
         $this->setExpectedException('Exception', 'Unsupported binding:');
         $bind = Binding::getBinding('nonsense');

--- a/tests/SAML2/SOAPTest.php
+++ b/tests/SAML2/SOAPTest.php
@@ -23,7 +23,7 @@ class SOAPTest extends PHPUnit_Framework_TestCase
         $artifact = 'AAQAADWNEw5VT47wcO4zX/iEzMmFQvGknDfws2ZtqSGdkNSbsW1cmVR0bzU=';
         $issuer = 'https://ServiceProvider.com/SAML';
 
-        $input = <<<SOAP
+        $stub = $this->getStubWithInput(<<<SOAP
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
     <SOAP-ENV:Body>
         <samlp:ArtifactResolve
@@ -36,8 +36,9 @@ class SOAPTest extends PHPUnit_Framework_TestCase
         </samlp:ArtifactResolve>
     </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>
-SOAP;
-        $stub = $this->getStubWithInput($input);
+SOAP
+    );
+
         $message = $stub->receive();
 
         $this->assertInstanceOf('SAML2\\ArtifactResolve', $message);
@@ -48,9 +49,10 @@ SOAP;
         // TODO Validate XML signature is received?
     }
 
-    public function testResponse()
+    public function testSendArtifactResponse()
     {
-        $xml = <<<SOAP
+        $doc = new DOMDocument;
+        $doc->loadXML(<<<XML
 <samlp:ArtifactResponse
   xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
   xmlns="urn:oasis:names:tc:SAML:2.0:assertion"
@@ -73,24 +75,90 @@ SOAP;
         </samlp:Status>
     </samlp:LogoutResponse>
 </samlp:ArtifactResponse>
-SOAP;
-        $doc = new DOMDocument();
-        $doc->loadXML($xml);
+XML
+        );
 
         $message = Message::fromXML($doc->getElementsByTagName('ArtifactResponse')->item(0));
 
-        $soap = new SOAP();
-        $output = $soap->getOutputToSend($message);
-
         $expected = <<<SOAP
-<?xml version="1.0" encoding="UTF-8"?><SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Body><samlp:ArtifactResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_FQvGknDfws2Z" Version="2.0" IssueInstant="2004-01-21T19:00:49Z" InResponseTo="_6c3a4f8b9c2d"><saml:Issuer>https://IdentityProvider.com/SAML</saml:Issuer><samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status><samlp:LogoutResponse ID="_b0730d21b628110d8b7e004005b13a2b" InResponseTo="_d2b7c388cec36fa7c39c28fd298644a8" IssueInstant="2004-01-21T19:05:49Z" Version="2.0">
+<?xml version="1.0" encoding="utf-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Header/>
+    <SOAP-ENV:Body><samlp:ArtifactResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_FQvGknDfws2Z" Version="2.0" IssueInstant="2004-01-21T19:00:49Z" InResponseTo="_6c3a4f8b9c2d"><saml:Issuer>https://IdentityProvider.com/SAML</saml:Issuer><samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status><samlp:LogoutResponse ID="_b0730d21b628110d8b7e004005b13a2b" InResponseTo="_d2b7c388cec36fa7c39c28fd298644a8" IssueInstant="2004-01-21T19:05:49Z" Version="2.0">
         <saml:Issuer>https://ServiceProvider.com/SAML</saml:Issuer>
         <samlp:Status>
             <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
         </samlp:Status>
-    </samlp:LogoutResponse></samlp:ArtifactResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
+    </samlp:LogoutResponse></samlp:ArtifactResponse></SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+
 SOAP;
-        $this->assertEquals($output, $expected);
+
+        $soap = new SOAP;
+        $output = $soap->getOutputToSend($message);
+
+        $this->assertEquals($expected, $output);
+    }
+
+    public function testSendResponse()
+    {
+        $doc = new DOMDocument();
+        $doc->loadXML(<<<XML
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_8e8dc5f69a98cc4c1ff3427e5ce34606fd672f91e6" Version="2.0" IssueInstant="2014-07-17T01:01:48Z" Destination="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685">
+  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+  <saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" ID="_d71a3a8e9fcc45c9e9d248ef7049393fc8f04e5f75" Version="2.0" IssueInstant="2014-07-17T01:01:48Z">
+    <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
+    <saml:Subject>
+      <saml:NameID SPNameQualifier="http://sp.example.com/demo1/metadata.php" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">_ce3d2948b4cf20146dee0a0b3dd6f69b6cf86f62d7</saml:NameID>
+      <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml:SubjectConfirmationData NotOnOrAfter="2024-01-18T06:21:48Z" Recipient="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"/>
+      </saml:SubjectConfirmation>
+    </saml:Subject>
+    <saml:Conditions NotBefore="2014-07-17T01:01:18Z" NotOnOrAfter="2024-01-18T06:21:48Z">
+      <saml:AudienceRestriction>
+        <saml:Audience>http://sp.example.com/demo1/metadata.php</saml:Audience>
+      </saml:AudienceRestriction>
+    </saml:Conditions>
+    <saml:AuthnStatement AuthnInstant="2014-07-17T01:01:48Z" SessionNotOnOrAfter="2024-07-17T09:01:48Z" SessionIndex="_be9967abd904ddcae3c0eb4189adbe3f71e327cf93">
+      <saml:AuthnContext>
+        <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>
+      </saml:AuthnContext>
+    </saml:AuthnStatement>
+    <saml:AttributeStatement>
+      <saml:Attribute Name="uid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xsi:type="xs:string">test</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="mail" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xsi:type="xs:string">test@example.com</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="eduPersonAffiliation" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xsi:type="xs:string">users</saml:AttributeValue>
+        <saml:AttributeValue xsi:type="xs:string">examplerole1</saml:AttributeValue>
+      </saml:Attribute>
+    </saml:AttributeStatement>
+  </saml:Assertion>
+</samlp:Response>
+XML
+    );
+
+        $message = Message::fromXML($doc->getElementsByTagName('Response')->item(0));
+
+        $expected = <<<SOAP
+<?xml version="1.0" encoding="utf-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Header><ecp:Response xmlns:ecp="urn:oasis:names:tc:SAML:2.0:profiles:SSO:ecp" SOAP-ENV:mustUnderstand="1" SOAP-ENV:actor="http://schemas.xmlsoap.org/soap/actor/next" AssertionConsumerServiceURL="http://sp.example.com/demo1/index.php?acs"/></SOAP-ENV:Header>
+    <SOAP-ENV:Body><samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="_8e8dc5f69a98cc4c1ff3427e5ce34606fd672f91e6" Version="2.0" IssueInstant="2014-07-17T01:01:48Z" Destination="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"><saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer><samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status><saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" ID="_d71a3a8e9fcc45c9e9d248ef7049393fc8f04e5f75" Version="2.0" IssueInstant="2014-07-17T01:01:48Z"><saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer><saml:Subject><saml:NameID SPNameQualifier="http://sp.example.com/demo1/metadata.php" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">_ce3d2948b4cf20146dee0a0b3dd6f69b6cf86f62d7</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData NotOnOrAfter="2024-01-18T06:21:48Z" Recipient="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"/></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="2014-07-17T01:01:18Z" NotOnOrAfter="2024-01-18T06:21:48Z"><saml:AudienceRestriction><saml:Audience>http://sp.example.com/demo1/metadata.php</saml:Audience></saml:AudienceRestriction></saml:Conditions><saml:AuthnStatement AuthnInstant="2014-07-17T01:01:48Z" SessionNotOnOrAfter="2024-07-17T09:01:48Z" SessionIndex="_be9967abd904ddcae3c0eb4189adbe3f71e327cf93"><saml:AuthnContext><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement><saml:AttributeStatement><saml:Attribute Name="uid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"><saml:AttributeValue xsi:type="xs:string">test</saml:AttributeValue></saml:Attribute><saml:Attribute Name="mail" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"><saml:AttributeValue xsi:type="xs:string">test@example.com</saml:AttributeValue></saml:Attribute><saml:Attribute Name="eduPersonAffiliation" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"><saml:AttributeValue xsi:type="xs:string">users</saml:AttributeValue><saml:AttributeValue xsi:type="xs:string">examplerole1</saml:AttributeValue></saml:Attribute></saml:AttributeStatement></saml:Assertion></samlp:Response></SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+
+SOAP;
+
+        $soap = new SOAP;
+        $output = $soap->getOutputToSend($message);
+
+        $this->assertEquals($expected, $output);
     }
 
     private function getStubWithInput($input)

--- a/tests/SAML2/XML/ResponseTest.php
+++ b/tests/SAML2/XML/ResponseTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace SAML2\XML\ecp;
+
+use stdClass;
+use DOMDocument;
+use DOMElement;
+
+use SAML2\Constants;
+
+use PHPUnit_Framework_TestCase;
+
+class ResponseTest extends PHPUnit_Framework_TestCase
+{
+    public function testConstructorWithoutXML()
+    {
+        $response = new Response;
+
+        $this->assertNull($response->AssertionConsumerServiceURL);
+    }
+
+    public function toXMLInvalidACSProvider()
+    {
+        return array(
+            array(null),
+            array(1),
+            array(false),
+            array(array()),
+            array(new stdClass),
+        );
+    }
+
+    /**
+     * @dataProvider toXMLInvalidACSProvider
+     */
+    public function testToXMLInvalidACS($url)
+    {
+        $this->setExpectedException('InvalidArgumentException', 'AssertionConsumerServiceURL');
+
+        $response = new Response;
+        $response->AssertionConsumerServiceURL = $url;
+        $response->toXML(new DOMElement('Foobar'));
+    }
+
+    public function testToXMLReturnsResponse()
+    {
+        $doc = new DOMDocument;
+        $element = $doc->createElement('Foobar');
+
+        $response = new Response;
+        $response->AssertionConsumerServiceURL = 'https://example.com/ACS';
+        $return = $response->toXML($element);
+
+        $this->assertInstanceOf('DOMElement', $return);
+        $this->assertEquals('ecp:Response', $return->tagName);
+    }
+
+    public function testToXMLResponseAttributes()
+    {
+        $acs = 'https://example.com/ACS';
+
+        $doc = new DOMDocument;
+        $element = $doc->createElement('Foobar');
+
+        $response = new Response;
+        $response->AssertionConsumerServiceURL = $acs;
+        $return = $response->toXML($element);
+
+        $this->assertTrue($return->hasAttributeNS(Constants::NS_SOAP, 'mustUnderstand'));
+        $this->assertEquals('1', $return->getAttributeNS(Constants::NS_SOAP, 'mustUnderstand'));
+        $this->assertTrue($return->hasAttributeNS(Constants::NS_SOAP, 'actor'));
+        $this->assertEquals('http://schemas.xmlsoap.org/soap/actor/next', $return->getAttributeNS(Constants::NS_SOAP, 'actor'));
+        $this->assertTrue($return->hasAttribute('AssertionConsumerServiceURL'));
+        $this->assertEquals($acs, $return->getAttribute('AssertionConsumerServiceURL'));
+    }
+
+    public function testToXMLResponseAppended()
+    {
+        $doc = new DOMDocument;
+        $element = $doc->createElement('Foobar');
+
+        $response = new Response;
+        $response->AssertionConsumerServiceURL = 'https://example.com/ACS';
+        $return = $response->toXML($element);
+
+        $elements = $element->getElementsByTagNameNS(Constants::NS_ECP, 'Response');
+
+        $this->assertEquals(1, $elements->length);
+        $this->assertEquals($return, $elements->item(0));
+    }
+}


### PR DESCRIPTION
- Add constants for ECP
- Add support for ECP Response in SOAP binding
- Add support for SOAP in Binding::getBinding()

This is an updated version of #48 to fix some issues, and add unit tests. A PR to `simplesamlphp` is coming soon to complete support in the application.