### PR TITLE
Two small bugs regarding class name references

### DIFF
--- a/src/SAML2/Certificate/PrivateKeyLoader.php
+++ b/src/SAML2/Certificate/PrivateKeyLoader.php
@@ -47,7 +47,7 @@ class PrivateKeyLoader
         }
 
         $newPrivateKey = $serviceProvider->getPrivateKey(PrivateKeyConfiguration::NAME_NEW);
-        if ($newPrivateKey instanceof PrivateKey) {
+        if ($newPrivateKey instanceof PrivateKeyConfiguration) {
             $loadedKey = $this->loadPrivateKey($newPrivateKey);
             $decryptionKeys->add($this->convertPrivateKeyToRsaKey($loadedKey));
         }

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -456,7 +456,7 @@ abstract class Message implements SignedElement
 
         if ($this->issuer !== null) {
             if (is_string($this->issuer)) {
-                Utils::addString($root, \SAML2_Const::NS_SAML, 'saml:Issuer', $this->issuer);
+                Utils::addString($root, Constants::NS_SAML, 'saml:Issuer', $this->issuer);
             } elseif ($this->issuer instanceof XML\saml\Issuer) {
                 $this->issuer->toXML($root);
             }


### PR DESCRIPTION
I ran into two small bugs while testing out the library. They're pretty small fixes, but fixes nonetheless. See explanations below. Hope this helps.

1. In `src/SAML2/Certificate/PrivateKeyLoader.php` there is one remaining reference to `PrivateKey` where it should be `PrivateKeyConfiguration`, on [line 50](/simplesamlphp/saml2/blob/v3.0.3/src/SAML2/Certificate/PrivateKeyLoader.php#L50).

    Quick verification:

    - On [line 49](/simplesamlphp/saml2/blob/v3.0.3/src/SAML2/Certificate/PrivateKeyLoader.php#L49), `$newPrivateKey` is set to the return value of `$serviceProvider->getPrivateKey()`, which returns a `SAML2\Configuration\PrivateKey` instance (or `null`).
    - On [line 51](/simplesamlphp/saml2/blob/v3.0.3/src/SAML2/Certificate/PrivateKeyLoader.php#L51), `$this->loadPrivateKey($newPrivateKey)` is called, this method takes as argument a `SAML2\Configuration\PrivateKey` instance.

    History leading up to the bug:

    - In commit 4ffccff, the `use` statement is changed to use `SAML2\Configuration\PrivateKey` as `PrivateKeyConfiguration` (which makes `PrivateKey` refer to `SAML2\Certificate\PrivateKey`).
    - In commit e619582, most of the references to `PrivateKey` that should refer to `SAML2\Configuration\PrivateKey` have been changed to `PrivateKeyConfiguration`.

2. In `src/SAML2/Message.php` there is one remaining reference to `SAML2_Const` where it should be `Constants`, on [line 459](/simplesamlphp/saml2/blob/v3.0.3/src/SAML2/Message.php#L459).

    Quick verification:

    - On [lines 443 and 444](/simplesamlphp/saml2/blob/v3.0.3/src/SAML2/Message.php#L443-L444), references to the same constant do use the `Constants` class.

    History leading up to the bug:

    - In commit 504baa0, the `SAML2_Const` class is renamed to `SAML2_Constants`.
    - In commit cc2e360, an autoloader is added, which (among other things) aliases the old class name to the new one.
    - In commit 431576a, namespaces are introduced and references to `SAML2_Constants` are replaced with references to `\SAML2\Constants` (or `Constants`), but `SAML2_Const` references are not.