### PR TITLE
Fix deprecated assert(...) usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,10 @@
         "psr-0": {
             "SAML2\\": "tests/"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "v3.0.x-dev"
+        }
     }
 }

--- a/src/SAML2/ArtifactResolve.php
+++ b/src/SAML2/ArtifactResolve.php
@@ -41,7 +41,7 @@ class ArtifactResolve extends Request
      */
     public function setArtifact($artifact)
     {
-        assert('is_string($artifact)');
+        assert(is_string($artifact));
         $this->artifact = $artifact;
     }
 

--- a/src/SAML2/ArtifactResponse.php
+++ b/src/SAML2/ArtifactResponse.php
@@ -25,7 +25,7 @@ class ArtifactResponse extends StatusResponse
 
         if (!is_null($xml)) {
             $status = Utils::xpQuery($xml, './saml_protocol:Status');
-            assert('!empty($status)'); /* Will have failed during StatusResponse parsing. */
+            assert(!empty($status)); /* Will have failed during StatusResponse parsing. */
 
             $status = $status[0];
 

--- a/src/SAML2/Assertion.php
+++ b/src/SAML2/Assertion.php
@@ -618,7 +618,7 @@ class Assertion implements SignedElement
      */
     public function validate(XMLSecurityKey $key)
     {
-        assert('$key->type === \RobRichards\XMLSecLibs\XMLSecurityKey::RSA_SHA1');
+        assert($key->type === \RobRichards\XMLSecLibs\XMLSecurityKey::RSA_SHA1);
 
         if ($this->signatureData === null) {
             return false;
@@ -646,7 +646,7 @@ class Assertion implements SignedElement
      */
     public function setId($id)
     {
-        assert('is_string($id)');
+        assert(is_string($id));
 
         $this->id = $id;
     }
@@ -668,7 +668,7 @@ class Assertion implements SignedElement
      */
     public function setIssueInstant($issueInstant)
     {
-        assert('is_int($issueInstant)');
+        assert(is_int($issueInstant));
 
         $this->issueInstant = $issueInstant;
     }
@@ -690,7 +690,7 @@ class Assertion implements SignedElement
      */
     public function setIssuer($issuer)
     {
-        assert('is_string($issuer) || $issuer instanceof \SAML2\XML\saml\Issuer');
+        assert(is_string($issuer) || $issuer instanceof \SAML2\XML\saml\Issuer);
 
         $this->issuer = $issuer;
     }
@@ -721,7 +721,7 @@ class Assertion implements SignedElement
      */
     public function setNameId($nameId)
     {
-        assert('is_array($nameId) || is_null($nameId) || is_a($nameId, "\SAML2\XML\saml\NameID")');
+        assert(is_array($nameId) || is_null($nameId) || is_a($nameId, "\SAML2\XML\saml\NameID"));
 
         if (is_array($nameId)) {
             $nameId = XML\saml\NameID::fromArray($nameId);
@@ -873,7 +873,7 @@ class Assertion implements SignedElement
      */
     public function setNotBefore($notBefore)
     {
-        assert('is_int($notBefore) || is_null($notBefore)');
+        assert(is_int($notBefore) || is_null($notBefore));
 
         $this->notBefore = $notBefore;
     }
@@ -900,7 +900,7 @@ class Assertion implements SignedElement
      */
     public function setNotOnOrAfter($notOnOrAfter)
     {
-        assert('is_int($notOnOrAfter) || is_null($notOnOrAfter)');
+        assert(is_int($notOnOrAfter) || is_null($notOnOrAfter));
 
         $this->notOnOrAfter = $notOnOrAfter;
     }
@@ -957,7 +957,7 @@ class Assertion implements SignedElement
      */
     public function setAuthnInstant($authnInstant)
     {
-        assert('is_int($authnInstant) || is_null($authnInstant)');
+        assert(is_int($authnInstant) || is_null($authnInstant));
 
         $this->authnInstant = $authnInstant;
     }
@@ -984,7 +984,7 @@ class Assertion implements SignedElement
      */
     public function setSessionNotOnOrAfter($sessionNotOnOrAfter)
     {
-        assert('is_int($sessionNotOnOrAfter) || is_null($sessionNotOnOrAfter)');
+        assert(is_int($sessionNotOnOrAfter) || is_null($sessionNotOnOrAfter));
 
         $this->sessionNotOnOrAfter = $sessionNotOnOrAfter;
     }
@@ -1009,7 +1009,7 @@ class Assertion implements SignedElement
      */
     public function setSessionIndex($sessionIndex)
     {
-        assert('is_string($sessionIndex) || is_null($sessionIndex)');
+        assert(is_string($sessionIndex) || is_null($sessionIndex));
 
         $this->sessionIndex = $sessionIndex;
     }
@@ -1076,7 +1076,7 @@ class Assertion implements SignedElement
      */
     public function setAuthnContextClassRef($authnContextClassRef)
     {
-        assert('is_string($authnContextClassRef) || is_null($authnContextClassRef)');
+        assert(is_string($authnContextClassRef) || is_null($authnContextClassRef));
 
         $this->authnContextClassRef = $authnContextClassRef;
     }
@@ -1203,7 +1203,7 @@ class Assertion implements SignedElement
      */
     public function setAttributeNameFormat($nameFormat)
     {
-        assert('is_string($nameFormat)');
+        assert(is_string($nameFormat));
 
         $this->nameFormat = $nameFormat;
     }

--- a/src/SAML2/AttributeQuery.php
+++ b/src/SAML2/AttributeQuery.php
@@ -127,7 +127,7 @@ class AttributeQuery extends SubjectQuery
      */
     public function setAttributeNameFormat($nameFormat)
     {
-        assert('is_string($nameFormat)');
+        assert(is_string($nameFormat));
 
         $this->nameFormat = $nameFormat;
     }

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -351,7 +351,7 @@ class AuthnRequest extends Request
      */
     public function setForceAuthn($forceAuthn)
     {
-        assert('is_bool($forceAuthn)');
+        assert(is_bool($forceAuthn));
 
         $this->forceAuthn = $forceAuthn;
     }
@@ -375,7 +375,7 @@ class AuthnRequest extends Request
      */
     public function setProviderName($ProviderName)
     {
-        assert('is_string($ProviderName)');
+        assert(is_string($ProviderName));
 
         $this->ProviderName = $ProviderName;
     }
@@ -399,7 +399,7 @@ class AuthnRequest extends Request
      */
     public function setIsPassive($isPassive)
     {
-        assert('is_bool($isPassive)');
+        assert(is_bool($isPassive));
 
         $this->isPassive = $isPassive;
     }
@@ -420,7 +420,7 @@ class AuthnRequest extends Request
      */
     public function setIDPList($IDPList)
     {
-        assert('is_array($IDPList)');
+        assert(is_array($IDPList));
         $this->IDPList = $IDPList;
     }
 
@@ -440,7 +440,7 @@ class AuthnRequest extends Request
      */
     public function setProxyCount($ProxyCount)
     {
-        assert('is_int($ProxyCount)');
+        assert(is_int($ProxyCount));
         $this->ProxyCount = $ProxyCount;
     }
 
@@ -485,7 +485,7 @@ class AuthnRequest extends Request
      */
     public function setAssertionConsumerServiceURL($assertionConsumerServiceURL)
     {
-        assert('is_string($assertionConsumerServiceURL) || is_null($assertionConsumerServiceURL)');
+        assert(is_string($assertionConsumerServiceURL) || is_null($assertionConsumerServiceURL));
 
         $this->assertionConsumerServiceURL = $assertionConsumerServiceURL;
     }
@@ -507,7 +507,7 @@ class AuthnRequest extends Request
      */
     public function setProtocolBinding($protocolBinding)
     {
-        assert('is_string($protocolBinding) || is_null($protocolBinding)');
+        assert(is_string($protocolBinding) || is_null($protocolBinding));
 
         $this->protocolBinding = $protocolBinding;
     }
@@ -529,7 +529,7 @@ class AuthnRequest extends Request
      */
     public function setAttributeConsumingServiceIndex($attributeConsumingServiceIndex)
     {
-        assert('is_int($attributeConsumingServiceIndex) || is_null($attributeConsumingServiceIndex)');
+        assert(is_int($attributeConsumingServiceIndex) || is_null($attributeConsumingServiceIndex));
 
         $this->attributeConsumingServiceIndex = $attributeConsumingServiceIndex;
     }
@@ -551,7 +551,7 @@ class AuthnRequest extends Request
      */
     public function setAssertionConsumerServiceIndex($assertionConsumerServiceIndex)
     {
-        assert('is_int($assertionConsumerServiceIndex) || is_null($assertionConsumerServiceIndex)');
+        assert(is_int($assertionConsumerServiceIndex) || is_null($assertionConsumerServiceIndex));
 
         $this->assertionConsumerServiceIndex = $assertionConsumerServiceIndex;
     }
@@ -573,7 +573,7 @@ class AuthnRequest extends Request
      */
     public function setRequestedAuthnContext($requestedAuthnContext)
     {
-        assert('is_array($requestedAuthnContext) || is_null($requestedAuthnContext)');
+        assert(is_array($requestedAuthnContext) || is_null($requestedAuthnContext));
 
         $this->requestedAuthnContext = $requestedAuthnContext;
     }
@@ -600,7 +600,7 @@ class AuthnRequest extends Request
      */
     public function setNameId($nameId)
     {
-        assert('is_array($nameId) || is_null($nameId) || is_a($nameId, "\SAML2\XML\saml\NameID")');
+        assert(is_array($nameId) || is_null($nameId) || is_a($nameId, "\SAML2\XML\saml\NameID"));
 
         if (is_array($nameId)) {
             $nameId = XML\saml\NameID::fromArray($nameId);

--- a/src/SAML2/Binding.php
+++ b/src/SAML2/Binding.php
@@ -27,7 +27,7 @@ abstract class Binding
      */
     public static function getBinding($urn)
     {
-        assert('is_string($urn)');
+        assert(is_string($urn));
 
         switch ($urn) {
             case Constants::BINDING_HTTP_POST:
@@ -118,7 +118,7 @@ abstract class Binding
      */
     public function setDestination($destination)
     {
-        assert('is_string($destination) || is_null($destination)');
+        assert(is_string($destination) || is_null($destination));
 
         $this->destination = $destination;
     }

--- a/src/SAML2/HTTPRedirect.php
+++ b/src/SAML2/HTTPRedirect.php
@@ -209,9 +209,9 @@ class HTTPRedirect extends Binding
      */
     public static function validateSignature(array $data, XMLSecurityKey $key)
     {
-        assert('array_key_exists("Query", $data)');
-        assert('array_key_exists("SigAlg", $data)');
-        assert('array_key_exists("Signature", $data)');
+        assert(array_key_exists("Query", $data));
+        assert(array_key_exists("SigAlg", $data));
+        assert(array_key_exists("Signature", $data));
 
         $query = $data['Query'];
         $sigAlg = $data['SigAlg'];

--- a/src/SAML2/LogoutRequest.php
+++ b/src/SAML2/LogoutRequest.php
@@ -99,7 +99,7 @@ class LogoutRequest extends Request
      */
     public function setNotOnOrAfter($notOnOrAfter)
     {
-        assert('is_int($notOnOrAfter) || is_null($notOnOrAfter)');
+        assert(is_int($notOnOrAfter) || is_null($notOnOrAfter));
 
         $this->notOnOrAfter = $notOnOrAfter;
     }
@@ -190,7 +190,7 @@ class LogoutRequest extends Request
      */
     public function setNameId($nameId)
     {
-        assert('is_array($nameId) || is_a($nameId, "\SAML2\XML\saml\NameID")');
+        assert(is_array($nameId) || is_a($nameId, "\SAML2\XML\saml\NameID"));
 
         if (is_array($nameId)) {
             $nameId = XML\saml\NameID::fromArray($nameId);
@@ -239,7 +239,7 @@ class LogoutRequest extends Request
      */
     public function setSessionIndex($sessionIndex)
     {
-        assert('is_string($sessionIndex) || is_null($sessionIndex)');
+        assert(is_string($sessionIndex) || is_null($sessionIndex));
 
         if (is_null($sessionIndex)) {
             $this->sessionIndexes = array();

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -135,7 +135,7 @@ abstract class Message implements SignedElement
      */
     protected function __construct($tagName, \DOMElement $xml = null)
     {
-        assert('is_string($tagName)');
+        assert(is_string($tagName));
         $this->tagName = $tagName;
 
         $this->id = Utils::getContainer()->generateId();
@@ -224,7 +224,7 @@ abstract class Message implements SignedElement
      */
     public function addValidator($function, $data)
     {
-        assert('is_callable($function)');
+        assert(is_callable($function));
 
         $this->validators[] = array(
             'Function' => $function,
@@ -288,7 +288,7 @@ abstract class Message implements SignedElement
      */
     public function setId($id)
     {
-        assert('is_string($id)');
+        assert(is_string($id));
 
         $this->id = $id;
     }
@@ -310,7 +310,7 @@ abstract class Message implements SignedElement
      */
     public function setIssueInstant($issueInstant)
     {
-        assert('is_int($issueInstant)');
+        assert(is_int($issueInstant));
 
         $this->issueInstant = $issueInstant;
     }
@@ -332,7 +332,7 @@ abstract class Message implements SignedElement
      */
     public function setDestination($destination)
     {
-        assert('is_string($destination) || is_null($destination)');
+        assert(is_string($destination) || is_null($destination));
 
         $this->destination = $destination;
     }
@@ -348,7 +348,7 @@ abstract class Message implements SignedElement
      */
     public function setConsent($consent)
     {
-        assert('is_string($consent)');
+        assert(is_string($consent));
 
         $this->consent = $consent;
     }
@@ -388,7 +388,7 @@ abstract class Message implements SignedElement
      */
     public function setIssuer($issuer)
     {
-        assert('is_string($issuer) || $issuer instanceof \SAML2\XML\saml\Issuer || is_null($issuer)');
+        assert(is_string($issuer) || $issuer instanceof \SAML2\XML\saml\Issuer || is_null($issuer));
 
         $this->issuer = $issuer;
     }
@@ -420,7 +420,7 @@ abstract class Message implements SignedElement
      */
     public function setRelayState($relayState)
     {
-        assert('is_string($relayState) || is_null($relayState)');
+        assert(is_string($relayState) || is_null($relayState));
 
         $this->relayState = $relayState;
     }
@@ -602,7 +602,7 @@ abstract class Message implements SignedElement
      */
     public function setExtensions($extensions)
     {
-        assert('is_array($extensions) || is_null($extensions)');
+        assert(is_array($extensions) || is_null($extensions));
 
         $this->extensions = $extensions;
     }

--- a/src/SAML2/SOAPClient.php
+++ b/src/SAML2/SOAPClient.php
@@ -202,7 +202,7 @@ class SOAPClient
      */
     public static function validateSSL($data, XMLSecurityKey $key)
     {
-        assert('is_string($data)');
+        assert(is_string($data));
 
         $keyInfo = openssl_pkey_get_details($key->key);
         if ($keyInfo === false) {

--- a/src/SAML2/SignedElementHelper.php
+++ b/src/SAML2/SignedElementHelper.php
@@ -76,7 +76,7 @@ class SignedElementHelper implements SignedElement
      */
     public function addValidator($function, $data)
     {
-        assert('is_callable($function)');
+        assert(is_callable($function));
 
         $this->validators[] = array(
             'Function' => $function,

--- a/src/SAML2/StatusResponse.php
+++ b/src/SAML2/StatusResponse.php
@@ -98,7 +98,7 @@ abstract class StatusResponse extends Message
      */
     public function isSuccess()
     {
-        assert('array_key_exists("Code", $this->status)');
+        assert(array_key_exists("Code", $this->status));
 
         if ($this->status['Code'] === Constants::STATUS_SUCCESS) {
             return true;
@@ -126,7 +126,7 @@ abstract class StatusResponse extends Message
      */
     public function setInResponseTo($inResponseTo)
     {
-        assert('is_string($inResponseTo) || is_null($inResponseTo)');
+        assert(is_string($inResponseTo) || is_null($inResponseTo));
 
         $this->inResponseTo = $inResponseTo;
     }
@@ -150,7 +150,7 @@ abstract class StatusResponse extends Message
      */
     public function setStatus(array $status)
     {
-        assert('array_key_exists("Code", $status)');
+        assert(array_key_exists("Code", $status));
 
         $this->status = $status;
         if (!array_key_exists('SubCode', $status)) {

--- a/src/SAML2/SubjectQuery.php
+++ b/src/SAML2/SubjectQuery.php
@@ -87,7 +87,7 @@ abstract class SubjectQuery extends Request
      */
     public function setNameId($nameId)
     {
-        assert('is_array($nameId) || is_null($nameId) || is_a($nameId, "\SAML2\XML\saml\NameID")');
+        assert(is_array($nameId) || is_null($nameId) || is_a($nameId, "\SAML2\XML\saml\NameID"));
 
         if (is_array($nameId)) {
             $nameId = XML\saml\NameID::fromArray($nameId);

--- a/src/SAML2/Utils.php
+++ b/src/SAML2/Utils.php
@@ -111,8 +111,8 @@ class Utils
      */
     public static function castKey(XMLSecurityKey $key, $algorithm, $type = 'public')
     {
-        assert('is_string($algorithm)');
-        assert('$type === "public" || $type === "private"');
+        assert(is_string($algorithm));
+        assert($type === "public" || $type === "private");
 
         // do nothing if algorithm is already the type of the key
         if ($key->type === $algorithm) {
@@ -145,7 +145,7 @@ class Utils
      */
     public static function validateSignature(array $info, XMLSecurityKey $key)
     {
-        assert('array_key_exists("Signature", $info)');
+        assert(array_key_exists("Signature", $info));
 
         /** @var XMLSecurityDSig $objXMLSecDSig */
         $objXMLSecDSig = $info['Signature'];
@@ -180,7 +180,7 @@ class Utils
      */
     public static function xpQuery(\DOMNode $node, $query)
     {
-        assert('is_string($query)');
+        assert(is_string($query));
         static $xpCache = null;
 
         if ($node instanceof \DOMDocument) {
@@ -265,7 +265,7 @@ class Utils
      */
     public static function parseBoolean(\DOMElement $node, $attributeName, $default = null)
     {
-        assert('is_string($attributeName)');
+        assert(is_string($attributeName));
 
         if (!$node->hasAttribute($attributeName)) {
             return $default;
@@ -303,7 +303,7 @@ class Utils
      */
     public static function addNameId(\DOMElement $node, array $nameId)
     {
-        assert('array_key_exists("Value", $nameId)');
+        assert(array_key_exists("Value", $nameId));
 
         $nid = new XML\saml\NameID();
 
@@ -569,8 +569,8 @@ class Utils
      */
     public static function extractLocalizedStrings(\DOMElement $parent, $namespaceURI, $localName)
     {
-        assert('is_string($namespaceURI)');
-        assert('is_string($localName)');
+        assert(is_string($namespaceURI));
+        assert(is_string($localName));
 
         $ret = array();
         for ($node = $parent->firstChild; $node !== null; $node = $node->nextSibling) {
@@ -599,8 +599,8 @@ class Utils
      */
     public static function extractStrings(\DOMElement $parent, $namespaceURI, $localName)
     {
-        assert('is_string($namespaceURI)');
-        assert('is_string($localName)');
+        assert(is_string($namespaceURI));
+        assert(is_string($localName));
 
         $ret = array();
         for ($node = $parent->firstChild; $node !== null; $node = $node->nextSibling) {
@@ -624,9 +624,9 @@ class Utils
      */
     public static function addString(\DOMElement $parent, $namespace, $name, $value)
     {
-        assert('is_string($namespace)');
-        assert('is_string($name)');
-        assert('is_string($value)');
+        assert(is_string($namespace));
+        assert(is_string($name));
+        assert(is_string($value));
 
         $doc = $parent->ownerDocument;
 
@@ -648,9 +648,9 @@ class Utils
      */
     public static function addStrings(\DOMElement $parent, $namespace, $name, $localized, array $values)
     {
-        assert('is_string($namespace)');
-        assert('is_string($name)');
-        assert('is_bool($localized)');
+        assert(is_string($namespace));
+        assert(is_string($name));
+        assert(is_bool($localized));
 
         $doc = $parent->ownerDocument;
 
@@ -672,7 +672,7 @@ class Utils
      */
     public static function createKeyDescriptor($x509Data)
     {
-        assert('is_string($x509Data)');
+        assert(is_string($x509Data));
 
         $x509Certificate = new X509Certificate();
         $x509Certificate->certificate = $x509Data;

--- a/src/SAML2/XML/alg/DigestMethod.php
+++ b/src/SAML2/XML/alg/DigestMethod.php
@@ -47,7 +47,7 @@ class DigestMethod
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_string($this->Algorithm)');
+        assert(is_string($this->Algorithm));
 
         $doc = $parent->ownerDocument;
         $e = $doc->createElementNS(Common::NS, 'alg:DigestMethod');

--- a/src/SAML2/XML/alg/SigningMethod.php
+++ b/src/SAML2/XML/alg/SigningMethod.php
@@ -73,9 +73,9 @@ class SigningMethod
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_string($this->Algorithm)');
-        assert('is_int($this->MinKeySize) || is_null($this->MinKeySize)');
-        assert('is_int($this->MaxKeySize) || is_null($this->MaxKeySize)');
+        assert(is_string($this->Algorithm));
+        assert(is_int($this->MinKeySize) || is_null($this->MinKeySize));
+        assert(is_int($this->MaxKeySize) || is_null($this->MaxKeySize));
 
         $doc = $parent->ownerDocument;
         $e = $doc->createElementNS(Common::NS, 'alg:SigningMethod');

--- a/src/SAML2/XML/ds/KeyInfo.php
+++ b/src/SAML2/XML/ds/KeyInfo.php
@@ -75,8 +75,8 @@ class KeyInfo
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_null($this->Id) || is_string($this->Id)');
-        assert('is_array($this->info)');
+        assert(is_null($this->Id) || is_string($this->Id));
+        assert(is_array($this->info));
 
         $doc = $parent->ownerDocument;
 

--- a/src/SAML2/XML/ds/KeyName.php
+++ b/src/SAML2/XML/ds/KeyName.php
@@ -41,7 +41,7 @@ class KeyName
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_string($this->name)');
+        assert(is_string($this->name));
 
         return Utils::addString($parent, XMLSecurityDSig::XMLDSIGNS, 'ds:KeyName', $this->name);
     }

--- a/src/SAML2/XML/ds/X509Certificate.php
+++ b/src/SAML2/XML/ds/X509Certificate.php
@@ -41,7 +41,7 @@ class X509Certificate
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_string($this->certificate)');
+        assert(is_string($this->certificate));
 
         return Utils::addString($parent, XMLSecurityDSig::XMLDSIGNS, 'ds:X509Certificate', $this->certificate);
     }

--- a/src/SAML2/XML/ds/X509Data.php
+++ b/src/SAML2/XML/ds/X509Data.php
@@ -61,7 +61,7 @@ class X509Data
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_array($this->data)');
+        assert(is_array($this->data));
 
         $doc = $parent->ownerDocument;
 

--- a/src/SAML2/XML/md/AdditionalMetadataLocation.php
+++ b/src/SAML2/XML/md/AdditionalMetadataLocation.php
@@ -54,8 +54,8 @@ class AdditionalMetadataLocation
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_string($this->namespace)');
-        assert('is_string($this->location)');
+        assert(is_string($this->namespace));
+        assert(is_string($this->location));
 
         $e = Utils::addString($parent, Constants::NS_MD, 'md:AdditionalMetadataLocation', $this->location);
         $e->setAttribute('namespace', $this->namespace);

--- a/src/SAML2/XML/md/AffiliationDescriptor.php
+++ b/src/SAML2/XML/md/AffiliationDescriptor.php
@@ -119,14 +119,14 @@ class AffiliationDescriptor extends SignedElementHelper
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_string($this->affiliationOwnerID)');
-        assert('is_null($this->ID) || is_string($this->ID)');
-        assert('is_null($this->validUntil) || is_int($this->validUntil)');
-        assert('is_null($this->cacheDuration) || is_string($this->cacheDuration)');
-        assert('is_array($this->Extensions)');
-        assert('is_array($this->AffiliateMember)');
-        assert('!empty($this->AffiliateMember)');
-        assert('is_array($this->KeyDescriptor)');
+        assert(is_string($this->affiliationOwnerID));
+        assert(is_null($this->ID) || is_string($this->ID));
+        assert(is_null($this->validUntil) || is_int($this->validUntil));
+        assert(is_null($this->cacheDuration) || is_string($this->cacheDuration));
+        assert(is_array($this->Extensions));
+        assert(is_array($this->AffiliateMember));
+        assert(!empty($this->AffiliateMember));
+        assert(is_array($this->KeyDescriptor));
 
         $e = $parent->ownerDocument->createElementNS(Constants::NS_MD, 'md:AffiliationDescriptor');
         $parent->appendChild($e);

--- a/src/SAML2/XML/md/AttributeAuthorityDescriptor.php
+++ b/src/SAML2/XML/md/AttributeAuthorityDescriptor.php
@@ -100,12 +100,12 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_array($this->AttributeService)');
-        assert('!empty($this->AttributeService)');
-        assert('is_array($this->AssertionIDRequestService)');
-        assert('is_array($this->NameIDFormat)');
-        assert('is_array($this->AttributeProfile)');
-        assert('is_array($this->Attribute)');
+        assert(is_array($this->AttributeService));
+        assert(!empty($this->AttributeService));
+        assert(is_array($this->AssertionIDRequestService));
+        assert(is_array($this->NameIDFormat));
+        assert(is_array($this->AttributeProfile));
+        assert(is_array($this->Attribute));
 
         $e = parent::toXML($parent);
 

--- a/src/SAML2/XML/md/AttributeConsumingService.php
+++ b/src/SAML2/XML/md/AttributeConsumingService.php
@@ -92,11 +92,11 @@ class AttributeConsumingService
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_int($this->index)');
-        assert('is_null($this->isDefault) || is_bool($this->isDefault)');
-        assert('is_array($this->ServiceName)');
-        assert('is_array($this->ServiceDescription)');
-        assert('is_array($this->RequestedAttribute)');
+        assert(is_int($this->index));
+        assert(is_null($this->isDefault) || is_bool($this->isDefault));
+        assert(is_array($this->ServiceName));
+        assert(is_array($this->ServiceDescription));
+        assert(is_array($this->RequestedAttribute));
 
         $doc = $parent->ownerDocument;
 

--- a/src/SAML2/XML/md/AuthnAuthorityDescriptor.php
+++ b/src/SAML2/XML/md/AuthnAuthorityDescriptor.php
@@ -75,10 +75,10 @@ class AuthnAuthorityDescriptor extends RoleDescriptor
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_array($this->AuthnQueryService)');
-        assert('!empty($this->AuthnQueryService)');
-        assert('is_array($this->AssertionIDRequestService)');
-        assert('is_array($this->NameIDFormat)');
+        assert(is_array($this->AuthnQueryService));
+        assert(!empty($this->AuthnQueryService));
+        assert(is_array($this->AssertionIDRequestService));
+        assert(is_array($this->NameIDFormat));
 
         $e = parent::toXML($parent);
 

--- a/src/SAML2/XML/md/ContactPerson.php
+++ b/src/SAML2/XML/md/ContactPerson.php
@@ -113,7 +113,7 @@ class ContactPerson
      */
     private static function getStringElements(\DOMElement $parent, $name)
     {
-        assert('is_string($name)');
+        assert(is_string($name));
 
         $e = Utils::xpQuery($parent, './saml_metadata:' . $name);
 
@@ -135,7 +135,7 @@ class ContactPerson
      */
     private static function getStringElement(\DOMElement $parent, $name)
     {
-        assert('is_string($name)');
+        assert(is_string($name));
 
         $e = self::getStringElements($parent, $name);
         if (empty($e)) {
@@ -156,14 +156,14 @@ class ContactPerson
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_string($this->contactType)');
-        assert('is_array($this->Extensions)');
-        assert('is_null($this->Company) || is_string($this->Company)');
-        assert('is_null($this->GivenName) || is_string($this->GivenName)');
-        assert('is_null($this->SurName) || is_string($this->SurName)');
-        assert('is_array($this->EmailAddress)');
-        assert('is_array($this->TelephoneNumber)');
-        assert('is_array($this->ContactPersonAttributes)');
+        assert(is_string($this->contactType));
+        assert(is_array($this->Extensions));
+        assert(is_null($this->Company) || is_string($this->Company));
+        assert(is_null($this->GivenName) || is_string($this->GivenName));
+        assert(is_null($this->SurName) || is_string($this->SurName));
+        assert(is_array($this->EmailAddress));
+        assert(is_array($this->TelephoneNumber));
+        assert(is_array($this->ContactPersonAttributes));
 
         $doc = $parent->ownerDocument;
 

--- a/src/SAML2/XML/md/EndpointType.php
+++ b/src/SAML2/XML/md/EndpointType.php
@@ -87,8 +87,8 @@ class EndpointType
      */
     public function hasAttributeNS($namespaceURI, $localName)
     {
-        assert('is_string($namespaceURI)');
-        assert('is_string($localName)');
+        assert(is_string($namespaceURI));
+        assert(is_string($localName));
 
         $fullName = '{' . $namespaceURI . '}' . $localName;
 
@@ -104,8 +104,8 @@ class EndpointType
      */
     public function getAttributeNS($namespaceURI, $localName)
     {
-        assert('is_string($namespaceURI)');
-        assert('is_string($localName)');
+        assert(is_string($namespaceURI));
+        assert(is_string($localName));
 
         $fullName = '{' . $namespaceURI . '}' . $localName;
         if (!isset($this->attributes[$fullName])) {
@@ -125,8 +125,8 @@ class EndpointType
      */
     public function setAttributeNS($namespaceURI, $qualifiedName, $value)
     {
-        assert('is_string($namespaceURI)');
-        assert('is_string($qualifiedName)');
+        assert(is_string($namespaceURI));
+        assert(is_string($qualifiedName));
 
         $name = explode(':', $qualifiedName, 2);
         if (count($name) < 2) {
@@ -150,8 +150,8 @@ class EndpointType
      */
     public function removeAttributeNS($namespaceURI, $localName)
     {
-        assert('is_string($namespaceURI)');
-        assert('is_string($localName)');
+        assert(is_string($namespaceURI));
+        assert(is_string($localName));
 
         $fullName = '{' . $namespaceURI . '}' . $localName;
         unset($this->attributes[$fullName]);
@@ -166,10 +166,10 @@ class EndpointType
      */
     public function toXML(\DOMElement $parent, $name)
     {
-        assert('is_string($name)');
-        assert('is_string($this->Binding)');
-        assert('is_string($this->Location)');
-        assert('is_null($this->ResponseLocation) || is_string($this->ResponseLocation)');
+        assert(is_string($name));
+        assert(is_string($this->Binding));
+        assert(is_string($this->Location));
+        assert(is_null($this->ResponseLocation) || is_string($this->ResponseLocation));
 
         $e = $parent->ownerDocument->createElementNS(Constants::NS_MD, $name);
         $parent->appendChild($e);

--- a/src/SAML2/XML/md/EntitiesDescriptor.php
+++ b/src/SAML2/XML/md/EntitiesDescriptor.php
@@ -103,12 +103,12 @@ class EntitiesDescriptor extends SignedElementHelper
      */
     public function toXML(\DOMElement $parent = null)
     {
-        assert('is_null($this->ID) || is_string($this->ID)');
-        assert('is_null($this->validUntil) || is_int($this->validUntil)');
-        assert('is_null($this->cacheDuration) || is_string($this->cacheDuration)');
-        assert('is_null($this->Name) || is_string($this->Name)');
-        assert('is_array($this->Extensions)');
-        assert('is_array($this->children)');
+        assert(is_null($this->ID) || is_string($this->ID));
+        assert(is_null($this->validUntil) || is_int($this->validUntil));
+        assert(is_null($this->cacheDuration) || is_string($this->cacheDuration));
+        assert(is_null($this->Name) || is_string($this->Name));
+        assert(is_array($this->Extensions));
+        assert(is_array($this->children));
 
         if ($parent === null) {
             $doc = DOMDocumentFactory::create();

--- a/src/SAML2/XML/md/EntityDescriptor.php
+++ b/src/SAML2/XML/md/EntityDescriptor.php
@@ -187,16 +187,16 @@ class EntityDescriptor extends SignedElementHelper
      */
     public function toXML(\DOMElement $parent = null)
     {
-        assert('is_string($this->entityID)');
-        assert('is_null($this->ID) || is_string($this->ID)');
-        assert('is_null($this->validUntil) || is_int($this->validUntil)');
-        assert('is_null($this->cacheDuration) || is_string($this->cacheDuration)');
-        assert('is_array($this->Extensions)');
-        assert('is_array($this->RoleDescriptor)');
-        assert('is_null($this->AffiliationDescriptor) || $this->AffiliationDescriptor instanceof \SAML2\XML\md\AffiliationDescriptor');
-        assert('is_null($this->Organization) || $this->Organization instanceof \SAML2\XML\md\Organization');
-        assert('is_array($this->ContactPerson)');
-        assert('is_array($this->AdditionalMetadataLocation)');
+        assert(is_string($this->entityID));
+        assert(is_null($this->ID) || is_string($this->ID));
+        assert(is_null($this->validUntil) || is_int($this->validUntil));
+        assert(is_null($this->cacheDuration) || is_string($this->cacheDuration));
+        assert(is_array($this->Extensions));
+        assert(is_array($this->RoleDescriptor));
+        assert(is_null($this->AffiliationDescriptor) || $this->AffiliationDescriptor instanceof \SAML2\XML\md\AffiliationDescriptor);
+        assert(is_null($this->Organization) || $this->Organization instanceof \SAML2\XML\md\Organization);
+        assert(is_array($this->ContactPerson));
+        assert(is_array($this->AdditionalMetadataLocation));
 
         if ($parent === null) {
             $doc = DOMDocumentFactory::create();

--- a/src/SAML2/XML/md/IDPSSODescriptor.php
+++ b/src/SAML2/XML/md/IDPSSODescriptor.php
@@ -107,12 +107,12 @@ class IDPSSODescriptor extends SSODescriptorType
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_null($this->WantAuthnRequestsSigned) || is_bool($this->WantAuthnRequestsSigned)');
-        assert('is_array($this->SingleSignOnService)');
-        assert('is_array($this->NameIDMappingService)');
-        assert('is_array($this->AssertionIDRequestService)');
-        assert('is_array($this->AttributeProfile)');
-        assert('is_array($this->Attribute)');
+        assert(is_null($this->WantAuthnRequestsSigned) || is_bool($this->WantAuthnRequestsSigned));
+        assert(is_array($this->SingleSignOnService));
+        assert(is_array($this->NameIDMappingService));
+        assert(is_array($this->AssertionIDRequestService));
+        assert(is_array($this->AttributeProfile));
+        assert(is_array($this->Attribute));
 
         $e = parent::toXML($parent);
 

--- a/src/SAML2/XML/md/IndexedEndpointType.php
+++ b/src/SAML2/XML/md/IndexedEndpointType.php
@@ -56,9 +56,9 @@ class IndexedEndpointType extends EndpointType
      */
     public function toXML(\DOMElement $parent, $name)
     {
-        assert('is_string($name)');
-        assert('is_int($this->index)');
-        assert('is_null($this->isDefault) || is_bool($this->isDefault)');
+        assert(is_string($name));
+        assert(is_int($this->index));
+        assert(is_null($this->isDefault) || is_bool($this->isDefault));
 
         $e = parent::toXML($parent, $name);
         $e->setAttribute('index', (string) $this->index);

--- a/src/SAML2/XML/md/KeyDescriptor.php
+++ b/src/SAML2/XML/md/KeyDescriptor.php
@@ -76,9 +76,9 @@ class KeyDescriptor
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_null($this->use) || is_string($this->use)');
-        assert('$this->KeyInfo instanceof \SAML2\XML\ds\KeyInfo');
-        assert('is_array($this->EncryptionMethod)');
+        assert(is_null($this->use) || is_string($this->use));
+        assert($this->KeyInfo instanceof \SAML2\XML\ds\KeyInfo);
+        assert(is_array($this->EncryptionMethod));
 
         $doc = $parent->ownerDocument;
 

--- a/src/SAML2/XML/md/Organization.php
+++ b/src/SAML2/XML/md/Organization.php
@@ -79,13 +79,13 @@ class Organization
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_array($this->Extensions)');
-        assert('is_array($this->OrganizationName)');
-        assert('!empty($this->OrganizationName)');
-        assert('is_array($this->OrganizationDisplayName)');
-        assert('!empty($this->OrganizationDisplayName)');
-        assert('is_array($this->OrganizationURL)');
-        assert('!empty($this->OrganizationURL)');
+        assert(is_array($this->Extensions));
+        assert(is_array($this->OrganizationName));
+        assert(!empty($this->OrganizationName));
+        assert(is_array($this->OrganizationDisplayName));
+        assert(!empty($this->OrganizationDisplayName));
+        assert(is_array($this->OrganizationURL));
+        assert(!empty($this->OrganizationURL));
 
         $doc = $parent->ownerDocument;
 

--- a/src/SAML2/XML/md/PDPDescriptor.php
+++ b/src/SAML2/XML/md/PDPDescriptor.php
@@ -75,10 +75,10 @@ class PDPDescriptor extends RoleDescriptor
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_array($this->AuthzService)');
-        assert('!empty($this->AuthzService)');
-        assert('is_array($this->AssertionIDRequestService)');
-        assert('is_array($this->NameIDFormat)');
+        assert(is_array($this->AuthzService));
+        assert(!empty($this->AuthzService));
+        assert(is_array($this->AssertionIDRequestService));
+        assert(is_array($this->NameIDFormat));
 
         $e = parent::toXML($parent);
 

--- a/src/SAML2/XML/md/RequestedAttribute.php
+++ b/src/SAML2/XML/md/RequestedAttribute.php
@@ -44,7 +44,7 @@ class RequestedAttribute extends Attribute
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_bool($this->isRequired) || is_null($this->isRequired)');
+        assert(is_bool($this->isRequired) || is_null($this->isRequired));
 
         $e = $this->toXMLInternal($parent, Constants::NS_MD, 'md:RequestedAttribute');
 

--- a/src/SAML2/XML/md/RoleDescriptor.php
+++ b/src/SAML2/XML/md/RoleDescriptor.php
@@ -98,7 +98,7 @@ class RoleDescriptor extends SignedElementHelper
      */
     protected function __construct($elementName, \DOMElement $xml = null)
     {
-        assert('is_string($elementName)');
+        assert(is_string($elementName));
 
         parent::__construct($xml);
         $this->elementName = $elementName;
@@ -152,15 +152,15 @@ class RoleDescriptor extends SignedElementHelper
      */
     protected function toXML(\DOMElement $parent)
     {
-        assert('is_null($this->ID) || is_string($this->ID)');
-        assert('is_null($this->validUntil) || is_int($this->validUntil)');
-        assert('is_null($this->cacheDuration) || is_string($this->cacheDuration)');
-        assert('is_array($this->protocolSupportEnumeration)');
-        assert('is_null($this->errorURL) || is_string($this->errorURL)');
-        assert('is_array($this->Extensions)');
-        assert('is_array($this->KeyDescriptor)');
-        assert('is_null($this->Organization) || $this->Organization instanceof \SAML2\XML\md\Organization');
-        assert('is_array($this->ContactPerson)');
+        assert(is_null($this->ID) || is_string($this->ID));
+        assert(is_null($this->validUntil) || is_int($this->validUntil));
+        assert(is_null($this->cacheDuration) || is_string($this->cacheDuration));
+        assert(is_array($this->protocolSupportEnumeration));
+        assert(is_null($this->errorURL) || is_string($this->errorURL));
+        assert(is_array($this->Extensions));
+        assert(is_array($this->KeyDescriptor));
+        assert(is_null($this->Organization) || $this->Organization instanceof \SAML2\XML\md\Organization);
+        assert(is_array($this->ContactPerson));
 
         $e = $parent->ownerDocument->createElementNS(Constants::NS_MD, $this->elementName);
         $parent->appendChild($e);

--- a/src/SAML2/XML/md/SPSSODescriptor.php
+++ b/src/SAML2/XML/md/SPSSODescriptor.php
@@ -76,10 +76,10 @@ class SPSSODescriptor extends SSODescriptorType
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_null($this->AuthnRequestsSigned) || is_bool($this->AuthnRequestsSigned)');
-        assert('is_null($this->WantAssertionsSigned) || is_bool($this->WantAssertionsSigned)');
-        assert('is_array($this->AssertionConsumerService)');
-        assert('is_array($this->AttributeConsumingService)');
+        assert(is_null($this->AuthnRequestsSigned) || is_bool($this->AuthnRequestsSigned));
+        assert(is_null($this->WantAssertionsSigned) || is_bool($this->WantAssertionsSigned));
+        assert(is_array($this->AssertionConsumerService));
+        assert(is_array($this->AttributeConsumingService));
 
         $e = parent::toXML($parent);
 

--- a/src/SAML2/XML/md/SSODescriptorType.php
+++ b/src/SAML2/XML/md/SSODescriptorType.php
@@ -56,7 +56,7 @@ abstract class SSODescriptorType extends RoleDescriptor
      */
     protected function __construct($elementName, \DOMElement $xml = null)
     {
-        assert('is_string($elementName)');
+        assert(is_string($elementName));
 
         parent::__construct($elementName, $xml);
 
@@ -87,10 +87,10 @@ abstract class SSODescriptorType extends RoleDescriptor
      */
     protected function toXML(\DOMElement $parent)
     {
-        assert('is_array($this->ArtifactResolutionService)');
-        assert('is_array($this->SingleLogoutService)');
-        assert('is_array($this->ManageNameIDService)');
-        assert('is_array($this->NameIDFormat)');
+        assert(is_array($this->ArtifactResolutionService));
+        assert(is_array($this->SingleLogoutService));
+        assert(is_array($this->ManageNameIDService));
+        assert(is_array($this->NameIDFormat));
 
         $e = parent::toXML($parent);
 

--- a/src/SAML2/XML/mdattr/EntityAttributes.php
+++ b/src/SAML2/XML/mdattr/EntityAttributes.php
@@ -56,7 +56,7 @@ class EntityAttributes
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_array($this->children)');
+        assert(is_array($this->children));
 
         $doc = $parent->ownerDocument;
 

--- a/src/SAML2/XML/mdrpi/PublicationInfo.php
+++ b/src/SAML2/XML/mdrpi/PublicationInfo.php
@@ -78,10 +78,10 @@ class PublicationInfo
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_string($this->publisher)');
-        assert('is_int($this->creationInstant) || is_null($this->creationInstant)');
-        assert('is_string($this->publicationId) || is_null($this->publicationId)');
-        assert('is_array($this->UsagePolicy)');
+        assert(is_string($this->publisher));
+        assert(is_int($this->creationInstant) || is_null($this->creationInstant));
+        assert(is_string($this->publicationId) || is_null($this->publicationId));
+        assert(is_array($this->UsagePolicy));
 
         $doc = $parent->ownerDocument;
 

--- a/src/SAML2/XML/mdrpi/RegistrationInfo.php
+++ b/src/SAML2/XML/mdrpi/RegistrationInfo.php
@@ -67,9 +67,9 @@ class RegistrationInfo
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_string($this->registrationAuthority)');
-        assert('is_int($this->registrationInstant) || is_null($this->registrationInstant)');
-        assert('is_array($this->RegistrationPolicy)');
+        assert(is_string($this->registrationAuthority));
+        assert(is_int($this->registrationInstant) || is_null($this->registrationInstant));
+        assert(is_array($this->RegistrationPolicy));
 
         if (empty($this->registrationAuthority)) {
             throw new \Exception('Missing required registration authority.');

--- a/src/SAML2/XML/mdui/DiscoHints.php
+++ b/src/SAML2/XML/mdui/DiscoHints.php
@@ -71,10 +71,10 @@ class DiscoHints
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_array($this->IPHint)');
-        assert('is_array($this->DomainHint)');
-        assert('is_array($this->GeolocationHint)');
-        assert('is_array($this->children)');
+        assert(is_array($this->IPHint));
+        assert(is_array($this->DomainHint));
+        assert(is_array($this->GeolocationHint));
+        assert(is_array($this->children));
 
         if (!empty($this->IPHint)
          || !empty($this->DomainHint)

--- a/src/SAML2/XML/mdui/Keywords.php
+++ b/src/SAML2/XML/mdui/Keywords.php
@@ -60,8 +60,8 @@ class Keywords
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_string($this->lang)');
-        assert('is_array($this->Keywords)');
+        assert(is_string($this->lang));
+        assert(is_array($this->Keywords));
 
         $doc = $parent->ownerDocument;
 

--- a/src/SAML2/XML/mdui/Logo.php
+++ b/src/SAML2/XML/mdui/Logo.php
@@ -73,9 +73,9 @@ class Logo
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_int($this->width)');
-        assert('is_int($this->height)');
-        assert('is_string($this->url)');
+        assert(is_int($this->width));
+        assert(is_int($this->height));
+        assert(is_string($this->url));
 
         $doc = $parent->ownerDocument;
 

--- a/src/SAML2/XML/mdui/UIInfo.php
+++ b/src/SAML2/XML/mdui/UIInfo.php
@@ -104,12 +104,12 @@ class UIInfo
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_array($this->DisplayName)');
-        assert('is_array($this->InformationURL)');
-        assert('is_array($this->PrivacyStatementURL)');
-        assert('is_array($this->Keywords)');
-        assert('is_array($this->Logo)');
-        assert('is_array($this->children)');
+        assert(is_array($this->DisplayName));
+        assert(is_array($this->InformationURL));
+        assert(is_array($this->PrivacyStatementURL));
+        assert(is_array($this->Keywords));
+        assert(is_array($this->Logo));
+        assert(is_array($this->children));
 
         $e = null;
         if (!empty($this->DisplayName)

--- a/src/SAML2/XML/saml/Attribute.php
+++ b/src/SAML2/XML/saml/Attribute.php
@@ -83,12 +83,12 @@ class Attribute
      */
     protected function toXMLInternal(\DOMElement $parent, $namespace, $name)
     {
-        assert('is_string($namespace)');
-        assert('is_string($name)');
-        assert('is_string($this->Name)');
-        assert('is_null($this->NameFormat) || is_string($this->NameFormat)');
-        assert('is_null($this->FriendlyName) || is_string($this->FriendlyName)');
-        assert('is_array($this->AttributeValue)');
+        assert(is_string($namespace));
+        assert(is_string($name));
+        assert(is_string($this->Name));
+        assert(is_null($this->NameFormat) || is_string($this->NameFormat));
+        assert(is_null($this->FriendlyName) || is_string($this->FriendlyName));
+        assert(is_array($this->AttributeValue));
 
         $e = $parent->ownerDocument->createElementNS($namespace, $name);
         $parent->appendChild($e);

--- a/src/SAML2/XML/saml/AttributeValue.php
+++ b/src/SAML2/XML/saml/AttributeValue.php
@@ -30,7 +30,7 @@ class AttributeValue implements \Serializable
      */
     public function __construct($value)
     {
-        assert('is_string($value) || $value instanceof \DOMElement');
+        assert(is_string($value) || $value instanceof \DOMElement);
 
         if (is_string($value)) {
             $doc = DOMDocumentFactory::create();
@@ -64,8 +64,8 @@ class AttributeValue implements \Serializable
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('$this->element instanceof \DOMElement');
-        assert('$this->element->namespaceURI === \SAML2\Constants::NS_SAML && $this->element->localName === "AttributeValue"');
+        assert($this->element instanceof \DOMElement);
+        assert($this->element->namespaceURI === \SAML2\Constants::NS_SAML && $this->element->localName === "AttributeValue");
 
         $v = Utils::copyElement($this->element, $parent);
 
@@ -89,7 +89,7 @@ class AttributeValue implements \Serializable
      */
     public function __toString()
     {
-        assert('$this->element instanceof \DOMElement');
+        assert($this->element instanceof \DOMElement);
 
         $doc = $this->element->ownerDocument;
 

--- a/src/SAML2/XML/saml/BaseIDType.php
+++ b/src/SAML2/XML/saml/BaseIDType.php
@@ -75,8 +75,8 @@ abstract class BaseIDType
      */
     public function toXML(\DOMElement $parent = null)
     {
-        assert('is_string($this->NameQualifier) || is_null($this->NameQualifier)');
-        assert('is_string($this->SPNameQualifier) || is_null($this->SPNameQualifier)');
+        assert(is_string($this->NameQualifier) || is_null($this->NameQualifier));
+        assert(is_string($this->SPNameQualifier) || is_null($this->SPNameQualifier));
 
         if ($parent === null) {
             $parent = DOMDocumentFactory::create();

--- a/src/SAML2/XML/saml/NameIDType.php
+++ b/src/SAML2/XML/saml/NameIDType.php
@@ -117,9 +117,9 @@ abstract class NameIDType extends BaseIDType
      */
     public function toXML(\DOMElement $parent = null)
     {
-        assert('is_string($this->Format) || is_null($this->Format)');
-        assert('is_string($this->SPProvidedID) || is_null($this->SPProvidedID)');
-        assert('is_string($this->value)');
+        assert(is_string($this->Format) || is_null($this->Format));
+        assert(is_string($this->SPProvidedID) || is_null($this->SPProvidedID));
+        assert(is_string($this->value));
 
         $element = parent::toXML($parent);
 

--- a/src/SAML2/XML/saml/SubjectConfirmation.php
+++ b/src/SAML2/XML/saml/SubjectConfirmation.php
@@ -73,9 +73,9 @@ class SubjectConfirmation
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_string($this->Method)');
-        assert('is_null($this->NameID) || $this->NameID instanceof \SAML2\XML\saml\NameID');
-        assert('is_null($this->SubjectConfirmationData) || $this->SubjectConfirmationData instanceof SAML2\XML\saml\SubjectConfirmationData');
+        assert(is_string($this->Method));
+        assert(is_null($this->NameID) || $this->NameID instanceof \SAML2\XML\saml\NameID);
+        assert(is_null($this->SubjectConfirmationData) || $this->SubjectConfirmationData instanceof SAML2\XML\saml\SubjectConfirmationData);
 
         $e = $parent->ownerDocument->createElementNS(Constants::NS_SAML, 'saml:SubjectConfirmation');
         $parent->appendChild($e);

--- a/src/SAML2/XML/saml/SubjectConfirmationData.php
+++ b/src/SAML2/XML/saml/SubjectConfirmationData.php
@@ -113,11 +113,11 @@ class SubjectConfirmationData
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_null($this->NotBefore) || is_int($this->NotBefore)');
-        assert('is_null($this->NotOnOrAfter) || is_int($this->NotOnOrAfter)');
-        assert('is_null($this->Recipient) || is_string($this->Recipient)');
-        assert('is_null($this->InResponseTo) || is_string($this->InResponseTo)');
-        assert('is_null($this->Address) || is_string($this->Address)');
+        assert(is_null($this->NotBefore) || is_int($this->NotBefore));
+        assert(is_null($this->NotOnOrAfter) || is_int($this->NotOnOrAfter));
+        assert(is_null($this->Recipient) || is_string($this->Recipient));
+        assert(is_null($this->InResponseTo) || is_string($this->InResponseTo));
+        assert(is_null($this->Address) || is_string($this->Address));
 
         $e = $parent->ownerDocument->createElementNS(Constants::NS_SAML, 'saml:SubjectConfirmationData');
         $parent->appendChild($e);

--- a/src/SAML2/XML/shibmd/Scope.php
+++ b/src/SAML2/XML/shibmd/Scope.php
@@ -54,8 +54,8 @@ class Scope
      */
     public function toXML(\DOMElement $parent)
     {
-        assert('is_string($this->scope)');
-        assert('is_bool($this->regexp) || is_null($this->regexp)');
+        assert(is_string($this->scope));
+        assert(is_bool($this->regexp) || is_null($this->regexp));
 
         $doc = $parent->ownerDocument;
 


### PR DESCRIPTION
Hi,

I replaced calling assert with string parameter, related to #90.

Of course it will be nice use strict types in method signature, but it is long term work.