### PR TITLE
ECP - remove nonexistent class

### DIFF
--- a/src/SAML2/SOAP.php
+++ b/src/SAML2/SOAP.php
@@ -68,7 +68,7 @@ SOAP;
         header('Content-Type: text/xml', true);
 
         $xml = $this->getOutputToSend($message);
-        SAML2_Utils::getContainer()->debugMessage($xml, 'out');
+        Utils::getContainer()->debugMessage($xml, 'out');
         echo $xml;
 
         exit(0);


### PR DESCRIPTION
When processing SOAP / ECP requests, no assertion would be sent back to the ECP because of a PHP exception - 
```
Apr 17 20:08:15 simplesamlphp ERROR [8f823eba13] SimpleSAML_Error_Exception: Error 1 - Class 'SAML2\SAML2_Utils' not found
Apr 17 20:08:15 simplesamlphp ERROR [8f823eba13] Backtrace:
Apr 17 20:08:15 simplesamlphp ERROR [8f823eba13] 2 /opt/simplesamlphp/www/_include.php:58 (SimpleSAML_error_handler)
Apr 17 20:08:15 simplesamlphp ERROR [8f823eba13] 1 /opt/simplesamlphp/www/_include.php:26 (SimpleSAML_exception_handler)
Apr 17 20:08:15 simplesamlphp ERROR [8f823eba13] 0 [builtin] (N/A)
```

Changing SAML2_Utils to just Utils (like other areas of the source) fixes the error message as well as allows (latest) SSP to service the request fully. 