### PR TITLE
Fix broken handling of unsigned response with encrypted assertions

### DIFF
--- a/src/SAML2/Assertion/Processor.php
+++ b/src/SAML2/Assertion/Processor.php
@@ -101,7 +101,7 @@ class Processor
     }
 
     /**
-     * @param \SAML2\Utilities\ArrayCollection|array $assertions Collection of decrypted assertions
+     * @param \SAML2\Utilities\ArrayCollection $assertions Collection of decrypted assertions
      *
      * @return \SAML2\Utilities\ArrayCollection Collection of processed assertions
      */

--- a/src/SAML2/Assertion/Processor.php
+++ b/src/SAML2/Assertion/Processor.php
@@ -85,13 +85,35 @@ class Processor
 
 
     /**
+     * Decrypt assertions, or do nothing if assertions are already decrypted.
+     *
      * @param \SAML2\Utilities\ArrayCollection $assertions
+     * @return \SAML2\Utilities\ArrayCollection Collection of processed assertions
+     */
+    public function decryptAssertions(ArrayCollection $assertions)
+    {
+        $decrypted = new ArrayCollection();
+        foreach ($assertions->getIterator() as $assertion) {
+            $decrypted->add($this->decryptAssertion($assertion));
+        }
+
+        return $decrypted;
+    }
+
+    /**
+     * @param \SAML2\Utilities\ArrayCollection|array $assertions Collection of decrypted assertions
+     *
      * @return \SAML2\Utilities\ArrayCollection Collection of processed assertions
      */
     public function processAssertions(ArrayCollection $assertions) : ArrayCollection
     {
+        // BC compatibility, allow array argument.
+        if (is_array($assertions)) {
+            $assertions = new ArrayCollection($assertions);
+        }
+
         $processed = new ArrayCollection();
-        foreach ($assertions as $assertion) {
+        foreach ($assertions->getIterator() as $assertion) {
             $processed->add($this->process($assertion));
         }
 

--- a/src/SAML2/Assertion/Processor.php
+++ b/src/SAML2/Assertion/Processor.php
@@ -107,11 +107,6 @@ class Processor
      */
     public function processAssertions(ArrayCollection $assertions) : ArrayCollection
     {
-        // BC compatibility, allow array argument.
-        if (is_array($assertions)) {
-            $assertions = new ArrayCollection($assertions);
-        }
-
         $processed = new ArrayCollection();
         foreach ($assertions->getIterator() as $assertion) {
             $processed->add($this->process($assertion));

--- a/src/SAML2/Response/Processor.php
+++ b/src/SAML2/Response/Processor.php
@@ -152,6 +152,10 @@ class Processor
             throw new NoAssertionsFoundException('No assertions found in response from IdP.');
         }
 
+        $decryptedAssertions = $this->assertionProcessor->decryptAssertions(
+            new ArrayCollection($assertions)
+        );
+
         if (!$this->responseIsSigned) {
             foreach ($assertions as $assertion) {
                 if (!$assertion->wasSignedAtConstruction()) {
@@ -162,7 +166,6 @@ class Processor
             }
         }
 
-        $assertions = new ArrayCollection($assertions);
-        return $this->assertionProcessor->processAssertions($assertions);
+        return $this->assertionProcessor->processAssertions($decryptedAssertions);
     }
 }

--- a/tests/SAML2/Response/SignatureValidationTest.php
+++ b/tests/SAML2/Response/SignatureValidationTest.php
@@ -148,6 +148,8 @@ class SignatureValidationTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testThatAnUnsignedResponseWithNoSignedAssertionsThrowsAnException() : void
     {
+        $this->expectException(UnsignedResponseException::class);
+
         $assertion = \Mockery::mock('SAML2\Assertion');
 
         // The processAssertions is called to decrypt possible encrypted assertions,

--- a/tests/SAML2/Response/SignatureValidationTest.php
+++ b/tests/SAML2/Response/SignatureValidationTest.php
@@ -139,6 +139,8 @@ class SignatureValidationTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
             $this->getSignedResponseWithSignedAssertion()
         );
     }
+
+
     /**
      * @runInSeparateProcess
      * @preserveGlobalState disabled
@@ -146,15 +148,7 @@ class SignatureValidationTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testThatAnUnsignedResponseWithNoSignedAssertionsThrowsAnException() : void
     {
-        $this->expectException(UnsignedResponseException::class);
-
-        // here the processAssertions may not be called as it should fail with an exception due to having no signature
-        $this->assertionProcessor->shouldReceive('processAssertions')->never();
-
         $assertion = \Mockery::mock('SAML2\Assertion');
-        $assertion->shouldReceive('wasSignedAtConstruction')
-            ->once()
-            ->andReturn(false);
 
         // The processAssertions is called to decrypt possible encrypted assertions,
         // after which it should fail with an exception due to having no signature

--- a/tests/SAML2/Response/SignatureValidationTest.php
+++ b/tests/SAML2/Response/SignatureValidationTest.php
@@ -156,8 +156,6 @@ class SignatureValidationTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
             ->once()
             ->andReturn(false);
 
-        $assertion = \Mockery::mock('SAML2\Assertion');
-
         // The processAssertions is called to decrypt possible encrypted assertions,
         // after which it should fail with an exception due to having no signature
         $this->assertionProcessor->shouldReceive('decryptAssertions')

--- a/tests/SAML2/Response/SignatureValidationTest.php
+++ b/tests/SAML2/Response/SignatureValidationTest.php
@@ -10,6 +10,7 @@ use SAML2\Configuration\Destination;
 use SAML2\Configuration\IdentityProvider;
 use SAML2\Configuration\ServiceProvider;
 use SAML2\Response;
+use SAML2\Utilities\ArrayCollection;
 use SAML2\Utilities\Certificate;
 use SAML2\Response\Exception\UnsignedResponseException;
 
@@ -75,9 +76,13 @@ class SignatureValidationTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testThatAnUnsignedResponseWithASignedAssertionCanBeProcessed() : void
     {
+        $this->assertionProcessor->shouldReceive('decryptAssertions')
+            ->once()
+            ->andReturn(new ArrayCollection());
+
         $this->assertionProcessor->shouldReceive('processAssertions')->once();
 
-        $processor = new Response\Processor(new \Psr\Log\NullLogger());
+        $processor = new Processor(new \Psr\Log\NullLogger());
 
         $processor->process(
             $this->serviceProviderConfiguration,
@@ -95,6 +100,10 @@ class SignatureValidationTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testThatAnSignedResponseWithAnUnsignedAssertionCanBeProcessed() : void
     {
+        $this->assertionProcessor->shouldReceive('decryptAssertions')
+            ->once()
+            ->andReturn(new ArrayCollection());
+
         $this->assertionProcessor->shouldReceive('processAssertions')->once();
 
         $processor = new Response\Processor(new \Psr\Log\NullLogger());
@@ -115,6 +124,10 @@ class SignatureValidationTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testThatASignedResponseWithASignedAssertionIsValid() : void
     {
+        $this->assertionProcessor->shouldReceive('decryptAssertions')
+            ->once()
+            ->andReturn(new ArrayCollection());
+
         $this->assertionProcessor->shouldReceive('processAssertions')->once();
 
         $processor = new Response\Processor(new \Psr\Log\NullLogger());
@@ -126,8 +139,6 @@ class SignatureValidationTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
             $this->getSignedResponseWithSignedAssertion()
         );
     }
-
-
     /**
      * @runInSeparateProcess
      * @preserveGlobalState disabled
@@ -140,10 +151,26 @@ class SignatureValidationTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         // here the processAssertions may not be called as it should fail with an exception due to having no signature
         $this->assertionProcessor->shouldReceive('processAssertions')->never();
 
-        $processor = new Response\Processor(new \Psr\Log\NullLogger());
+        $assertion = \Mockery::mock('SAML2\Assertion');
+        $assertion->shouldReceive('getWasSignedAtConstruction')
+            ->once()
+            ->andReturn(false);
+
+        $assertion = \Mockery::mock('SAML2\Assertion');
+
+        // The processAssertions is called to decrypt possible encrypted assertions,
+        // after which it should fail with an exception due to having no signature
+        $this->assertionProcessor->shouldReceive('decryptAssertions')
+            ->once()
+            ->andReturn(new ArrayCollection([
+                $assertion
+            ]));
+
+        $processor = new Processor(new \Psr\Log\NullLogger());
+
         $processor->process(
-            new ServiceProvider([]),
-            new IdentityProvider([]),
+            $this->serviceProviderConfiguration,
+            $this->identityProviderConfiguration,
             new Destination($this->currentDestination),
             $this->getUnsignedResponseWithUnsignedAssertion()
         );

--- a/tests/SAML2/Response/SignatureValidationTest.php
+++ b/tests/SAML2/Response/SignatureValidationTest.php
@@ -152,7 +152,7 @@ class SignatureValidationTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $this->assertionProcessor->shouldReceive('processAssertions')->never();
 
         $assertion = \Mockery::mock('SAML2\Assertion');
-        $assertion->shouldReceive('getWasSignedAtConstruction')
+        $assertion->shouldReceive('wasSignedAtConstruction')
             ->once()
             ->andReturn(false);
 


### PR DESCRIPTION
The response processor currently assumes all assertions are decrypted,
and causes a fatal error when the response is unsigned:

    Call to undefined method SAML2\EncryptedAssertion::getWasSignedAtConstruction()

Whether the assertion is signed can only be determined after
decryption. This fix decrypts the assertions before checking if
the response or assertion is signed. In order to do this I had
to separate the verification from decryption in the assertion
processor.