### PR TITLE
Add PasswordProtectedTransport to constants

### DIFF
--- a/src/SAML2/Constants.php
+++ b/src/SAML2/Constants.php
@@ -15,6 +15,11 @@ class Constants
     const AC_PASSWORD = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password';
 
     /**
+     * PasswordProtectedTransport authentication context.
+     */
+    const AC_PASSWORD_PROTECTED_TRANSPORT = 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport';
+
+    /**
      * Unspecified authentication context.
      */
     const AC_UNSPECIFIED = 'urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified';


### PR DESCRIPTION
As mentioned in SSP [PR#937](https://github.com/simplesamlphp/simplesamlphp/pull/937), it may be useful to automatically select `PasswordProtectedTransport` based on a secure transport.