### PR TITLE
Fix dependency conflict with simplesamlphp/simplesamlphp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-dom": "*",
         "ext-zlib": "*",
 
-        "robrichards/xmlseclibs": "^3.0",
+        "robrichards/xmlseclibs": "dev-master#93f8c07976b36b6050ab341ab5850484dc897ce0 as 3.0.2",
         "psr/log": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
There is a discussion in https://github.com/simplesamlphp/simplesamlphp/issues/925 about the dependency conflicts when installing simplesamlphp via composer. It suggests to use the dev-master commit directly. After merging, a new version should be tagged, so that simplesamlphp can reference it.