### PR TITLE
Fix PHP 5.3 run on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -12,6 +11,9 @@ matrix:
   fast_finish: true
   allow_failures:
     - php: hhvm
+  include:
+    - php: '5.3'
+      dist: precise
 
 script:
   - ant


### PR DESCRIPTION
https://blog.travis-ci.com/2017-08-31-trusty-as-default-status

As of August 31st, Ubuntu Trusty is the default run environment for Travis-CI, and that environment does not provide PHP 5.3.

If you still wish to test against PHP 5.3, this PR will bump the runner for that version back to Ubuntu Precise.  This will work until April 1st, 2018 when Travis-CI decommissions the Ubuntu Precise workers. 