### PR TITLE
Assertion Attribute Value xsi:type

### DIFF
--- a/src/SAML2/Assertion.php
+++ b/src/SAML2/Assertion.php
@@ -1576,7 +1576,7 @@ class Assertion implements SignedElement
                 $valueTypes = $this->attributesValueTypes[$name];
                 if (is_array($valueTypes) && count($valueTypes) != count($values)) {
                     throw new \Exception('Array of value types and array of values have different size for attribute '. var_export($name, true));
-                };
+                }
             } else {
                 // if no type(s), default behaviour
                 $valueTypes = null;

--- a/src/SAML2/Assertion.php
+++ b/src/SAML2/Assertion.php
@@ -578,7 +578,9 @@ class Assertion implements SignedElement
             }
 
             $type = $value->getAttribute('xsi:type');
-            if($type === '') $type = null;
+            if ($type === '') {
+                $type = null;
+            }
             $this->attributesValueTypes[$attributeName][] = $type;
 
             if ($hasNonTextChildElements) {
@@ -1570,9 +1572,9 @@ class Assertion implements SignedElement
             }
 
             // get value type(s) for the current attribute
-            if(is_array($this->attributesValueTypes) && array_key_exists($name, $this->attributesValueTypes)) {
+            if (is_array($this->attributesValueTypes) && array_key_exists($name, $this->attributesValueTypes)) {
                 $valueTypes = $this->attributesValueTypes[$name];
-                if(is_array($valueTypes) && count($valueTypes) != count($values)) {
+                if (is_array($valueTypes) && count($valueTypes) != count($values)) {
                     throw new \Exception('Array of value types and array of values have different size for attribute '. var_export($name, true));
                 };
             }
@@ -1587,7 +1589,7 @@ class Assertion implements SignedElement
 
                 // try to get type from current types
                 $type = null;
-                if(!is_null($valueTypes)) {
+                if (!is_null($valueTypes)) {
                     if(is_array($valueTypes)) {
                         $type = $valueTypes[$vidx];
                     }
@@ -1597,7 +1599,7 @@ class Assertion implements SignedElement
                 }
 
                 // if no type get from types, use default behaviour
-                if(is_null($type)) {
+                if (is_null($type)) {
                     if (is_string($value)) {
                         $type = 'xs:string';
                     } elseif (is_int($value)) {

--- a/src/SAML2/Assertion.php
+++ b/src/SAML2/Assertion.php
@@ -1593,7 +1593,7 @@ class Assertion implements SignedElement
                         $type = $valueTypes[$vidx];
                     } else {
                         $type = $valueTypes;
-                    }                    
+                    }
                 }
 
                 // if no type get from types, use default behaviour

--- a/src/SAML2/Assertion.php
+++ b/src/SAML2/Assertion.php
@@ -1577,8 +1577,7 @@ class Assertion implements SignedElement
                 if (is_array($valueTypes) && count($valueTypes) != count($values)) {
                     throw new \Exception('Array of value types and array of values have different size for attribute '. var_export($name, true));
                 };
-            }
-            else {
+            } else {
                 // if no type(s), default behaviour
                 $valueTypes = null;
             }
@@ -1590,10 +1589,9 @@ class Assertion implements SignedElement
                 // try to get type from current types
                 $type = null;
                 if (!is_null($valueTypes)) {
-                    if(is_array($valueTypes)) {
+                    if (is_array($valueTypes)) {
                         $type = $valueTypes[$vidx];
-                    }
-                    else {
+                    } else {
                         $type = $valueTypes;
                     }                    
                 }


### PR DESCRIPTION
# Underlining goal
Allow simplesamlphp SAML2 IdP to generate assertion heaving AttributeValues with specified xs:type(s) (other than `xs:string` and `xs:integer`)

# Description
Two new methods allow to get\set xs:type for attribute values, allowing to get xs:type(s) for parsed assertion and specify xs:type(s) for each attribute values when generating assertion.

This has been implemented using additional internal variables to minimize code changes and easly allow backward compatibility.

## Parsing Assertion (Marshalling)
Parsing an Assertion containing the following `AttributeStatement`:
```
...
  <saml:AttributeStatement>
    <saml:Attribute Name="name1">
      <saml:AttributeValue xsi:type="xs:string">value1</saml:AttributeValue>
      <saml:AttributeValue>123</saml:AttributeValue>
      <saml:AttributeValue xsi:type="xs:date">2017-31-12</saml:AttributeValue>
    </saml:Attribute>
    <saml:Attribute Name="name2">
      <saml:AttributeValue>2</saml:AttributeValue>
    </saml:Attribute>
    <saml:Attribute Name="name3">
      <saml:AttributeValue xsi:type="xs:decimal">1234</saml:AttributeValue>
      <saml:AttributeValue xsi:type="xs:decimal">+2345</saml:AttributeValue>
    </saml:Attribute>
  </saml:AttributeStatement>
...
```
then calling `$avt = $assertion->getAttributesValueTypes();` you'll obtain:

```
array(
'name1' => array('xs:string', null, 'xs:date'),
'name2' => array(null),
'name3' => array('xs:decimal', 'xs:decimal')
)
```

## Generating Assertion (Unmarshalling)

If you don't call `$assertion->setAttributesValueTypes` there will be no changes in current behavior.

If you instead call the new method as follows:

```
$assertion->setAttributes(array(
    "name1" => array("value1",123,"2017-31-12"),
    "name2" => array(2),
    "name3" => array(1234,"+2345")));
$assertion->setAttributeNameFormat("urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified");

// set xs:type for first and third name1 values, and all name3 values.
// second name1 value and all name2 values will use default behaviour
$assertion->setAttributesValueTypes(array(
    "name1" => array("xs:string",null,"xs:date"),
    "name3" => "xs:decimal"));

setAttributesValueTypes(array(
   "attrname1" => array("xs:string","xs:date"),
   "attrname2" => "xs:decimal"));
```

you will obtain an AttributeStatement like:

```
...
  <saml:AttributeStatement>
    <saml:Attribute Name="name1">
      <saml:AttributeValue xsi:type="xs:string">value1</saml:AttributeValue>
      <saml:AttributeValue xsi:type="xs:integer">123</saml:AttributeValue>
      <saml:AttributeValue xsi:type="xs:date">2017-31-12</saml:AttributeValue>
    </saml:Attribute>
    <saml:Attribute Name="name2">
      <saml:AttributeValue xsi:type="xs:integer">2</saml:AttributeValue>
    </saml:Attribute>
    <saml:Attribute Name="name3">
      <saml:AttributeValue xsi:type="xs:decimal">1234</saml:AttributeValue>
      <saml:AttributeValue xsi:type="xs:decimal">+2345</saml:AttributeValue>
    </saml:Attribute>
  </saml:AttributeStatement>
...
```

# TODO?
implement official [regular expressions](https://www.w3.org/TR/xmlschema11-2/) check to validate data types?