### PR TITLE
Fix typehint typo: XMLsecurityKey --> XMLSecurityKey

### DIFF
--- a/src/SAML2/Assertion.php
+++ b/src/SAML2/Assertion.php
@@ -1245,7 +1245,7 @@ class Assertion implements SignedElement
      *
      * @param XMLSecurityKey|null $signatureKey
      */
-    public function setSignatureKey(XMLsecurityKey $signatureKey = null)
+    public function setSignatureKey(XMLSecurityKey $signatureKey = null)
     {
         $this->signatureKey = $signatureKey;
     }

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -523,7 +523,7 @@ abstract class Message implements SignedElement
      *
      * @param XMLSecurityKey|null $signatureKey
      */
-    public function setSignatureKey(XMLsecurityKey $signatureKey = null)
+    public function setSignatureKey(XMLSecurityKey $signatureKey = null)
     {
         $this->signatureKey = $signatureKey;
     }

--- a/src/SAML2/SignedElement.php
+++ b/src/SAML2/SignedElement.php
@@ -52,5 +52,5 @@ interface SignedElement
      *
      * @param XMLSecurityKey|null $signatureKey
      */
-    public function setSignatureKey(XMLsecurityKey $signatureKey = null);
+    public function setSignatureKey(XMLSecurityKey $signatureKey = null);
 }

--- a/src/SAML2/SignedElementHelper.php
+++ b/src/SAML2/SignedElementHelper.php
@@ -138,7 +138,7 @@ class SignedElementHelper implements SignedElement
      *
      * @param XMLSecurityKey|null $signatureKey
      */
-    public function setSignatureKey(XMLsecurityKey $signatureKey = null)
+    public function setSignatureKey(XMLSecurityKey $signatureKey = null)
     {
         $this->signatureKey = $signatureKey;
     }


### PR DESCRIPTION
There is a case-typo in some uses of the XMLSecurityKey typehint which is tripping up [PHPStan](https://github.com/phpstan/phpstan) in my app's test suite.  Example:

```
 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/Adapter/Symfony/Framework/SamlIdpBundle/SamlResponseFactory.php                                                                        
 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 
  94     Parameter #1 $signatureKey of method SAML2_Message::setSignatureKey() expects (XMLSecurityKey&XMLsecurityKey)|null, XMLSecurityKey given.  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 
```

This PR corrects all instances of `XMLsecurityKey` to `XMLSecurityKey`.