### PR TITLE
Fix Psalm-issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ php:
 matrix:
   fast_finish: true
   allow_failures:
-    - php: 7.3
     - php: hhvm
 
 before_script:

--- a/psalm.xml
+++ b/psalm.xml
@@ -3,6 +3,7 @@
   name="SimpleSAMLphp"
   useDocblockTypes="true"
   totallyTyped="false"
+  hideExternalErrors="true"
 >
   <projectFiles>
     <directory name="src/SAML2" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,31 +1,30 @@
 <?xml version="1.0"?>
 <psalm
-    name="SimpleSAMLphp"
-    useDocblockTypes="true"
-    totallyTyped="false"
+  name="SimpleSAMLphp"
+  useDocblockTypes="true"
+  totallyTyped="false"
 >
-    <projectFiles>
-        <directory name="src/SAML2" />
-    </projectFiles>
+  <projectFiles>
+    <directory name="src/SAML2" />
+  </projectFiles>
 
-    <issueHandlers>
-        <LessSpecificReturnType errorLevel="info" />
+  <issueHandlers>
+    <LessSpecificReturnType errorLevel="info" />
 
-        <!-- level 3 issues - slightly lazy code writing, but probably low false-negatives -->
-        <DeprecatedMethod errorLevel="info" />
+    <!-- level 3 issues - slightly lazy code writing, but probably low false-negatives -->
+    <DeprecatedMethod errorLevel="info" />
 
-        <MissingClosureReturnType errorLevel="info" />
-        <MissingReturnType errorLevel="info" />
-        <MissingPropertyType errorLevel="info" />
-        <InvalidDocblock errorLevel="info" />
-        <MisplacedRequiredParam errorLevel="info" />
+    <MissingClosureReturnType errorLevel="info" />
+    <MissingReturnType errorLevel="info" />
+    <MissingPropertyType errorLevel="info" />
+    <InvalidDocblock errorLevel="info" />
+    <MisplacedRequiredParam errorLevel="info" />
 
-        <PropertyNotSetInConstructor errorLevel="info" />
-        <MissingConstructor errorLevel="info" />
-        <MissingClosureParamType errorLevel="info" />
-        <MissingParamType errorLevel="info" />
-        <UnusedClass errorLevel="info" />
-        <PossiblyUnusedMethod errorLevel="info" />
-    </issueHandlers>
+    <PropertyNotSetInConstructor errorLevel="info" />
+    <MissingConstructor errorLevel="info" />
+    <MissingClosureParamType errorLevel="info" />
+    <MissingParamType errorLevel="info" />
+    <UnusedClass errorLevel="info" />
+    <PossiblyUnusedMethod errorLevel="info" />
+  </issueHandlers>
 </psalm>
-

--- a/psalm.xml
+++ b/psalm.xml
@@ -26,5 +26,7 @@
     <MissingParamType errorLevel="info" />
     <UnusedClass errorLevel="info" />
     <PossiblyUnusedMethod errorLevel="info" />
+    <PropertyNotSetInConstructor errorLevel="suppress" />
+    <MissingClosureReturnType errorLevel="suppress" />
   </issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,6 +7,9 @@
 >
   <projectFiles>
     <directory name="src/SAML2" />
+    <ignoreFiles>
+      <directory name="vendor" />
+    </ignoreFiles>
   </projectFiles>
 
   <issueHandlers>

--- a/src/SAML2/ArtifactResolve.php
+++ b/src/SAML2/ArtifactResolve.php
@@ -14,6 +14,7 @@ namespace SAML2;
  */
 class ArtifactResolve extends Request
 {
+    /** @var string */
     private $artifact;
 
 

--- a/src/SAML2/ArtifactResponse.php
+++ b/src/SAML2/ArtifactResponse.php
@@ -35,7 +35,7 @@ class ArtifactResponse extends StatusResponse
             $status = Utils::xpQuery($xml, './saml_protocol:Status');
             $status = $status[0];
 
-            for ($any = $status->nextSibling; $any !== null; $any = $any->nextSibling) {
+            for ($any = $status->nextSibling; $any instanceof \DOMNode; $any = $any->nextSibling) {
                 if ($any instanceof \DOMElement) {
                     $this->any = $any;
                     break;

--- a/src/SAML2/ArtifactResponse.php
+++ b/src/SAML2/ArtifactResponse.php
@@ -35,6 +35,7 @@ class ArtifactResponse extends StatusResponse
             $status = Utils::xpQuery($xml, './saml_protocol:Status');
             $status = $status[0];
 
+            /** @psalm-suppress RedundantCondition */
             for ($any = $status->nextSibling; $any instanceof \DOMNode; $any = $any->nextSibling) {
                 if ($any instanceof \DOMElement) {
                     $this->any = $any;

--- a/src/SAML2/Assertion.php
+++ b/src/SAML2/Assertion.php
@@ -817,7 +817,10 @@ class Assertion extends SignedElement
         $symmetricKey->generateSessionKey();
         $enc->encryptKey($key, $symmetricKey);
 
-        /** @var \DOMElement encryptedNameId */
+        /**
+         * @var \DOMElement encryptedNameId
+         * @psalm-suppress UndefinedClass
+         */
         $this->encryptedNameId = $enc->encryptNode($symmetricKey);
         $this->nameId = null;
     }
@@ -1804,10 +1807,12 @@ class Assertion extends SignedElement
             $symmetricKey->generateSessionKey();
             /** @psalm-suppress PossiblyNullArgument */
             $EncAssert->encryptKey($this->encryptionKey, $symmetricKey);
+            /** @psalm-suppress UndefinedClass */
             $EncrNode = $EncAssert->encryptNode($symmetricKey);
 
             $EncAttribute = $document->createElementNS(Constants::NS_SAML, 'saml:EncryptedAttribute');
             $attributeStatement->appendChild($EncAttribute);
+            /** @psalm-suppress InvalidArgument */
             $n = $document->importNode($EncrNode, true);
             $EncAttribute->appendChild($n);
         }

--- a/src/SAML2/Assertion.php
+++ b/src/SAML2/Assertion.php
@@ -661,7 +661,7 @@ class Assertion implements SignedElement
         /* Validate the signature element of the message. */
         $sig = Utils::validateElement($xml);
         if ($sig !== false) {
-            $this->setWasSignedAtConstruction(true);
+            $this->wasSignedAtConstruction = true;
             $this->setCertificates($sig['Certificates']);
             $this->setSignatureData($sig);
             $this->setSignatureMethod($signatureMethod[0]->value);
@@ -1465,19 +1465,9 @@ class Assertion implements SignedElement
     /**
      * @return bool
      */
-    public function getWasSignedAtConstruction() : bool
+    public function wasSignedAtConstruction() : bool
     {
         return $this->wasSignedAtConstruction;
-    }
-
-
-    /**
-     * @param bool $flag
-     * @return void
-     */
-    public function setWasSignedAtConstruction(bool $flag)
-    {
-        $this->wasSignedAtConstruction = $flag;
     }
 
 

--- a/src/SAML2/Assertion.php
+++ b/src/SAML2/Assertion.php
@@ -152,7 +152,7 @@ class Assertion implements SignedElement
      *
      * @var string
      */
-    private $authnContextDeclRef;
+    private $authnContextDeclRef = null;
 
     /**
      * The list of AuthenticatingAuthorities for this assertion.
@@ -240,7 +240,7 @@ class Assertion implements SignedElement
     /**
      * The SubjectConfirmation elements of the Subject in the assertion.
      *
-     * @var \SAML2\XML\saml\SubjectConfirmation[].
+     * @var \SAML2\XML\saml\SubjectConfirmation[]
      */
     private $SubjectConfirmation;
 
@@ -863,6 +863,7 @@ class Assertion implements SignedElement
      *
      * @param XMLSecurityKey $key
      * @param array $blacklist
+     * @return void
      * @throws \Exception
      * @return void
      */
@@ -1149,6 +1150,7 @@ class Assertion implements SignedElement
      * Set the authentication context declaration.
      *
      * @param \SAML2\XML\Chunk $authnContextDecl
+     * @return void
      * @throws \Exception
      * @return void
      */
@@ -1225,7 +1227,7 @@ class Assertion implements SignedElement
     /**
      * Set the AuthenticatingAuthority
      *
-     * @param array
+     * @param array $authenticatingAuthority
      * @return void
      */
     public function setAuthenticatingAuthority(array $authenticatingAuthority)

--- a/src/SAML2/Assertion.php
+++ b/src/SAML2/Assertion.php
@@ -80,7 +80,7 @@ class Assertion extends SignedElement
      */
     private $encryptionKey;
 
-     /**
+    /**
      * The earliest time this assertion is valid, as an UNIX timestamp.
      *
      * @var int|null

--- a/src/SAML2/Assertion.php
+++ b/src/SAML2/Assertion.php
@@ -20,7 +20,7 @@ use SAML2\XML\saml\SubjectConfirmation;
  *
  * @package SimpleSAMLphp
  */
-class Assertion implements SignedElement
+class Assertion extends SignedElement
 {
     /**
      * The identifier of this assertion.
@@ -213,14 +213,14 @@ class Assertion implements SignedElement
      *
      * @var XMLSecurityKey|null
      */
-    private $signatureKey;
+    protected $signatureKey;
 
     /**
      * List of certificates that should be included in the assertion.
      *
      * @var array
      */
-    private $certificates;
+    protected $certificates;
 
     /**
      * The data needed to verify the signature.

--- a/src/SAML2/Assertion/Processor.php
+++ b/src/SAML2/Assertion/Processor.php
@@ -106,7 +106,7 @@ class Processor
     {
         $assertion = $this->decryptAssertion($assertion);
 
-        if (!$assertion->getWasSignedAtConstruction()) {
+        if (!$assertion->wasSignedAtConstruction()) {
             $this->logger->info(sprintf(
                 'Assertion with id "%s" was not signed at construction, not verifying the signature',
                 $assertion->getId()

--- a/src/SAML2/Assertion/Transformer/NameIdDecryptionTransformer.php
+++ b/src/SAML2/Assertion/Transformer/NameIdDecryptionTransformer.php
@@ -13,7 +13,7 @@ use SAML2\Configuration\IdentityProviderAware;
 use SAML2\Configuration\ServiceProvider;
 use SAML2\Configuration\ServiceProviderAware;
 
-class NameIdDecryptionTransformer implements
+final class NameIdDecryptionTransformer implements
     Transformer,
     IdentityProviderAware,
     ServiceProviderAware
@@ -56,6 +56,8 @@ class NameIdDecryptionTransformer implements
 
     /**
      * @param Assertion $assertion
+     *
+     * @throws \Exception
      * @return Assertion
      */
     public function transform(Assertion $assertion) : Assertion

--- a/src/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationMethod.php
+++ b/src/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationMethod.php
@@ -20,7 +20,7 @@ final class SubjectConfirmationMethod implements SubjectConfirmationConstraintVa
         SubjectConfirmation $subjectConfirmation,
         Result $result
     ) {
-        if ($subjectConfirmation->Method !== Constants::CM_BEARER) {
+        if ($subjectConfirmation->getMethod() !== Constants::CM_BEARER) {
             $result->addError(sprintf(
                 'Invalid Method on SubjectConfirmation, current;y only Bearer (%s) is supported',
                 Constants::CM_BEARER

--- a/src/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationMethod.php
+++ b/src/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationMethod.php
@@ -9,8 +9,7 @@ use SAML2\Assertion\Validation\SubjectConfirmationConstraintValidator;
 use SAML2\Constants;
 use SAML2\XML\saml\SubjectConfirmation;
 
-class SubjectConfirmationMethod implements
-    SubjectConfirmationConstraintValidator
+final class SubjectConfirmationMethod implements SubjectConfirmationConstraintValidator
 {
     /**
      * @param SubjectConfirmation $subjectConfirmation

--- a/src/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationNotBefore.php
+++ b/src/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationNotBefore.php
@@ -8,6 +8,7 @@ use SAML2\Assertion\Validation\Result;
 use SAML2\Assertion\Validation\SubjectConfirmationConstraintValidator;
 use SAML2\Utilities\Temporal;
 use SAML2\XML\saml\SubjectConfirmation;
+use Webmozart\Assert\Assert;
 
 class SubjectConfirmationNotBefore implements
     SubjectConfirmationConstraintValidator
@@ -21,7 +22,11 @@ class SubjectConfirmationNotBefore implements
         SubjectConfirmation $subjectConfirmation,
         Result $result
     ) {
-        $notBefore = $subjectConfirmation->getSubjectConfirmationData()->getNotBefore();
+        $data = $subjectConfirmation->getSubjectConfirmationData();
+        Assert::notNull($data);
+
+        /** @psalm-suppress PossiblyNullReference */
+        $notBefore = $data->getNotBefore();
         if ($notBefore && $notBefore > Temporal::getTime() + 60) {
             $result->addError('NotBefore in SubjectConfirmationData is in the future');
         }

--- a/src/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationNotOnOrAfter.php
+++ b/src/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationNotOnOrAfter.php
@@ -8,6 +8,7 @@ use SAML2\Assertion\Validation\Result;
 use SAML2\Assertion\Validation\SubjectConfirmationConstraintValidator;
 use SAML2\Utilities\Temporal;
 use SAML2\XML\saml\SubjectConfirmation;
+use Webmozart\Assert\Assert;
 
 class SubjectConfirmationNotOnOrAfter implements
     SubjectConfirmationConstraintValidator
@@ -21,7 +22,11 @@ class SubjectConfirmationNotOnOrAfter implements
         SubjectConfirmation $subjectConfirmation,
         Result $result
     ) {
-        $notOnOrAfter = $subjectConfirmation->getSubjectConfirmationData()->getNotOnOrAfter();
+        $data = $subjectConfirmation->getSubjectConfirmationData();
+        Assert::notNull($data);
+
+        /** @psalm-suppress PossiblyNullReference */
+        $notOnOrAfter = $data->getNotOnOrAfter();
         if ($notOnOrAfter && $notOnOrAfter <= Temporal::getTime() - 60) {
             $result->addError('NotOnOrAfter in SubjectConfirmationData is in the past');
         }

--- a/src/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationRecipientMatches.php
+++ b/src/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationRecipientMatches.php
@@ -8,6 +8,7 @@ use SAML2\Assertion\Validation\Result;
 use SAML2\Assertion\Validation\SubjectConfirmationConstraintValidator;
 use SAML2\Configuration\Destination;
 use SAML2\XML\saml\SubjectConfirmation;
+use Webmozart\Assert\Assert;
 
 class SubjectConfirmationRecipientMatches implements
     SubjectConfirmationConstraintValidator
@@ -29,15 +30,17 @@ class SubjectConfirmationRecipientMatches implements
 
 
     /**
-     * @param SubjectConfirmation
+     * @param SubjectConfirmation $subjectConfirmation
      * @param Result $result
      * @return void
      */
-    public function validate(
-        SubjectConfirmation $subjectConfirmation,
-        Result $result
-    ) {
-        $recipient = $subjectConfirmation->getSubjectConfirmationData()->getRecipient();
+    public function validate(SubjectConfirmation $subjectConfirmation, Result $result)
+    {
+        $data = $subjectConfirmation->getSubjectConfirmationData();
+        Assert::notNull($data);
+
+        /** @psalm-suppress PossiblyNullReference */
+        $recipient = $data->getRecipient();
         if ($recipient && !$this->destination->equals(new Destination($recipient))) {
             $result->addError(sprintf(
                 'Recipient in SubjectConfirmationData ("%s") does not match the current destination ("%s")',

--- a/src/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationResponseToMatches.php
+++ b/src/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationResponseToMatches.php
@@ -8,6 +8,7 @@ use SAML2\Assertion\Validation\Result;
 use SAML2\Assertion\Validation\SubjectConfirmationConstraintValidator;
 use SAML2\Response;
 use SAML2\XML\saml\SubjectConfirmation;
+use Webmozart\Assert\Assert;
 
 class SubjectConfirmationResponseToMatches implements
     SubjectConfirmationConstraintValidator
@@ -27,15 +28,17 @@ class SubjectConfirmationResponseToMatches implements
 
 
     /**
-     * @param \SAML2\XML\saml\SubjectConfirmation
+     * @param \SAML2\XML\saml\SubjectConfirmation $subjectConfirmation
      * @param Result $result
      * @return void
      */
-    public function validate(
-        SubjectConfirmation $subjectConfirmation,
-        Result $result
-    ) {
-        $inResponseTo = $subjectConfirmation->getSubjectConfirmationData()->getInResponseTo();
+    public function validate(SubjectConfirmation $subjectConfirmation, Result $result)
+    {
+        $data = $subjectConfirmation->getSubjectConfirmationData();
+        Assert::notNull($data);
+
+        /** @psalm-suppress PossiblyNullReference */
+        $inResponseTo = $data->getInResponseTo();
         if ($inResponseTo && ($this->getInResponseTo() !== false) && ($this->getInResponseTo() !== $inResponseTo)) {
             $result->addError(sprintf(
                 'InResponseTo in SubjectConfirmationData ("%s") does not match the Response InResponseTo ("%s")',

--- a/src/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationResponseToMatches.php
+++ b/src/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationResponseToMatches.php
@@ -27,7 +27,7 @@ class SubjectConfirmationResponseToMatches implements
 
 
     /**
-     * @param SubjectConfirmation
+     * @param \SAML2\XML\saml\SubjectConfirmation
      * @param Result $result
      * @return void
      */

--- a/src/SAML2/AttributeQuery.php
+++ b/src/SAML2/AttributeQuery.php
@@ -26,7 +26,7 @@ class AttributeQuery extends SubjectQuery
      *
      * @var array
      */
-    private $attributes;
+    private $attributes = [];
 
     /**
      * The NameFormat used on all attributes.
@@ -57,6 +57,7 @@ class AttributeQuery extends SubjectQuery
         }
 
         $firstAttribute = true;
+        /** @var \DOMElement[] $attributes */
         $attributes = Utils::xpQuery($xml, './saml_assertion:Attribute');
         foreach ($attributes as $attribute) {
             if (!$attribute->hasAttribute('Name')) {
@@ -167,7 +168,12 @@ class AttributeQuery extends SubjectQuery
                     $type = null;
                 }
 
-                $attributeValue = Utils::addString($attribute, Constants::NS_SAML, 'saml:AttributeValue', strval($value));
+                $attributeValue = Utils::addString(
+                    $attribute,
+                    Constants::NS_SAML,
+                    'saml:AttributeValue',
+                    strval($value)
+                );
                 if ($type !== null) {
                     $attributeValue->setAttributeNS(Constants::NS_XSI, 'xsi:type', $type);
                 }

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -722,7 +722,10 @@ class AuthnRequest extends Request
         $symmetricKey->generateSessionKey();
         $enc->encryptKey($key, $symmetricKey);
 
-        /** @var \DOMElement encryptedNameId */
+        /**
+         * @var \DOMElement encryptedNameId
+         * @psalm-suppress UndefinedClass
+         */
         $this->encryptedNameId = $enc->encryptNode($symmetricKey);
         $this->nameId = null;
     }

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -9,6 +9,7 @@ use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 use SAML2\XML\saml\SubjectConfirmation;
 use SAML2\Exception\InvalidArgumentException;
+use Webmozart\Assert\Assert;
 
 /**
  * Class for SAML 2 authentication request messages.
@@ -22,28 +23,28 @@ class AuthnRequest extends Request
      *
      * @var array
      */
-    private $nameIdPolicy;
+    private $nameIdPolicy = [];
 
     /**
      * Whether the Identity Provider must authenticate the user again.
      *
      * @var bool
      */
-    private $forceAuthn;
+    private $forceAuthn = false;
 
     /**
      * Optional ProviderID attribute
      *
-     * @var string
+     * @var string|null
      */
-    private $ProviderName;
+    private $ProviderName = null;
 
     /**
      * Set to true if this request is passive.
      *
      * @var bool
      */
-    private $isPassive;
+    private $isPassive = false;
 
     /**
      * The list of providerIDs in this request's scoping element
@@ -55,7 +56,7 @@ class AuthnRequest extends Request
     /**
      * The ProxyCount in this request's scoping element
      *
-     * @var int
+     * @var int|null
      */
     private $ProxyCount = null;
 
@@ -119,14 +120,14 @@ class AuthnRequest extends Request
     private $subjectConfirmation = [];
 
     /**
-     * @var string
+     * @var \DOMElement|null
      */
-    private $encryptedNameId;
+    private $encryptedNameId = null;
 
     /**
-     * @var \SAML2\XML\saml\NameID
+     * @var \SAML2\XML\saml\NameID|null
      */
-    private $nameId;
+    private $nameId = null;
 
 
     /**
@@ -138,10 +139,6 @@ class AuthnRequest extends Request
     public function __construct(\DOMElement $xml = null)
     {
         parent::__construct('AuthnRequest', $xml);
-
-        $this->nameIdPolicy = [];
-        $this->forceAuthn = false;
-        $this->isPassive = false;
 
         if ($xml === null) {
             return;
@@ -185,6 +182,7 @@ class AuthnRequest extends Request
      */
     private function parseSubject(\DOMElement $xml)
     {
+        /** @var \DOMElement[] $subject */
         $subject = Utils::xpQuery($xml, './saml_assertion:Subject');
         if (empty($subject)) {
             return;
@@ -195,6 +193,7 @@ class AuthnRequest extends Request
         }
         $subject = $subject[0];
 
+        /** @var \DOMElement[] $nameId */
         $nameId = Utils::xpQuery(
             $subject,
             './saml_assertion:NameID | ./saml_assertion:EncryptedID/xenc:EncryptedData'
@@ -205,13 +204,13 @@ class AuthnRequest extends Request
             throw new \Exception('More than one <saml:NameID> or <saml:EncryptedID> in <saml:Subject>.');
         }
         $nameId = $nameId[0];
-        if ($nameId->localName === 'EncryptedData') {
-            /* The NameID element is encrypted. */
+        if ($nameId->localName === 'EncryptedData') { // the NameID element is encrypted
             $this->encryptedNameId = $nameId;
         } else {
             $this->nameId = new XML\saml\NameID($nameId);
         }
 
+        /** @var \DOMElement[] $subjectConfirmation */
         $subjectConfirmation = Utils::xpQuery($subject, './saml_assertion:SubjectConfirmation');
         foreach ($subjectConfirmation as $sc) {
             $this->subjectConfirmation[] = new SubjectConfirmation($sc);
@@ -226,6 +225,7 @@ class AuthnRequest extends Request
      */
     protected function parseNameIdPolicy(\DOMElement $xml)
     {
+        /** @var \DOMElement[] $nameIdPolicy */
         $nameIdPolicy = Utils::xpQuery($xml, './saml_protocol:NameIDPolicy');
         if (empty($nameIdPolicy)) {
             return;
@@ -250,6 +250,7 @@ class AuthnRequest extends Request
      */
     protected function parseRequestedAuthnContext(\DOMElement $xml)
     {
+        /** @var \DOMElement[] $requestedAuthnContext */
         $requestedAuthnContext = Utils::xpQuery($xml, './saml_protocol:RequestedAuthnContext');
         if (empty($requestedAuthnContext)) {
             return;
@@ -262,6 +263,7 @@ class AuthnRequest extends Request
             'Comparison'           => Constants::COMPARISON_EXACT,
         ];
 
+        /** @var \DOMElement[] $accr */
         $accr = Utils::xpQuery($requestedAuthnContext, './saml_assertion:AuthnContextClassRef');
         foreach ($accr as $i) {
             $rac['AuthnContextClassRef'][] = trim($i->textContent);
@@ -282,6 +284,7 @@ class AuthnRequest extends Request
      */
     protected function parseScoping(\DOMElement $xml)
     {
+        /** @var \DOMElement[] $scoping */
         $scoping = Utils::xpQuery($xml, './saml_protocol:Scoping');
         if (empty($scoping)) {
             return;
@@ -292,6 +295,7 @@ class AuthnRequest extends Request
         if ($scoping->hasAttribute('ProxyCount')) {
             $this->ProxyCount = (int) $scoping->getAttribute('ProxyCount');
         }
+        /** @var \DOMElement[] $idpEntries */
         $idpEntries = Utils::xpQuery($scoping, './saml_protocol:IDPList/saml_protocol:IDPEntry');
 
         foreach ($idpEntries as $idpEntry) {
@@ -301,6 +305,7 @@ class AuthnRequest extends Request
             $this->IDPList[] = $idpEntry->getAttribute('ProviderID');
         }
 
+        /** @var \DOMElement[] $requesterIDs */
         $requesterIDs = Utils::xpQuery($scoping, './saml_protocol:RequesterID');
         foreach ($requesterIDs as $requesterID) {
             $this->RequesterID[] = trim($requesterID->textContent);
@@ -314,18 +319,21 @@ class AuthnRequest extends Request
      */
     protected function parseConditions(\DOMElement $xml)
     {
+        /** @var \DOMElement[] $conditions */
         $conditions = Utils::xpQuery($xml, './saml_assertion:Conditions');
         if (empty($conditions)) {
             return;
         }
         $conditions = $conditions[0];
 
+        /** @var \DOMElement[] $ar */
         $ar = Utils::xpQuery($conditions, './saml_assertion:AudienceRestriction');
         if (empty($ar)) {
             return;
         }
         $ar = $ar[0];
 
+        /** @var \DOMElement[] $audiences */
         $audiences = Utils::xpQuery($ar, './saml_assertion:Audience');
         $this->audiences = array();
         foreach ($audiences as $a) {
@@ -399,9 +407,9 @@ class AuthnRequest extends Request
     /**
      * Retrieve the value of the ProviderName attribute.
      *
-     * @return string The ProviderName attribute.
+     * @return string|null The ProviderName attribute.
      */
-    public function getProviderName() : string
+    public function getProviderName()
     {
         return $this->ProviderName;
     }
@@ -458,7 +466,7 @@ class AuthnRequest extends Request
      * Set the audiences to send in the request.
      * This may be null, in which case no audience will be sent.
      *
-     * @param array|null $audiences The audiences.
+     * @param array $audiences The audiences.
      * @return void
      */
     public function setAudiences(array $audiences)
@@ -690,11 +698,15 @@ class AuthnRequest extends Request
      */
     public function encryptNameId(XMLSecurityKey $key)
     {
+        Assert::notNull($this->nameId, 'Cannot encrypt NameID if no NameID has been set.');
+
         /* First create a XML representation of the NameID. */
         $doc  = new \DOMDocument();
         $root = $doc->createElement('root');
         $doc->appendChild($root);
+        /** @psalm-suppress PossiblyNullReference */
         $this->nameId->toXML($root);
+        /** @var \DOMElement $nameId */
         $nameId = $root->firstChild;
 
         Utils::getContainer()->debugMessage($nameId, 'encrypt');
@@ -710,6 +722,7 @@ class AuthnRequest extends Request
         $symmetricKey->generateSessionKey();
         $enc->encryptKey($key, $symmetricKey);
 
+        /** @var \DOMElement encryptedNameId */
         $this->encryptedNameId = $enc->encryptNode($symmetricKey);
         $this->nameId = null;
     }

--- a/src/SAML2/Binding.php
+++ b/src/SAML2/Binding.php
@@ -15,8 +15,10 @@ abstract class Binding
      * The destination of messages.
      *
      * This can be null, in which case the destination in the message is used.
+     * @var string|null
      */
-    protected $destination;
+    protected $destination = null;
+
 
 
     /**
@@ -110,7 +112,7 @@ abstract class Binding
     /**
      * Retrieve the destination of a message.
      *
-     * @return string|null $destination  The destination the message will be delivered to.
+     * @return string|null $destination The destination the message will be delivered to.
      */
     public function getDestination()
     {

--- a/src/SAML2/Certificate/Exception/InvalidKeyUsageException.php
+++ b/src/SAML2/Certificate/Exception/InvalidKeyUsageException.php
@@ -20,7 +20,7 @@ class InvalidKeyUsageException extends \InvalidArgumentException implements
     {
         $message = sprintf(
             'Invalid key usage given: "%s", usages "%s" allowed',
-            is_string($usage) ? $usage : gettype($usage),
+            $usage,
             implode('", "', Key::getValidKeyUsages())
         );
 

--- a/src/SAML2/Certificate/KeyCollection.php
+++ b/src/SAML2/Certificate/KeyCollection.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace SAML2\Certificate;
 
-use SAML2\Exception\InvalidArgumentException;
 use SAML2\Utilities\ArrayCollection;
+use Webmozart\Assert\Assert;
 
 /**
  * Simple collection object for transporting keys
@@ -15,6 +15,7 @@ class KeyCollection extends ArrayCollection
     /**
      * Add a key to the collection
      *
+     * @psalm-suppress MoreSpecificImplementedParamType
      * @param \SAML2\Certificate\Key $key
      * @return void
      *
@@ -22,12 +23,7 @@ class KeyCollection extends ArrayCollection
      */
     public function add($key)
     {
-        if (!($key instanceof Key)) {
-            throw InvalidArgumentException::invalidType(
-                'SAML2\Certificate\Key',
-                $key
-            );
-        }
+        Assert::isInstanceOf($key, Key::class);
         parent::add($key);
     }
 }

--- a/src/SAML2/Certificate/KeyLoader.php
+++ b/src/SAML2/Certificate/KeyLoader.php
@@ -54,8 +54,8 @@ class KeyLoader
 
     /**
      * @param \SAML2\Configuration\CertificateProvider $config
-     * @param null|string                             $usage
-     * @param bool                                    $required
+     * @param null|string $usage
+     * @param bool $required
      * @return \SAML2\Certificate\KeyCollection
      */
     public function loadKeysFromConfiguration(
@@ -90,11 +90,11 @@ class KeyLoader
      * Loads the keys given, optionally excluding keys when a usage is given and they
      * are not configured to be used with the usage given
      *
-     * @param array $configuredKeys
+     * @param array|\Traversable $configuredKeys
      * @param string|null $usage
      * @return void
      */
-    public function loadKeys(array $configuredKeys, string $usage = null)
+    public function loadKeys($configuredKeys, string $usage = null)
     {
         foreach ($configuredKeys as $keyData) {
             if (isset($keyData['X509Certificate'])) {

--- a/src/SAML2/Compat/AbstractContainer.php
+++ b/src/SAML2/Compat/AbstractContainer.php
@@ -31,11 +31,12 @@ abstract class AbstractContainer
      * - **encrypt** XML that is about to be encrypted
      * - **decrypt** XML that was just decrypted
      *
-     * @param \DOMElement $message
+     * @param \DOMElement|string $message
      * @param string $type
      * @return void
      */
-    abstract public function debugMessage(\DOMElement $message, string $type);
+    abstract public function debugMessage($message, string $type);
+
 
 
     /**
@@ -56,4 +57,28 @@ abstract class AbstractContainer
      * @return void
      */
     abstract public function postRedirect(string $url, array $data = []);
+
+
+    /**
+     * This function retrieves the path to a directory where temporary files can be saved.
+     *
+     * @return string Path to a temporary directory, without a trailing directory separator.
+     * @throws \Exception If the temporary directory cannot be created or it exists and does not belong
+     * to the current user.
+     */
+    abstract public function getTempDir();
+
+
+    /**
+     * Atomically write a file.
+     *
+     * This is a helper function for writing data atomically to a file. It does this by writing the file data to a
+     * temporary file, then renaming it to the required file name.
+     *
+     * @param string $filename The path to the file we want to write to.
+     * @param string $data The data we should write to the file.
+     * @param int $mode The permissions to apply to the file. Defaults to 0600.
+     * @return void
+     */
+    abstract public function writeFile(string $filename, string $data, int $mode = null);
 }

--- a/src/SAML2/Compat/ContainerSingleton.php
+++ b/src/SAML2/Compat/ContainerSingleton.php
@@ -20,7 +20,7 @@ class ContainerSingleton
     public static function getInstance() : AbstractContainer
     {
         if (!self::$container) {
-            self::setContainer(self::initSspContainer());
+            self::$container = self::initSspContainer();
         }
         return self::$container;
     }
@@ -30,12 +30,11 @@ class ContainerSingleton
      * Set a container to use.
      *
      * @param \SAML2\Compat\AbstractContainer $container
-     * @return \SAML2\Compat\AbstractContainer
+     * @return void
      */
     public static function setContainer(AbstractContainer $container) : AbstractContainer
     {
         self::$container = $container;
-        return $container;
     }
 
 

--- a/src/SAML2/Compat/ContainerSingleton.php
+++ b/src/SAML2/Compat/ContainerSingleton.php
@@ -32,7 +32,7 @@ class ContainerSingleton
      * @param \SAML2\Compat\AbstractContainer $container
      * @return void
      */
-    public static function setContainer(AbstractContainer $container) : AbstractContainer
+    public static function setContainer(AbstractContainer $container)
     {
         self::$container = $container;
     }

--- a/src/SAML2/Compat/MockContainer.php
+++ b/src/SAML2/Compat/MockContainer.php
@@ -30,12 +30,12 @@ class MockContainer extends AbstractContainer
     /**
      * @var array
      */
-    private $redirectData;
+    private $redirectData = [];
 
     /**
-     * @var string
+     * @var string|null
      */
-    private $postRedirectUrl;
+    private $postRedirectUrl = null;
 
     /**
      * @var array

--- a/src/SAML2/Compat/MockContainer.php
+++ b/src/SAML2/Compat/MockContainer.php
@@ -72,11 +72,11 @@ class MockContainer extends AbstractContainer
      * - **encrypt** XML that is about to be encrypted
      * - **decrypt** XML that was just decrypted
      *
-     * @param \DOMElement $message
+     * @param \DOMElement|string $message
      * @param string $type
      * @return void
      */
-    public function debugMessage(\DOMElement $message, string $type)
+    public function debugMessage($message, string $type)
     {
         $this->debugMessages[$type] = $message;
     }
@@ -107,5 +107,27 @@ class MockContainer extends AbstractContainer
     {
         $this->postRedirectUrl = $url;
         $this->postRedirectData = $data;
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTempDir()
+    {
+        return sys_get_temp_dir();
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function writeFile(string $filename, string $data, int $mode = null)
+    {
+        if ($mode === null) {
+            $mode = 0600;
+        }
+        file_put_contents($filename, $data);
+        chmod($filename, $mode);
     }
 }

--- a/src/SAML2/Compat/Ssp/Container.php
+++ b/src/SAML2/Compat/Ssp/Container.php
@@ -41,6 +41,7 @@ class Container extends AbstractContainer
      */
     public function generateId() : string
     {
+        /** @psalm-suppress UndefinedClass */
         return \SimpleSAML\Utils\Random::generateID();
     }
 
@@ -51,6 +52,7 @@ class Container extends AbstractContainer
      */
     public function debugMessage($message, string $type)
     {
+        /** @psalm-suppress UndefinedClass */
         \SimpleSAML\Utils\XML::debugSAMLMessage($message, $type);
     }
 
@@ -63,6 +65,7 @@ class Container extends AbstractContainer
      */
     public function redirect(string $url, array $data = [])
     {
+        /** @psalm-suppress UndefinedClass */
         \SimpleSAML\Utils\HTTP::redirectTrustedURL($url, $data);
     }
 
@@ -75,6 +78,7 @@ class Container extends AbstractContainer
      */
     public function postRedirect(string $url, array $data = [])
     {
+        /** @psalm-suppress UndefinedClass */
         \SimpleSAML\Utils\HTTP::submitPOSTData($url, $data);
     }
 
@@ -84,6 +88,7 @@ class Container extends AbstractContainer
      */
     public function getTempDir()
     {
+        /** @psalm-suppress UndefinedClass */
         return \SimpleSAML\Utils\System::getTempDir();
     }
 
@@ -96,6 +101,7 @@ class Container extends AbstractContainer
         if ($mode === null) {
             $mode = 0600;
         }
+        /** @psalm-suppress UndefinedClass */
         \SimpleSAML\Utils\System::writeFile($filename, $data, $mode);
     }
 }

--- a/src/SAML2/Compat/Ssp/Container.php
+++ b/src/SAML2/Compat/Ssp/Container.php
@@ -49,7 +49,7 @@ class Container extends AbstractContainer
      * {@inheritdoc}
      * @return void
      */
-    public function debugMessage(\DOMElement $message, string $type)
+    public function debugMessage($message, string $type)
     {
         \SimpleSAML\Utils\XML::debugSAMLMessage($message, $type);
     }
@@ -76,5 +76,26 @@ class Container extends AbstractContainer
     public function postRedirect(string $url, array $data = [])
     {
         \SimpleSAML\Utils\HTTP::submitPOSTData($url, $data);
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTempDir()
+    {
+        return \SimpleSAML\Utils\System::getTempDir();
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function writeFile(string $filename, string $data, int $mode = null)
+    {
+        if ($mode === null) {
+            $mode = 0600;
+        }
+        \SimpleSAML\Utils\System::writeFile($filename, $data, $mode);
     }
 }

--- a/src/SAML2/Compat/Ssp/Logger.php
+++ b/src/SAML2/Compat/Ssp/Logger.php
@@ -21,6 +21,7 @@ class Logger implements LoggerInterface
      */
     public function emergency($message, array $context = [])
     {
+        /** @psalm-suppress UndefinedClass */
         \SimpleSAML\Logger::emergency($message.($context ? " ".var_export($context, true) : ""));
     }
 
@@ -39,6 +40,7 @@ class Logger implements LoggerInterface
      */
     public function alert($message, array $context = [])
     {
+        /** @psalm-suppress UndefinedClass */
         \SimpleSAML\Logger::alert($message.($context ? " ".var_export($context, true) : ""));
     }
 
@@ -56,6 +58,7 @@ class Logger implements LoggerInterface
      */
     public function critical($message, array $context = [])
     {
+        /** @psalm-suppress UndefinedClass */
         \SimpleSAML\Logger::critical($message.($context ? " ".var_export($context, true) : ""));
     }
 
@@ -72,6 +75,7 @@ class Logger implements LoggerInterface
      */
     public function error($message, array $context = [])
     {
+        /** @psalm-suppress UndefinedClass */
         \SimpleSAML\Logger::error($message.($context ? " ".var_export($context, true) : ""));
     }
 
@@ -90,6 +94,7 @@ class Logger implements LoggerInterface
      */
     public function warning($message, array $context = [])
     {
+        /** @psalm-suppress UndefinedClass */
         \SimpleSAML\Logger::warning($message.($context ? " ".var_export($context, true) : ""));
     }
 
@@ -105,6 +110,7 @@ class Logger implements LoggerInterface
      */
     public function notice($message, array $context = [])
     {
+        /** @psalm-suppress UndefinedClass */
         \SimpleSAML\Logger::notice($message.($context ? " ".var_export($context, true) : ""));
     }
 
@@ -122,6 +128,7 @@ class Logger implements LoggerInterface
      */
     public function info($message, array $context = [])
     {
+        /** @psalm-suppress UndefinedClass */
         \SimpleSAML\Logger::info($message.($context ? " ".var_export($context, true) : ""));
     }
 
@@ -137,6 +144,7 @@ class Logger implements LoggerInterface
      */
     public function debug($message, array $context = [])
     {
+        /** @psalm-suppress UndefinedClass */
         \SimpleSAML\Logger::debug($message.($context ? " ".var_export($context, true) : ""));
     }
 

--- a/src/SAML2/Configuration/DecryptionProvider.php
+++ b/src/SAML2/Configuration/DecryptionProvider.php
@@ -19,12 +19,13 @@ interface DecryptionProvider
 
 
     /**
-     * @param string  $name     the name of the private key
-     * @param boolean $required whether or not the private key must exist
+     * @param string $name The name of the private key
+     * @param bool $required Whether or not the private key must exist
      *
      * @return mixed
      */
-    public function getPrivateKey(string $name, bool $required = false);
+    public function getPrivateKey(string $name, bool $required = null);
+
 
 
     /**

--- a/src/SAML2/Configuration/IdentityProvider.php
+++ b/src/SAML2/Configuration/IdentityProvider.php
@@ -13,7 +13,7 @@ final class IdentityProvider extends ArrayAdapter implements
     EntityIdProvider
 {
     /**
-     * @return array|mixed|\Traversable|null
+     * @return array|\Traversable|null
      */
     public function getKeys()
     {
@@ -22,7 +22,7 @@ final class IdentityProvider extends ArrayAdapter implements
 
 
     /**
-     * @return mixed|string|null
+     * @return string|null
      */
     public function getCertificateData()
     {
@@ -31,7 +31,7 @@ final class IdentityProvider extends ArrayAdapter implements
 
 
     /**
-     * @return mixed|string|null
+     * @return string|null
      */
     public function getCertificateFile()
     {
@@ -40,7 +40,16 @@ final class IdentityProvider extends ArrayAdapter implements
 
 
     /**
-     * @return bool|mixed|null
+     * @return array|mixed|\Traversable|null
+     */
+    public function getCertificateFingerprints()
+    {
+        return $this->get('certificateFingerprints');
+    }
+
+
+    /**
+     * @return bool|null
      */
     public function isAssertionEncryptionRequired()
     {
@@ -49,7 +58,7 @@ final class IdentityProvider extends ArrayAdapter implements
 
 
     /**
-     * @return mixed|string|null
+     * @return string|null
      */
     public function getSharedKey()
     {
@@ -69,7 +78,7 @@ final class IdentityProvider extends ArrayAdapter implements
     /**
      * @param string $name
      * @param bool $required
-     * @return mixed|\TValue|null
+     * @return mixed|null
      */
     public function getPrivateKey(string $name, bool $required = null)
     {

--- a/src/SAML2/Configuration/IdentityProvider.php
+++ b/src/SAML2/Configuration/IdentityProvider.php
@@ -7,13 +7,13 @@ namespace SAML2\Configuration;
 /**
  * Basic configuration wrapper
  */
-class IdentityProvider extends ArrayAdapter implements
+final class IdentityProvider extends ArrayAdapter implements
     CertificateProvider,
     DecryptionProvider,
     EntityIdProvider
 {
     /**
-     * @return mixed
+     * @return array|mixed|\Traversable|null
      */
     public function getKeys()
     {
@@ -22,7 +22,7 @@ class IdentityProvider extends ArrayAdapter implements
 
 
     /**
-     * @return mixed
+     * @return mixed|string|null
      */
     public function getCertificateData()
     {
@@ -31,13 +31,17 @@ class IdentityProvider extends ArrayAdapter implements
 
 
     /**
-     * @return mixed
+     * @return mixed|string|null
      */
     public function getCertificateFile()
     {
         return $this->get('certificateFile');
     }
 
+
+    /**
+     * @return bool|mixed|null
+     */
     public function isAssertionEncryptionRequired()
     {
         return $this->get('assertionEncryptionEnabled');
@@ -45,7 +49,7 @@ class IdentityProvider extends ArrayAdapter implements
 
 
     /**
-     * @return mixed
+     * @return mixed|string|null
      */
     public function getSharedKey()
     {
@@ -54,7 +58,7 @@ class IdentityProvider extends ArrayAdapter implements
 
 
     /**
-     * @return mixed
+     * @return mixed|null
      */
     public function hasBase64EncodedAttributes()
     {
@@ -65,10 +69,13 @@ class IdentityProvider extends ArrayAdapter implements
     /**
      * @param string $name
      * @param bool $required
-     * @return mixed|null
+     * @return mixed|\TValue|null
      */
-    public function getPrivateKey(string $name, bool $required = false)
+    public function getPrivateKey(string $name, bool $required = null)
     {
+        if ($required === null) {
+            $required = false;
+        }
         $privateKeys = $this->get('privateKeys');
         $key = array_filter($privateKeys, function (PrivateKey $key) use ($name) {
             return $key->getName() === $name;

--- a/src/SAML2/Configuration/IdentityProvider.php
+++ b/src/SAML2/Configuration/IdentityProvider.php
@@ -7,10 +7,7 @@ namespace SAML2\Configuration;
 /**
  * Basic configuration wrapper
  */
-final class IdentityProvider extends ArrayAdapter implements
-    CertificateProvider,
-    DecryptionProvider,
-    EntityIdProvider
+final class IdentityProvider extends ArrayAdapter implements CertificateProvider, DecryptionProvider, EntityIdProvider
 {
     /**
      * @return array|\Traversable|null
@@ -118,7 +115,7 @@ final class IdentityProvider extends ArrayAdapter implements
 
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getEntityId()
     {

--- a/src/SAML2/Configuration/IdentityProviderAware.php
+++ b/src/SAML2/Configuration/IdentityProviderAware.php
@@ -11,6 +11,7 @@ interface IdentityProviderAware
 {
     /**
      * @param IdentityProvider $identityProvider
+     *
      * @return void
      */
     public function setIdentityProvider(IdentityProvider $identityProvider);

--- a/src/SAML2/Configuration/PrivateKey.php
+++ b/src/SAML2/Configuration/PrivateKey.php
@@ -67,7 +67,7 @@ class PrivateKey extends ArrayAdapter
     /**
      * @return string|null
      */
-    public function getPassPhrase() : string
+    public function getPassPhrase()
     {
         return $this->passphrase;
     }

--- a/src/SAML2/Configuration/PrivateKey.php
+++ b/src/SAML2/Configuration/PrivateKey.php
@@ -20,7 +20,7 @@ class PrivateKey extends ArrayAdapter
     private $filePath;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $passphrase;
 
@@ -60,12 +60,12 @@ class PrivateKey extends ArrayAdapter
      */
     public function hasPassPhrase() : bool
     {
-        return (bool) $this->passphrase;
+        return $this->passphrase !== null;
     }
 
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getPassPhrase() : string
     {

--- a/src/SAML2/Configuration/ServiceProvider.php
+++ b/src/SAML2/Configuration/ServiceProvider.php
@@ -69,8 +69,11 @@ class ServiceProvider extends ArrayAdapter implements
      * @param bool $required
      * @return mixed|null
      */
-    public function getPrivateKey(string $name, bool $required = false)
+    public function getPrivateKey(string $name, bool $required = null)
     {
+        if ($required === null) {
+            $required = false;
+        }
         $privateKeys = $this->get('privateKeys');
         $key         = array_filter($privateKeys, function (PrivateKey $key) use ($name) {
             return $key->getName() === $name;

--- a/src/SAML2/Configuration/ServiceProvider.php
+++ b/src/SAML2/Configuration/ServiceProvider.php
@@ -9,13 +9,10 @@ use RobRichards\XMLSecLibs\XMLSecurityKey;
 /**
  * Basic Configuration Wrapper
  */
-class ServiceProvider extends ArrayAdapter implements
-    CertificateProvider,
-    DecryptionProvider,
-    EntityIdProvider
+class ServiceProvider extends ArrayAdapter implements CertificateProvider, DecryptionProvider, EntityIdProvider
 {
     /**
-     * @return mixed
+     * @return null|array|\Traversable
      */
     public function getKeys()
     {
@@ -24,7 +21,7 @@ class ServiceProvider extends ArrayAdapter implements
 
 
     /**
-     * @return mixed
+     * @return null|string
      */
     public function getCertificateData()
     {
@@ -33,13 +30,26 @@ class ServiceProvider extends ArrayAdapter implements
 
 
     /**
-     * @return mixed
+     * @return null|string
      */
     public function getCertificateFile()
     {
         return $this->get('certificateFile');
     }
 
+
+    /**
+     * @return array|mixed|\Traversable|null
+     */
+    public function getCertificateFingerprints()
+    {
+        return $this->get('certificateFingerprints');
+    }
+
+
+    /**
+     * @return mixed|string|null
+     */
     public function getEntityId()
     {
         return $this->get('entityId');
@@ -47,7 +57,7 @@ class ServiceProvider extends ArrayAdapter implements
 
 
     /**
-     * @return mixed
+     * @return null|bool
      */
     public function isAssertionEncryptionRequired()
     {
@@ -56,7 +66,7 @@ class ServiceProvider extends ArrayAdapter implements
 
 
     /**
-     * @return mixed
+     * @return null|string
      */
     public function getSharedKey()
     {

--- a/src/SAML2/Configuration/ServiceProvider.php
+++ b/src/SAML2/Configuration/ServiceProvider.php
@@ -39,7 +39,7 @@ class ServiceProvider extends ArrayAdapter implements CertificateProvider, Decry
 
 
     /**
-     * @return array|mixed|\Traversable|null
+     * @return array|\Traversable|null
      */
     public function getCertificateFingerprints()
     {
@@ -48,7 +48,7 @@ class ServiceProvider extends ArrayAdapter implements CertificateProvider, Decry
 
 
     /**
-     * @return mixed|string|null
+     * @return string|null
      */
     public function getEntityId()
     {

--- a/src/SAML2/Configuration/SimpleSAMLConverter.php
+++ b/src/SAML2/Configuration/SimpleSAMLConverter.php
@@ -16,6 +16,8 @@ class SimpleSAMLConverter
      * @param string                    $certificatePrefix
      *
      * @return \SAML2\Configuration\IdentityProvider
+     *
+     * @psalm-suppress UndefinedClass
      */
     public static function convertToIdentityProvider(
         Configuration $configuration,
@@ -34,6 +36,8 @@ class SimpleSAMLConverter
      * @param string                    $certificatePrefix
      *
      * @return \SAML2\Configuration\ServiceProvider
+     *
+     * @psalm-suppress UndefinedClass
      */
     public static function convertToServiceProvider(
         Configuration $configuration,
@@ -52,6 +56,8 @@ class SimpleSAMLConverter
      * @param string                    $prefix
      *
      * @return array
+     *
+     * @psalm-suppress UndefinedClass
      */
     protected static function pluckConfiguration(Configuration $configuration, string $prefix = '') : array
     {
@@ -90,6 +96,8 @@ class SimpleSAMLConverter
      * @param array                     $baseConfiguration
      *
      * @return void
+     *
+     * @psalm-suppress UndefinedClass
      */
     protected static function enrichForIdentityProvider(Configuration $configuration, array &$baseConfiguration)
     {
@@ -103,6 +111,8 @@ class SimpleSAMLConverter
      * @param array                     $baseConfiguration
      *
      * @return void
+     *
+     * @psalm-suppress UndefinedClass
      */
     protected static function enrichForServiceProvider(Configuration $configuration, array &$baseConfiguration)
     {
@@ -115,6 +125,8 @@ class SimpleSAMLConverter
      * @param array                     $baseConfiguration
      *
      * @return void
+     *
+     * @psalm-suppress UndefinedClass
      */
     protected static function enrichForDecryptionProvider(
         Configuration $configuration,

--- a/src/SAML2/Configuration/SimpleSAMLConverter.php
+++ b/src/SAML2/Configuration/SimpleSAMLConverter.php
@@ -77,7 +77,7 @@ class SimpleSAMLConverter
 
         $extracted['assertionEncryptionEnabled'] = $configuration->getBoolean('assertion.encryption', false);
 
-        if ($configuration->has('sharedKey')) {
+        if ($configuration->hasValue('sharedKey')) {
             $extracted['sharedKey'] = $configuration->getString('sharedKey');
         }
 
@@ -120,11 +120,11 @@ class SimpleSAMLConverter
         Configuration $configuration,
         array &$baseConfiguration
     ) {
-        if ($configuration->has('sharedKey')) {
+        if ($configuration->hasValue('sharedKey')) {
             $baseConfiguration['sharedKey'] = $configuration->getString('sharedKey', null);
         }
 
-        if ($configuration->has('new_privatekey')) {
+        if ($configuration->hasValue('new_privatekey')) {
             $baseConfiguration['privateKeys'][] = new PrivateKey(
                 $configuration->getString('new_privatekey'),
                 PrivateKey::NAME_NEW,
@@ -139,9 +139,9 @@ class SimpleSAMLConverter
                 $configuration->getString('privatekey_pass', null)
             );
 
-            if ($configuration->has('encryption.blacklisted-algorithms')) {
+            if ($configuration->hasValue('encryption.blacklisted-algorithms')) {
                 $baseConfiguration['blacklistedEncryptionAlgorithms'] = $configuration
-                    ->get('encryption.blacklisted-algorithms');
+                    ->getValue('encryption.blacklisted-algorithms');
             }
         }
     }

--- a/src/SAML2/EncryptedAssertion.php
+++ b/src/SAML2/EncryptedAssertion.php
@@ -34,8 +34,9 @@ class EncryptedAssertion
             return;
         }
 
+        /** @var \DOMElement[] $data */
         $data = Utils::xpQuery($xml, './xenc:EncryptedData');
-        if (count($data) === 0) {
+        if (empty($data)) {
             throw new \Exception('Missing encrypted data in <saml:EncryptedAssertion>.');
         } elseif (count($data) > 1) {
             throw new \Exception('More than one encrypted data element in <saml:EncryptedAssertion>.');

--- a/src/SAML2/EncryptedAssertion.php
+++ b/src/SAML2/EncryptedAssertion.php
@@ -97,7 +97,10 @@ class EncryptedAssertion
                 throw new \Exception('Unknown key type for encryption: '.$key->type);
         }
 
-        /** @var \DOMElement encryptedData */
+        /**
+         * @var \DOMElement encryptedData
+         * @psalm-suppress UndefinedClass
+         */
         $this->encryptedData = $enc->encryptNode($symmetricKey);
     }
 

--- a/src/SAML2/EncryptedAssertion.php
+++ b/src/SAML2/EncryptedAssertion.php
@@ -84,6 +84,7 @@ class EncryptedAssertion
                 throw new \Exception('Unknown key type for encryption: '.$key->type);
         }
 
+        /** @var \DOMElement encryptedData */
         $this->encryptedData = $enc->encryptNode($symmetricKey);
     }
 

--- a/src/SAML2/Exception/UnparseableXmlException.php
+++ b/src/SAML2/Exception/UnparseableXmlException.php
@@ -8,6 +8,7 @@ use \LibXMLError;
 
 final class UnparseableXmlException extends RuntimeException
 {
+    /** @var array */
     private static $levelMap = [
         LIBXML_ERR_WARNING => 'WARNING',
         LIBXML_ERR_ERROR   => 'ERROR',

--- a/src/SAML2/HTTPArtifact.php
+++ b/src/SAML2/HTTPArtifact.php
@@ -19,6 +19,7 @@ use \SimpleSAML\Store;
 class HTTPArtifact extends Binding
 {
     /**
+     * @psalm-suppress UndefinedClass
      * @var \SimpleSAML\Configuration
      */
     private $spMetadata;
@@ -33,6 +34,7 @@ class HTTPArtifact extends Binding
      */
     public function getRedirectURL(Message $message) : string
     {
+        /** @psalm-suppress UndefinedClass */
         $store = Store::getInstance();
         if ($store === false) {
             throw new \Exception('Unable to send artifact without a datastore configured.');
@@ -98,6 +100,7 @@ class HTTPArtifact extends Binding
             throw new \Exception('Missing SAMLart parameter.');
         }
 
+        /**  @psalm-suppress UndefinedClass */
         $metadataHandler = MetaDataStorageHandler::getMetadataHandler();
 
         $idpMetadata = $metadataHandler->getMetaDataConfigForSha1($sourceId, 'saml20-idp-remote');
@@ -162,7 +165,10 @@ class HTTPArtifact extends Binding
 
     /**
      * @param \SimpleSAML\Configuration $sp
+     *
      * @return void
+     *
+     * @psalm-suppress UndefinedClass
      */
     public function setSPMetadata(Configuration $sp)
     {

--- a/src/SAML2/HTTPArtifact.php
+++ b/src/SAML2/HTTPArtifact.php
@@ -40,7 +40,7 @@ class HTTPArtifact extends Binding
 
         $generatedId = pack('H*', bin2hex(openssl_random_pseudo_bytes(20)));
         $issuer = $message->getIssuer();
-        if ($issuer === null || $value = $issuer->getValue() === null) {
+        if ($issuer === null || ($value = $issuer->getValue()) === null) {
             throw new \Exception('Cannot get redirect URL, no Issuer set in the message.');
         }
         $artifact = base64_encode("\x00\x04\x00\x00".sha1($value, true).$generatedId);

--- a/src/SAML2/HTTPArtifact.php
+++ b/src/SAML2/HTTPArtifact.php
@@ -40,10 +40,10 @@ class HTTPArtifact extends Binding
 
         $generatedId = pack('H*', bin2hex(openssl_random_pseudo_bytes(20)));
         $issuer = $message->getIssuer();
-        if ($issuer === null || ($value = $issuer->getValue()) === null) {
+        if ($issuer === null) {
             throw new \Exception('Cannot get redirect URL, no Issuer set in the message.');
         }
-        $artifact = base64_encode("\x00\x04\x00\x00".sha1($value, true).$generatedId);
+        $artifact = base64_encode("\x00\x04\x00\x00".sha1($issuer->getValue(), true).$generatedId);
         $artifactData = $message->toUnsignedXML();
         $artifactDataString = $artifactData->ownerDocument->saveXML($artifactData);
 

--- a/src/SAML2/HTTPArtifact.php
+++ b/src/SAML2/HTTPArtifact.php
@@ -18,10 +18,9 @@ use \SimpleSAML\Store;
  */
 class HTTPArtifact extends Binding
 {
+
     /**
-     * @psalm-suppress UndefinedClass
-     * @var \SimpleSAML\Configuration
-     * @psalm-suppress UndefinedClass
+     * @var mixed
      */
     private $spMetadata;
 
@@ -135,7 +134,8 @@ class HTTPArtifact extends Binding
         $ar->setArtifact($_REQUEST['SAMLart']);
         $ar->setDestination($endpoint['Location']);
 
-        /* Sign the request */
+        // sign the request
+        /** @psalm-suppress UndefinedClass */
         \SimpleSAML\Module\saml\Message::addSign($this->spMetadata, $idpMetadata, $ar); // Shoaib - moved from the SOAPClient.
 
         $soap = new SOAPClient();

--- a/src/SAML2/HTTPArtifact.php
+++ b/src/SAML2/HTTPArtifact.php
@@ -19,8 +19,8 @@ use \SimpleSAML\Store;
 class HTTPArtifact extends Binding
 {
     /**
-     * @psalm-suppress UndefinedClass
      * @var \SimpleSAML\Configuration
+     * @psalm-suppress UndefinedClass
      */
     private $spMetadata;
 
@@ -63,6 +63,7 @@ class HTTPArtifact extends Binding
         if ($destination === null) {
             throw new \Exception('Cannot get redirect URL, no destination set in the message.');
         }
+        /** @psalm-suppress UndefinedClass */
         return \SimpleSAML\Utils\HTTP::addURLparameters($destination, $params);
     }
 
@@ -100,7 +101,7 @@ class HTTPArtifact extends Binding
             throw new \Exception('Missing SAMLart parameter.');
         }
 
-        /**  @psalm-suppress UndefinedClass */
+        /** @psalm-suppress UndefinedClass */
         $metadataHandler = MetaDataStorageHandler::getMetadataHandler();
 
         $idpMetadata = $metadataHandler->getMetaDataConfigForSha1($sourceId, 'saml20-idp-remote');

--- a/src/SAML2/HTTPArtifact.php
+++ b/src/SAML2/HTTPArtifact.php
@@ -19,6 +19,7 @@ use \SimpleSAML\Store;
 class HTTPArtifact extends Binding
 {
     /**
+     * @psalm-suppress UndefinedClass
      * @var \SimpleSAML\Configuration
      * @psalm-suppress UndefinedClass
      */
@@ -129,6 +130,7 @@ class HTTPArtifact extends Binding
 
         /* Set the request attributes */
 
+        /** @psalm-suppress UndefinedClass */
         $ar->setIssuer($this->spMetadata->getString('entityid'));
         $ar->setArtifact($_REQUEST['SAMLart']);
         $ar->setDestination($endpoint['Location']);

--- a/src/SAML2/HTTPPost.php
+++ b/src/SAML2/HTTPPost.php
@@ -23,6 +23,9 @@ class HTTPPost extends Binding
     {
         if ($this->destination === null) {
             $destination = $message->getDestination();
+            if ($destination === null) {
+                throw new \Exception('Cannot send message, no destination set.');
+            }
         } else {
             $destination = $this->destination;
         }
@@ -78,6 +81,9 @@ class HTTPPost extends Binding
 
         $document = DOMDocumentFactory::fromString($msgStr);
         Utils::getContainer()->debugMessage($document->documentElement, 'in');
+        if (!$document->firstChild instanceof \DOMElement) {
+            throw new \Exception('Malformed SAML message received.');
+        }
 
         $msg = Message::fromXML($document->firstChild);
 

--- a/src/SAML2/HTTPRedirect.php
+++ b/src/SAML2/HTTPRedirect.php
@@ -27,6 +27,9 @@ class HTTPRedirect extends Binding
     {
         if ($this->destination === null) {
             $destination = $message->getDestination();
+            if ($destination === null) {
+                throw new \Exception('Cannot build a redirect URL, no destination set.');
+            }
         } else {
             $destination = $this->destination;
         }
@@ -126,6 +129,9 @@ class HTTPRedirect extends Binding
 
         $document = DOMDocumentFactory::fromString($message);
         Utils::getContainer()->debugMessage($document->documentElement, 'in');
+        if (!$document->firstChild instanceof \DOMElement) {
+            throw new \Exception('Malformed SAML message received.');
+        }
         $message  = Message::fromXML($document->firstChild);
 
         if (array_key_exists('RelayState', $data)) {

--- a/src/SAML2/HTTPRedirect.php
+++ b/src/SAML2/HTTPRedirect.php
@@ -132,7 +132,7 @@ class HTTPRedirect extends Binding
         if (!$document->firstChild instanceof \DOMElement) {
             throw new \Exception('Malformed SAML message received.');
         }
-        $message  = Message::fromXML($document->firstChild);
+        $message = Message::fromXML($document->firstChild);
 
         if (array_key_exists('RelayState', $data)) {
             $message->setRelayState($data['RelayState']);

--- a/src/SAML2/HTTPRedirect.php
+++ b/src/SAML2/HTTPRedirect.php
@@ -59,8 +59,8 @@ class HTTPRedirect extends Binding
             $msg .= '&RelayState='.urlencode($relayState);
         }
 
-        if ($key !== null) {
-            /* Add the signature. */
+        if ($key !== null) { // add the signature
+            /** @psalm-suppress PossiblyInvalidArgument */
             $msg .= '&SigAlg='.urlencode($key->type);
 
             $signature = $key->signData($msg);

--- a/src/SAML2/LogoutRequest.php
+++ b/src/SAML2/LogoutRequest.php
@@ -156,7 +156,10 @@ class LogoutRequest extends Request
         $symmetricKey->generateSessionKey();
         $enc->encryptKey($key, $symmetricKey);
 
-        /** @var \DOMElement encryptedNameId */
+        /**
+         * @var \DOMElement encryptedNameId
+         * @psalm-suppress UndefinedClass
+         */
         $this->encryptedNameId = $enc->encryptNode($symmetricKey);
         $this->nameId = null;
     }

--- a/src/SAML2/LogoutRequest.php
+++ b/src/SAML2/LogoutRequest.php
@@ -20,7 +20,7 @@ class LogoutRequest extends Request
      *
      * @var int|null
      */
-    private $notOnOrAfter;
+    private $notOnOrAfter = null;
 
     /**
      * The encrypted NameID in the request.
@@ -29,21 +29,21 @@ class LogoutRequest extends Request
      *
      * @var \DOMElement|null
      */
-    private $encryptedNameId;
+    private $encryptedNameId = null;
 
     /**
      * The name identifier of the session that should be terminated.
      *
-     * @var \SAML2\XML\saml\NameID
+     * @var \SAML2\XML\saml\NameID|null
      */
-    private $nameId;
+    private $nameId = null;
 
     /**
      * The SessionIndexes of the sessions that should be terminated.
      *
      * @var array
      */
-    private $sessionIndexes;
+    private $sessionIndexes = [];
 
 
     /**
@@ -63,23 +63,24 @@ class LogoutRequest extends Request
         }
 
         if ($xml->hasAttribute('NotOnOrAfter')) {
-            $this->setNotOnOrAfter(Utils::xsDateTimeToTimestamp($xml->getAttribute('NotOnOrAfter')));
+            $this->notOnOrAfter = Utils::xsDateTimeToTimestamp($xml->getAttribute('NotOnOrAfter'));
         }
 
+        /** @var \DOMElement[] $nameId */
         $nameId = Utils::xpQuery($xml, './saml_assertion:NameID | ./saml_assertion:EncryptedID/xenc:EncryptedData');
         if (empty($nameId)) {
             throw new \Exception('Missing <saml:NameID> or <saml:EncryptedID> in <samlp:LogoutRequest>.');
         } elseif (count($nameId) > 1) {
             throw new \Exception('More than one <saml:NameID> or <saml:EncryptedD> in <samlp:LogoutRequest>.');
         }
-        $nameId = $nameId[0];
-        if ($nameId->localName === 'EncryptedData') {
+        if ($nameId[0]->localName === 'EncryptedData') {
             /* The NameID element is encrypted. */
-            $this->setEncryptedNameId($nameId);
+            $this->encryptedNameId = $nameId[0];
         } else {
-            $this->setNameId(new NameID($nameId));
+            $this->nameId = new NameID($nameId[0]);
         }
 
+        /** @var \DOMElement[] $sessionIndexes */
         $sessionIndexes = Utils::xpQuery($xml, './saml_protocol:SessionIndex');
         foreach ($sessionIndexes as $sessionIndex) {
             $this->sessionIndexes[] = trim($sessionIndex->textContent);
@@ -117,7 +118,7 @@ class LogoutRequest extends Request
      */
     public function isNameIdEncrypted() : bool
     {
-        if ($this->getEncryptedNameId() !== null) {
+        if ($this->encryptedNameId !== null) {
             return true;
         }
 
@@ -133,11 +134,15 @@ class LogoutRequest extends Request
      */
     public function encryptNameId(XMLSecurityKey $key)
     {
+        if ($this->nameId === null) {
+            throw new \Exception('Cannot encrypt NameID without a NameID set.');
+        }
         /* First create a XML representation of the NameID. */
         $doc = DOMDocumentFactory::create();
         $root = $doc->createElement('root');
         $doc->appendChild($root);
-        $this->getNameId()->toXML($root);
+        $this->nameId->toXML($root);
+        /** @var \DOMElement $nameId */
         $nameId = $root->firstChild;
 
         Utils::getContainer()->debugMessage($nameId, 'encrypt');
@@ -151,30 +156,30 @@ class LogoutRequest extends Request
         $symmetricKey->generateSessionKey();
         $enc->encryptKey($key, $symmetricKey);
 
-        $this->setEncryptedNameId($enc->encryptNode($symmetricKey));
-        $this->setNameId(null);
+        /** @var \DOMElement encryptedNameId */
+        $this->encryptedNameId = $enc->encryptNode($symmetricKey);
+        $this->nameId = null;
     }
 
 
     /**
      * Decrypt the NameID in the LogoutRequest.
      *
-     * @param XMLSecurityKey $key       The decryption key.
-     * @param array          $blacklist Blacklisted decryption algorithms.
+     * @param XMLSecurityKey $key The decryption key.
+     * @param array $blacklist Blacklisted decryption algorithms.
      * @return void
      */
     public function decryptNameId(XMLSecurityKey $key, array $blacklist = [])
     {
-        if ($this->getEncryptedNameId() === null) {
+        if ($this->encryptedNameId === null) {
             /* No NameID to decrypt. */
             return;
         }
 
-        $nameId = Utils::decryptElement($this->getEncryptedNameId(), $key, $blacklist);
+        $nameId = Utils::decryptElement($this->encryptedNameId, $key, $blacklist);
         Utils::getContainer()->debugMessage($nameId, 'decrypt');
-        $this->setNameId(new NameID($nameId));
-
-        $this->setEncryptedNameId(null);
+        $this->nameId = new NameID($nameId);
+        $this->encryptedNameId = null;
     }
 
 
@@ -182,11 +187,11 @@ class LogoutRequest extends Request
      * Retrieve the name identifier of the session that should be terminated.
      *
      * @throws \Exception
-     * @return \SAML2\XML\saml\NameID The name identifier of the session that should be terminated.
+     * @return \SAML2\XML\saml\NameID|null The name identifier of the session that should be terminated.
      */
     public function getNameId() : NameID
     {
-        if ($this->getEncryptedNameId() !== null) {
+        if ($this->encryptedNameId !== null) {
             throw new \Exception('Attempted to retrieve encrypted NameID without decrypting it first.');
         }
 
@@ -197,10 +202,10 @@ class LogoutRequest extends Request
     /**
      * Set the name identifier of the session that should be terminated.
      *
-     * @param \SAML2\XML\saml\NameID|null $nameId The name identifier of the session that should be terminated.
+     * @param \SAML2\XML\saml\NameID $nameId The name identifier of the session that should be terminated.
      * @return void
      */
-    public function setNameId(NameID $nameId = null)
+    public function setNameId(NameID $nameId)
     {
         $this->nameId = $nameId;
     }
@@ -214,18 +219,6 @@ class LogoutRequest extends Request
     private function getEncryptedNameId()
     {
         return $this->encryptedNameId;
-    }
-
-
-    /**
-     * Set the encrypted name identifier.
-     *
-     * @param \DOMElement|null $nameId The name identifier of the session that should be terminated.
-     * @return void
-     */
-    private function setEncryptedNameId(\DOMElement $nameId = null)
-    {
-        $this->encryptedNameId = $nameId;
     }
 
 
@@ -290,18 +283,22 @@ class LogoutRequest extends Request
      */
     public function toUnsignedXML() : \DOMElement
     {
+        if ($this->encryptedNameId === null && $this->nameId === null) {
+            throw new \Exception('Cannot convert LogoutRequest to XML without a NameID set.');
+        }
+
         $root = parent::toUnsignedXML();
 
         if ($this->notOnOrAfter !== null) {
-            $root->setAttribute('NotOnOrAfter', gmdate('Y-m-d\TH:i:s\Z', $this->getNotOnOrAfter()));
+            $root->setAttribute('NotOnOrAfter', gmdate('Y-m-d\TH:i:s\Z', $this->notOnOrAfter));
         }
 
-        if ($this->getEncryptedNameId() === null) {
+        if ($this->encryptedNameId === null) {
             $this->nameId->toXML($root);
         } else {
             $eid = $root->ownerDocument->createElementNS(Constants::NS_SAML, 'saml:'.'EncryptedID');
             $root->appendChild($eid);
-            $eid->appendChild($root->ownerDocument->importNode($this->getEncryptedNameId(), true));
+            $eid->appendChild($root->ownerDocument->importNode($this->encryptedNameId, true));
         }
 
         foreach ($this->sessionIndexes as $sessionIndex) {

--- a/src/SAML2/LogoutRequest.php
+++ b/src/SAML2/LogoutRequest.php
@@ -189,7 +189,7 @@ class LogoutRequest extends Request
      * @throws \Exception
      * @return \SAML2\XML\saml\NameID|null The name identifier of the session that should be terminated.
      */
-    public function getNameId() : NameID
+    public function getNameId()
     {
         if ($this->encryptedNameId !== null) {
             throw new \Exception('Attempted to retrieve encrypted NameID without decrypting it first.');

--- a/src/SAML2/LogoutRequest.php
+++ b/src/SAML2/LogoutRequest.php
@@ -212,17 +212,6 @@ class LogoutRequest extends Request
 
 
     /**
-     * Retrieve the encrypted name identifier.
-     *
-     * @return \DOMElement|null
-     */
-    private function getEncryptedNameId()
-    {
-        return $this->encryptedNameId;
-    }
-
-
-    /**
      * Retrieve the SessionIndexes of the sessions that should be terminated.
      *
      * @return array The SessionIndexes, or an empty array if all sessions should be terminated.

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -92,7 +92,7 @@ abstract class Message extends SignedElement
      *
      * @var XMLSecurityKey|null
      */
-    private $signatureKey;
+    protected $signatureKey;
 
     /**
      * @var bool
@@ -104,7 +104,7 @@ abstract class Message extends SignedElement
      *
      * @var array
      */
-    private $certificates;
+    protected $certificates;
 
     /**
      * Available methods for validating this message.

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -15,7 +15,7 @@ use SAML2\XML\samlp\Extensions;
  * Implements what is common between the samlp:RequestAbstractType and
  * samlp:StatusResponseType element types.
  */
-abstract class Message implements SignedElement
+abstract class Message extends SignedElement
 {
     /**
      * Request extensions.

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -383,10 +383,10 @@ abstract class Message implements SignedElement
     /**
      * Set the issuer of this message.
      *
-     * @param \SAML2\XML\saml\Issuer $issuer The new issuer of this message
+     * @param \SAML2\XML\saml\Issuer|null $issuer The new issuer of this message
      * @return void
      */
-    public function setIssuer(\SAML2\XML\saml\Issuer $issuer = null)
+    public function setIssuer(Issuer $issuer = null)
     {
         $this->issuer = $issuer;
     }
@@ -434,9 +434,6 @@ abstract class Message implements SignedElement
      */
     public function toUnsignedXML() : \DOMElement
     {
-        if ($this->issuer === null) {
-            throw new \Exception('Cannot convert Assertion to XML without an Issuer set.');
-        }
         $this->document = DOMDocumentFactory::create();
 
         $root = $this->document->createElementNS(Constants::NS_SAMLP, 'samlp:'.$this->tagName);

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -347,10 +347,10 @@ abstract class Message extends SignedElement
      * Most likely (though not required) a value of urn:oasis:names:tc:SAML:2.0:consent.
      *
      * @see \SAML2\Constants
-     * @param string|null $consent
+     * @param string $consent
      * @return void
      */
-    public function setConsent(string $consent = null)
+    public function setConsent(string $consent)
     {
         $this->consent = $consent;
     }

--- a/src/SAML2/Response.php
+++ b/src/SAML2/Response.php
@@ -13,6 +13,8 @@ class Response extends StatusResponse
 {
     /**
      * The assertions in this response.
+     *
+     * @var (Assertion|EncryptedAssertion)[]
      */
     private $assertions;
 
@@ -32,7 +34,7 @@ class Response extends StatusResponse
             return;
         }
 
-        for ($node = $xml->firstChild; $node !== null; $node = $node->nextSibling) {
+        foreach ($xml->childNodes as $node) {
             if ($node->namespaceURI !== Constants::NS_SAML) {
                 continue;
             }

--- a/src/SAML2/Response/Processor.php
+++ b/src/SAML2/Response/Processor.php
@@ -63,8 +63,8 @@ class Processor
     /**
      * @param \SAML2\Configuration\ServiceProvider  $serviceProviderConfiguration
      * @param \SAML2\Configuration\IdentityProvider $identityProviderConfiguration
-     * @param \SAML2\Configuration\Destination      $currentDestination
-     * @param \SAML2\Response                       $response
+     * @param \SAML2\Configuration\Destination $currentDestination
+     * @param \SAML2\Response $response
      *
      * @return \SAML2\Utilities\ArrayCollection Collection of \SAML2\Assertion objects
      */
@@ -108,15 +108,13 @@ class Processor
 
 
     /**
-     * @param \SAML2\Response                       $response
+     * @param \SAML2\Response $response
      * @param \SAML2\Configuration\IdentityProvider $identityProviderConfiguration
      * @throws InvalidResponseException
      * @return void
      */
-    private function verifySignature(
-        Response $response,
-        IdentityProvider $identityProviderConfiguration
-    ) {
+    private function verifySignature(Response $response, IdentityProvider $identityProviderConfiguration)
+    {
         if (!$response->isMessageConstructedWithSignature()) {
             $this->logger->info(sprintf(
                 'SAMLResponse with id "%s" was not signed at root level, not attempting to verify the signature of the'
@@ -155,7 +153,7 @@ class Processor
 
         if (!$this->responseIsSigned) {
             foreach ($assertions as $assertion) {
-                if (!$assertion->getWasSignedAtConstruction()) {
+                if (!$assertion->wasSignedAtConstruction()) {
                     throw new UnsignedResponseException(
                         'Both the response and the assertion it contains are not signed.'
                     );

--- a/src/SAML2/Response/Validation/ConstraintValidator/DestinationMatches.php
+++ b/src/SAML2/Response/Validation/ConstraintValidator/DestinationMatches.php
@@ -9,7 +9,7 @@ use SAML2\Response;
 use SAML2\Response\Validation\ConstraintValidator;
 use SAML2\Response\Validation\Result;
 
-class DestinationMatches implements
+final class DestinationMatches implements
     ConstraintValidator
 {
     /**
@@ -18,7 +18,8 @@ class DestinationMatches implements
     private $expectedDestination;
 
     /**
-     * Constructor for DestinationMatches
+     * DestinationMatches constructor.
+     *
      * @param Destination $destination
      */
     public function __construct(Destination $destination)
@@ -35,6 +36,9 @@ class DestinationMatches implements
     public function validate(Response $response, Result $result)
     {
         $destination = $response->getDestination();
+        if ($destination === null) {
+            throw new \Exception('No destination set in the response.');
+        }
         if (!$this->expectedDestination->equals(new Destination($destination))) {
             $result->addError(sprintf(
                 'Destination in response "%s" does not match the expected destination "%s"',

--- a/src/SAML2/SOAP.php
+++ b/src/SAML2/SOAP.php
@@ -18,7 +18,7 @@ class SOAP extends Binding
     /**
      * @param Message $message
      * @throws \Exception
-     * @return string|bool The XML or false on error
+     * @return string|false The XML or false on error
      */
     public function getOutputToSend(Message $message)
     {
@@ -81,9 +81,12 @@ SOAP;
         header('Content-Type: text/xml', true);
 
         $xml = $this->getOutputToSend($message);
-        Utils::getContainer()->debugMessage($xml, 'out');
-        echo $xml;
+        if ($xml !== false) {
+            Utils::getContainer()->debugMessage($xml, 'out');
+            echo $xml;
+        }
 
+        // DOMDocument::saveXML() returned false. Something is seriously wrong here. Not much we can do.
         exit(0);
     }
 
@@ -98,20 +101,21 @@ SOAP;
     {
         $postText = $this->getInputStream();
 
-        if (empty($postText)) {
+        if ($postText === false) {
             throw new \Exception('Invalid message received to AssertionConsumerService endpoint.');
         }
 
         $document = DOMDocumentFactory::fromString($postText);
         $xml = $document->firstChild;
         Utils::getContainer()->debugMessage($document->documentElement, 'in');
+        /** @var \DOMElement[] $results */
         $results = Utils::xpQuery($xml, '/soap-env:Envelope/soap-env:Body/*[1]');
 
         return Message::fromXML($results[0]);
     }
 
     /**
-     * @return string|bool
+     * @return string|false
      */
     protected function getInputStream()
     {

--- a/src/SAML2/SOAPClient.php
+++ b/src/SAML2/SOAPClient.php
@@ -11,7 +11,6 @@ use SAML2\Exception\RuntimeException;
 
 use SimpleSAML\Configuration;
 use SimpleSAML\Utils\Config;
-use SimpleSAML\Utils\Crypto;
 
 /**
  * Implementation of the SAML 2.0 SOAP binding.
@@ -35,6 +34,8 @@ class SOAPClient
      * @return \SAML2\Message The response we received.
      * @throws \Exception
      * @return \SAML2\Message            The response we received.
+     *
+     * @psalm-suppress UndefinedClass
      */
     public function send(Message $msg, Configuration $srcMetadata, Configuration $dstMetadata = null) : Message
     {

--- a/src/SAML2/SOAPClient.php
+++ b/src/SAML2/SOAPClient.php
@@ -155,6 +155,7 @@ class SOAPClient
             throw new \Exception($soapfault);
         }
         //Extract the message from the response
+        /** @var \DOMElement[] $samlresponse */
         $samlresponse = Utils::xpQuery($dom->firstChild, '/soap-env:Envelope/soap-env:Body/*[1]');
         $samlresponse = Message::fromXML($samlresponse[0]);
 

--- a/src/SAML2/Signature/PublicKeyValidator.php
+++ b/src/SAML2/Signature/PublicKeyValidator.php
@@ -39,7 +39,7 @@ class PublicKeyValidator extends AbstractChainedValidator
 
 
     /**
-     * @param \SAML2\SignedElement             $signedElement
+     * @param \SAML2\SignedElement $signedElement
      * @param \SAML2\Configuration\CertificateProvider $configuration
      *
      * @return bool
@@ -55,7 +55,7 @@ class PublicKeyValidator extends AbstractChainedValidator
 
 
     /**
-     * @param \SAML2\SignedElement             $signedElement
+     * @param \SAML2\SignedElement $signedElement
      * @param \SAML2\Configuration\CertificateProvider $configuration
      *
      * @return bool

--- a/src/SAML2/Signature/Validator.php
+++ b/src/SAML2/Signature/Validator.php
@@ -33,7 +33,8 @@ class Validator
 
     /**
      * @param SignedElement $signedElement
-     * @oaram CertificateProvider $configuration
+     * @param CertificateProvider $configuration
+     *
      * @return bool
      */
     public function hasValidSignature(

--- a/src/SAML2/Signature/ValidatorChain.php
+++ b/src/SAML2/Signature/ValidatorChain.php
@@ -28,7 +28,7 @@ class ValidatorChain implements ValidatorInterface
 
 
     /**
-     * @param \Psr\Log\LoggerInterface           $logger
+     * @param \Psr\Log\LoggerInterface $logger
      * @param \SAML2\Signature\ChainedValidator[] $validators
      */
     public function __construct(LoggerInterface $logger, array $validators)
@@ -53,7 +53,7 @@ class ValidatorChain implements ValidatorInterface
 
 
     /**
-     * @param \SAML2\SignedElement             $signedElement
+     * @param \SAML2\SignedElement $signedElement
      * @param \SAML2\Configuration\CertificateProvider $configuration
      *
      * @return bool

--- a/src/SAML2/SignedElement.php
+++ b/src/SAML2/SignedElement.php
@@ -14,13 +14,30 @@ use RobRichards\XMLSecLibs\XMLSecurityKey;
 interface SignedElement
 {
     /**
+     * The private key we should use to sign the message.
+     *
+     * The private key can be null, in which case the message is sent unsigned.
+     *
+     * @var XMLSecurityKey|null
+     */
+    protected $signatureKey;
+
+    /**
+     * List of certificates that should be included in the message.
+     *
+     * @var array
+     */
+    protected $certificates;
+
+
+    /**
      * Validate this element against a public key.
      *
      * If no signature is present, false is returned. If a signature is present,
      * but cannot be verified, an exception will be thrown.
      *
      * @param  XMLSecurityKey $key The key we should check against.
-     * @return bool        true if successful, false if we don't have a signature that can be verified.
+     * @return bool True if successful, false if we don't have a signature that can be verified.
      */
     public function validate(XMLSecurityKey $key) : bool;
 

--- a/src/SAML2/SignedElement.php
+++ b/src/SAML2/SignedElement.php
@@ -11,7 +11,7 @@ use RobRichards\XMLSecLibs\XMLSecurityKey;
  *
  * @package SimpleSAMLphp
  */
-abstract SignedElement
+abstract class SignedElement
 {
     /**
      * The private key we should use to sign the message.

--- a/src/SAML2/SignedElement.php
+++ b/src/SAML2/SignedElement.php
@@ -39,7 +39,7 @@ abstract class SignedElement
      * @param  XMLSecurityKey $key The key we should check against.
      * @return bool True if successful, false if we don't have a signature that can be verified.
      */
-    public function validate(XMLSecurityKey $key) : bool;
+    public function validate(XMLSecurityKey $key);
 
 
     /**

--- a/src/SAML2/SignedElement.php
+++ b/src/SAML2/SignedElement.php
@@ -39,7 +39,7 @@ abstract class SignedElement
      * @param  XMLSecurityKey $key The key we should check against.
      * @return bool True if successful, false if we don't have a signature that can be verified.
      */
-    public function validate(XMLSecurityKey $key);
+    abstract public function validate(XMLSecurityKey $key) : bool;
 
 
     /**
@@ -49,7 +49,7 @@ abstract class SignedElement
      * @param array $certificates An array of certificates.
      * @return void
      */
-    public function setCertificates(array $certificates);
+    abstract public function setCertificates(array $certificates);
 
 
     /**
@@ -57,7 +57,7 @@ abstract class SignedElement
      *
      * @return array An array of certificates.
      */
-    public function getCertificates() : array;
+    abstract public function getCertificates() : array;
 
 
     /**
@@ -65,7 +65,7 @@ abstract class SignedElement
      *
      * @return XMLSecurityKey|null The key, or NULL if no key is specified.
      */
-    public function getSignatureKey();
+    abstract public function getSignatureKey();
 
 
     /**
@@ -75,5 +75,5 @@ abstract class SignedElement
      * @param XMLSecurityKey|null $signatureKey
      * @return void
      */
-    public function setSignatureKey(XMLSecurityKey $signatureKey = null);
+    abstract public function setSignatureKey(XMLSecurityKey $signatureKey = null);
 }

--- a/src/SAML2/SignedElement.php
+++ b/src/SAML2/SignedElement.php
@@ -11,7 +11,7 @@ use RobRichards\XMLSecLibs\XMLSecurityKey;
  *
  * @package SimpleSAMLphp
  */
-interface SignedElement
+abstract SignedElement
 {
     /**
      * The private key we should use to sign the message.

--- a/src/SAML2/SignedElement.php
+++ b/src/SAML2/SignedElement.php
@@ -30,7 +30,7 @@ abstract class SignedElement
     protected $certificates = [];
 
 
-      /**
+    /**
      * Validate this element against a public key.
      *
      * If no signature is present, false is returned. If a signature is present,

--- a/src/SAML2/SignedElement.php
+++ b/src/SAML2/SignedElement.php
@@ -27,7 +27,7 @@ abstract class SignedElement
      *
      * @var array
      */
-    protected $certificates;
+    protected $certificates = [];
 
 
       /**

--- a/src/SAML2/SignedElementHelper.php
+++ b/src/SAML2/SignedElementHelper.php
@@ -13,7 +13,7 @@ use RobRichards\XMLSecLibs\XMLSecurityKey;
  *
  * @package SimpleSAMLphp
  */
-class SignedElementHelper implements SignedElement
+class SignedElementHelper extends SignedElement
 {
     /**
      * The private key we should use to sign the message.

--- a/src/SAML2/SignedElementHelper.php
+++ b/src/SAML2/SignedElementHelper.php
@@ -71,7 +71,7 @@ class SignedElementHelper implements SignedElement
         try {
             $sig = Utils::validateElement($xml);
 
-            if ($sig !== false) {
+            if ($sig) {
                 $this->certificates = $sig['Certificates'];
                 $this->validators[] = [
                     'Function' => ['\SAML2\Utils', 'validateSignature'],
@@ -90,7 +90,7 @@ class SignedElementHelper implements SignedElement
      * This function is used for custom validation extensions
      *
      * @param callable $function The function which should be called.
-     * @param mixed    $data     The data that should be included as the first parameter to the function.
+     * @param mixed $data The data that should be included as the first parameter to the function.
      * @return void
      */
     public function addValidator(callable $function, $data)
@@ -110,6 +110,7 @@ class SignedElementHelper implements SignedElement
      * validation fails.
      *
      * @param  XMLSecurityKey $key The key we should check against.
+     * @return bool True on success, false when we don't have a signature.
      * @throws \Exception
      * @return bool        true on success, false when we don't have a signature.
      */

--- a/src/SAML2/SignedElementHelper.php
+++ b/src/SAML2/SignedElementHelper.php
@@ -22,14 +22,14 @@ class SignedElementHelper extends SignedElement
      *
      * @var XMLSecurityKey|null
      */
-    private $signatureKey;
+    protected $signatureKey;
 
     /**
      * List of certificates that should be included in the message.
      *
      * @var array
      */
-    private $certificates;
+    protected $certificates;
 
     /**
      * Available methods for validating this message.

--- a/src/SAML2/SignedElementHelper.php
+++ b/src/SAML2/SignedElementHelper.php
@@ -30,13 +30,6 @@ class SignedElementHelper extends SignedElement
     public $validUntil;
 
     /**
-     * How long this element is valid, as a unix timestamp.
-     *
-     * @var int|null
-     */
-    protected $validUntil;
-
-    /**
      * The length of time this element can be cached, as string.
      *
      * @var string|null

--- a/src/SAML2/SignedElementHelper.php
+++ b/src/SAML2/SignedElementHelper.php
@@ -223,7 +223,7 @@ class SignedElementHelper implements SignedElement
 
 
     /**
-     * Collect the value of the validUntil-property
+     * Collect the value of the validUntil property.
      *
      * @return int|null
      */
@@ -234,7 +234,7 @@ class SignedElementHelper implements SignedElement
 
 
     /**
-     * Set the value of the validUntil-property
+     * Set the value of the validUntil property.
      *
      * @param int|null $validUntil
      * @return void
@@ -246,7 +246,7 @@ class SignedElementHelper implements SignedElement
 
 
     /**
-     * Collect the value of the cacheDuration-property
+     * Collect the value of the cacheDuration property.
      *
      * @return string|null
      */
@@ -257,7 +257,7 @@ class SignedElementHelper implements SignedElement
 
 
     /**
-     * Set the value of the cacheDuration-property
+     * Set the value of the cacheDuration property.
      *
      * @param string|null $cacheDuration
      * @return void
@@ -271,11 +271,11 @@ class SignedElementHelper implements SignedElement
     /**
      * Sign the given XML element.
      *
-     * @param \DOMElement      $root         The element we should sign.
-     * @param \DOMElement|null $insertBefore The element we should insert the signature node before.
+     * @param \DOMElement $root The element we should sign.
+     * @param \DOMNode|null $insertBefore The element we should insert the signature node before.
      * @return \DOMElement|null
      */
-    protected function signElement(\DOMElement $root, \DOMElement $insertBefore = null)
+    protected function signElement(\DOMElement $root, \DOMNode $insertBefore = null)
     {
         if ($this->signatureKey === null) {
             /* We cannot sign this element. */

--- a/src/SAML2/SignedElementHelper.php
+++ b/src/SAML2/SignedElementHelper.php
@@ -39,6 +39,13 @@ class SignedElementHelper implements SignedElement
     private $validators;
 
     /**
+     * How long this element is valid, as a unix timestamp.
+     *
+     * @var int|null
+     */
+    protected $validUntil;
+
+    /**
      * The length of time this element can be cached, as string.
      *
      * @var string|null
@@ -217,6 +224,7 @@ class SignedElementHelper implements SignedElement
 
     /**
      * Collect the value of the validUntil-property
+     *
      * @return int|null
      */
     public function getValidUntil()
@@ -227,7 +235,9 @@ class SignedElementHelper implements SignedElement
 
     /**
      * Set the value of the validUntil-property
+     *
      * @param int|null $validUntil
+     * @return void
      */
     public function setValidUntil(int $validUntil = null)
     {
@@ -237,6 +247,7 @@ class SignedElementHelper implements SignedElement
 
     /**
      * Collect the value of the cacheDuration-property
+     *
      * @return string|null
      */
     public function getCacheDuration()
@@ -247,7 +258,9 @@ class SignedElementHelper implements SignedElement
 
     /**
      * Set the value of the cacheDuration-property
+     *
      * @param string|null $cacheDuration
+     * @return void
      */
     public function setCacheDuration(string $cacheDuration = null)
     {

--- a/src/SAML2/StatusResponse.php
+++ b/src/SAML2/StatusResponse.php
@@ -69,26 +69,27 @@ abstract class StatusResponse extends Message
             $this->inResponseTo = $xml->getAttribute('InResponseTo');
         }
 
+        /** @var \DOMElement[] $status */
         $status = Utils::xpQuery($xml, './saml_protocol:Status');
         if (empty($status)) {
             throw new \Exception('Missing status code on response.');
         }
-        $status = $status[0];
 
-        $statusCode = Utils::xpQuery($status, './saml_protocol:StatusCode');
+        /** @var \DOMElement[] $statusCode */
+        $statusCode = Utils::xpQuery($status[0], './saml_protocol:StatusCode');
         if (empty($statusCode)) {
             throw new \Exception('Missing status code in status element.');
         }
-        $statusCode = $statusCode[0];
+        $this->status['Code'] = $statusCode[0]->getAttribute('Value');
 
-        $this->status['Code'] = $statusCode->getAttribute('Value');
-
-        $subCode = Utils::xpQuery($statusCode, './saml_protocol:StatusCode');
+        /** @var \DOMElement[] $subCode */
+        $subCode = Utils::xpQuery($statusCode[0], './saml_protocol:StatusCode');
         if (!empty($subCode)) {
             $this->status['SubCode'] = $subCode[0]->getAttribute('Value');
         }
 
-        $message = Utils::xpQuery($status, './saml_protocol:StatusMessage');
+        /** @var \DOMElement[] $message */
+        $message = Utils::xpQuery($status[0], './saml_protocol:StatusMessage');
         if (!empty($message)) {
             $this->status['Message'] = trim($message[0]->textContent);
         }

--- a/src/SAML2/StatusResponse.php
+++ b/src/SAML2/StatusResponse.php
@@ -47,8 +47,8 @@ abstract class StatusResponse extends Message
     /**
      * Constructor for SAML 2 response messages.
      *
-     * @param string          $tagName The tag name of the root element.
-     * @param \DOMElement|null $xml     The input message.
+     * @param string $tagName The tag name of the root element.
+     * @param \DOMElement|null $xml The input message.
      * @throws \Exception
      */
     protected function __construct(string $tagName, \DOMElement $xml = null)
@@ -104,11 +104,7 @@ abstract class StatusResponse extends Message
     {
         Assert::keyExists($this->status, "Code");
 
-        if ($this->status['Code'] === Constants::STATUS_SUCCESS) {
-            return true;
-        }
-
-        return false;
+        return $this->status['Code'] === Constants::STATUS_SUCCESS;
     }
 
 
@@ -154,7 +150,7 @@ abstract class StatusResponse extends Message
      */
     public function setStatus(array $status)
     {
-        Assert::keyExists($status, "Code");
+        Assert::keyExists($status, "Code", 'Cannot set status without a Code key in the array.');
 
         $this->status = $status;
         if (!array_key_exists('SubCode', $status)) {

--- a/src/SAML2/SubjectQuery.php
+++ b/src/SAML2/SubjectQuery.php
@@ -22,16 +22,16 @@ abstract class SubjectQuery extends Request
     /**
      * The NameId of the subject in the query.
      *
-     * @var \SAML2\XML\saml\NameID
+     * @var \SAML2\XML\saml\NameID|null
      */
-    private $nameId;
+    private $nameId = null;
 
 
     /**
      * Constructor for SAML 2 subject query messages.
      *
-     * @param string          $tagName The tag name of the root element.
-     * @param \DOMElement|null $xml     The input message.
+     * @param string $tagName The tag name of the root element.
+     * @param \DOMElement|null $xml The input message.
      */
     protected function __construct(string $tagName, \DOMElement $xml = null)
     {
@@ -49,6 +49,7 @@ abstract class SubjectQuery extends Request
      * Parse subject in query.
      *
      * @param \DOMElement $xml The SubjectQuery XML element.
+     * @return void
      * @throws \Exception
      * @return void
      */
@@ -56,7 +57,6 @@ abstract class SubjectQuery extends Request
     {
         $subject = Utils::xpQuery($xml, './saml_assertion:Subject');
         if (empty($subject)) {
-            /* No Subject node. */
             throw new \Exception('Missing subject in subject query.');
         } elseif (count($subject) > 1) {
             throw new \Exception('More than one <saml:Subject> in subject query.');
@@ -104,6 +104,9 @@ abstract class SubjectQuery extends Request
      */
     public function toUnsignedXML() : \DOMElement
     {
+        if ($this->nameId === null) {
+            throw new \Exception('Cannot convert SubjectQuery to XML without a NameID set.');
+        }
         $root = parent::toUnsignedXML();
 
         $subject = $root->ownerDocument->createElementNS(Constants::NS_SAML, 'saml:Subject');

--- a/src/SAML2/SubjectQuery.php
+++ b/src/SAML2/SubjectQuery.php
@@ -55,22 +55,22 @@ abstract class SubjectQuery extends Request
      */
     private function parseSubject(\DOMElement $xml)
     {
+        /** @var \DOMElement[] $subject */
         $subject = Utils::xpQuery($xml, './saml_assertion:Subject');
         if (empty($subject)) {
             throw new \Exception('Missing subject in subject query.');
         } elseif (count($subject) > 1) {
             throw new \Exception('More than one <saml:Subject> in subject query.');
         }
-        $subject = $subject[0];
 
-        $nameId = Utils::xpQuery($subject, './saml_assertion:NameID');
+        /** @var \DOMElement[] $nameId */
+        $nameId = Utils::xpQuery($subject[0], './saml_assertion:NameID');
         if (empty($nameId)) {
             throw new \Exception('Missing <saml:NameID> in <saml:Subject>.');
         } elseif (count($nameId) > 1) {
             throw new \Exception('More than one <saml:NameID> in <saml:Subject>.');
         }
-        $nameId = $nameId[0];
-        $this->nameId = new NameID($nameId);
+        $this->nameId = new NameID($nameId[0]);
     }
 
 

--- a/src/SAML2/Utilities/ArrayCollection.php
+++ b/src/SAML2/Utilities/ArrayCollection.php
@@ -20,7 +20,9 @@ class ArrayCollection implements Collection
 
 
     /**
-     * @return void
+     * ArrayCollection constructor.
+     *
+     * @param array $elements
      */
     public function __construct(array $elements = [])
     {
@@ -29,6 +31,8 @@ class ArrayCollection implements Collection
 
 
     /**
+     * @param mixed $element
+     *
      * @return void
      */
     public function add($element)
@@ -38,6 +42,8 @@ class ArrayCollection implements Collection
 
 
     /**
+     * @param mixed $key
+     *
      * @return mixed|null
      */
     public function get($key)
@@ -47,6 +53,8 @@ class ArrayCollection implements Collection
 
 
     /**
+     * @param \Closure $f
+     *
      * @return ArrayCollection
      */
     public function filter(\Closure $f) : Collection
@@ -56,6 +64,8 @@ class ArrayCollection implements Collection
 
 
     /**
+     * @param mixed $key
+     * @param mixed $value
      * @return void
      */
     public function set($key, $value)
@@ -65,7 +75,9 @@ class ArrayCollection implements Collection
 
 
     /**
-     * @return mixed
+     * @param mixed $element
+     *
+     * @return bool|mixed
      */
     public function remove($element)
     {
@@ -84,7 +96,7 @@ class ArrayCollection implements Collection
 
     /**
      * @throws RuntimeException
-     * @return mixed
+     * @return bool|mixed
      */
     public function getOnlyElement()
     {
@@ -101,7 +113,7 @@ class ArrayCollection implements Collection
 
 
     /**
-     * @return mixed
+     * @return bool|mixed
      */
     public function first()
     {
@@ -110,7 +122,7 @@ class ArrayCollection implements Collection
 
 
     /**
-     * @return mixed
+     * @return bool|mixed
      */
     public function last()
     {
@@ -119,6 +131,8 @@ class ArrayCollection implements Collection
 
 
     /**
+     * @param \Closure $function
+     *
      * @return ArrayCollection
      */
     public function map(\Closure $function) : ArrayCollection
@@ -147,6 +161,7 @@ class ArrayCollection implements Collection
 
     /**
      * @param mixed $offset
+     *
      * @return bool
      */
     public function offsetExists($offset) : bool
@@ -157,6 +172,7 @@ class ArrayCollection implements Collection
 
     /**
      * @param mixed $offset
+     *
      * @return mixed
      */
     public function offsetGet($offset)
@@ -177,7 +193,7 @@ class ArrayCollection implements Collection
 
 
     /**
-     * @param mixed
+     * @param $offset
      * @return void
      */
     public function offsetUnset($offset)

--- a/src/SAML2/Utilities/ArrayCollection.php
+++ b/src/SAML2/Utilities/ArrayCollection.php
@@ -77,20 +77,15 @@ class ArrayCollection implements Collection
     /**
      * @param mixed $element
      *
-     * @return bool|mixed
+     * @return void
      */
     public function remove($element)
     {
         $key = array_search($element, $this->elements);
-
         if ($key === false) {
-            return false;
+            return;
         }
-
-        $removed = $this->elements[$key];
         unset($this->elements[$key]);
-
-        return $removed;
     }
 
 

--- a/src/SAML2/Utilities/Collection.php
+++ b/src/SAML2/Utilities/Collection.php
@@ -9,9 +9,9 @@ interface Collection extends \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Add an element to the collection
      *
-     * @param $element
+     * @param mixed $element
      *
-     * @return $this|\SAML2\Utilities\Collection
+     * @return void
      */
     public function add($element);
 
@@ -43,9 +43,10 @@ interface Collection extends \ArrayAccess, \Countable, \IteratorAggregate
 
 
     /**
-     * Applies the given function to each element in the collection and returns a new collection with the elements returned by the function.
+     * Applies the given function to each element in the collection and returns a new collection with the elements
+     * returned by the function.
      *
-     * @param callable $function
+     * @param \Closure $function
      *
      * @return mixed
      */
@@ -53,7 +54,7 @@ interface Collection extends \ArrayAccess, \Countable, \IteratorAggregate
 
 
     /**
-     * @param callable $filterFunction
+     * @param \Closure $filterFunction
      *
      * @return \SAML2\Utilities\Collection
      */
@@ -71,7 +72,7 @@ interface Collection extends \ArrayAccess, \Countable, \IteratorAggregate
 
 
     /**
-     * @param $element
+     * @param mixed $element
      * @return void
      */
     public function remove($element);

--- a/src/SAML2/Utils.php
+++ b/src/SAML2/Utils.php
@@ -167,8 +167,11 @@ class Utils
 
         /** @var XMLSecurityDSig $objXMLSecDSig */
         $objXMLSecDSig = $info['Signature'];
-
-        /** @var \DOMElement[] $sigMethod */
+        
+        /**
+         * @var \DOMElement[] $sigMethod
+         * @psalm-suppress UndefinedClass
+         */
         $sigMethod = self::xpQuery($objXMLSecDSig->sigNode, './ds:SignedInfo/ds:SignatureMethod');
         if (empty($sigMethod)) {
             throw new \Exception('Missing SignatureMethod element.');
@@ -421,7 +424,10 @@ class Utils
             }
 
             try {
-                /** @var string $key */
+                /**
+                 * @var string $key
+                 * @psalm-suppress UndefinedClass
+                 */
                 $key = $encKey->decryptKey($symmetricKeyInfo);
                 if (strlen($key) !== $keySize) {
                     throw new \Exception(
@@ -472,7 +478,10 @@ class Utils
             throw new \Exception('Algorithm disabled: '.var_export($algorithm, true));
         }
 
-        /** @var string $decrypted */
+        /**
+         * @var string $decrypted
+         * @psalm-suppress UndefinedClass
+         */
         $decrypted = $enc->decryptNode($symmetricKey, false);
 
         /*

--- a/src/SAML2/Utils.php
+++ b/src/SAML2/Utils.php
@@ -647,7 +647,7 @@ class Utils
         $keyInfo->addInfo($x509Data);
 
         $keyDescriptor = new KeyDescriptor();
-        $keyDescriptor->KeyInfo = $keyInfo;
+        $keyDescriptor->setKeyInfo($keyInfo);
 
         return $keyDescriptor;
     }

--- a/src/SAML2/Utils.php
+++ b/src/SAML2/Utils.php
@@ -28,7 +28,7 @@ class Utils
     /**
      * Check the Signature in a XML element.
      *
-     * This function expects the XML element to contain a Signature-element
+     * This function expects the XML element to contain a Signature element
      * which contains a reference to the XML-element. This is common for both
      * messages and assertions.
      *
@@ -42,7 +42,7 @@ class Utils
      *
      * @param \DOMElement $root The element which should be validated.
      * @throws \Exception
-     * @return array|bool An array with information about the Signature-element.
+     * @return array|false An array with information about the Signature element.
      */
     public static function validateElement(\DOMElement $root)
     {
@@ -53,8 +53,9 @@ class Utils
         $objXMLSecDSig->idKeys[] = 'ID';
 
         /* Locate the XMLDSig Signature element to be used. */
+        /** @var \DOMElement[] $signatureElement */
         $signatureElement = self::xpQuery($root, './ds:Signature');
-        if (count($signatureElement) === 0) {
+        if (empty($signatureElement)) {
             /* We don't have a signature element ot validate. */
 
             return false;
@@ -154,7 +155,7 @@ class Utils
      *
      * An exception is thrown if we are unable to validate the signature.
      *
-     * @param array $info The information returned by the validateElement()-function.
+     * @param array $info The information returned by the validateElement() function.
      * @param XMLSecurityKey $key The publickey that should validate the Signature object.
      * @return void
      * @throws \Exception
@@ -167,6 +168,7 @@ class Utils
         /** @var XMLSecurityDSig $objXMLSecDSig */
         $objXMLSecDSig = $info['Signature'];
 
+        /** @var \DOMElement[] $sigMethod */
         $sigMethod = self::xpQuery($objXMLSecDSig->sigNode, './ds:SignedInfo/ds:SignatureMethod');
         if (empty($sigMethod)) {
             throw new \Exception('Missing SignatureMethod element.');
@@ -193,7 +195,7 @@ class Utils
      *
      * @param \DOMNode $node  The XML node.
      * @param string $query The query.
-     * @return \DOMElement[] Array with matching DOM nodes.
+     * @return \DOMNode[] Array with matching DOM nodes.
      */
     public static function xpQuery(\DOMNode $node, string $query) : array
     {
@@ -299,7 +301,7 @@ class Utils
 
 
     /**
-     * Insert a Signature-node.
+     * Insert a Signature node.
      *
      * @param XMLSecurityKey $key The key we should use to sign the message.
      * @param array $certificates The certificates we should add to the signature node.
@@ -357,7 +359,7 @@ class Utils
      * @param array &$blacklist Blacklisted decryption algorithms.
      * @return \DOMElement The decrypted element.
      * @throws \Exception
-     * @return \DOMElement     The decrypted element.
+     * @return \DOMElement The decrypted element.
      */
     private static function doDecryptElement(\DOMElement $encryptedData, XMLSecurityKey $inputKey, array &$blacklist) : \DOMElement
     {

--- a/src/SAML2/Utils.php
+++ b/src/SAML2/Utils.php
@@ -170,7 +170,7 @@ class Utils
         
         /**
          * @var \DOMElement[] $sigMethod
-         * @psalm-suppress UndefinedClass
+         * @var \DOMElement $objXMLSecDSig->sigNode
          */
         $sigMethod = self::xpQuery($objXMLSecDSig->sigNode, './ds:SignedInfo/ds:SignatureMethod');
         if (empty($sigMethod)) {

--- a/src/SAML2/XML/Chunk.php
+++ b/src/SAML2/XML/Chunk.php
@@ -43,10 +43,21 @@ class Chunk implements \Serializable
      */
     public function __construct(\DOMElement $xml)
     {
-        $this->setLocalName($xml->localName);
-        $this->setNamespaceURI($xml->namespaceURI);
+        $this->localName = $xml->localName;
+        $this->namespaceURI = $xml->namespaceURI;
 
         $this->xml = Utils::copyElement($xml);
+    }
+
+
+    /**
+     * Get this \DOMElement.
+     *
+     * @return \DOMElement This element.
+     */
+    public function getXML()
+    {
+        return $this->xml;
     }
 
 
@@ -64,6 +75,7 @@ class Chunk implements \Serializable
 
     /**
      * Collect the value of the localName-property
+     *
      * @return string
      */
     public function getLocalName() : string
@@ -74,6 +86,7 @@ class Chunk implements \Serializable
 
     /**
      * Set the value of the localName-property
+     *
      * @param string $localName
      * @return void
      */
@@ -85,6 +98,7 @@ class Chunk implements \Serializable
 
     /**
      * Collect the value of the namespaceURI-property
+     *
      * @return string|null
      */
     public function getNamespaceURI()
@@ -95,6 +109,7 @@ class Chunk implements \Serializable
 
     /**
      * Set the value of the namespaceURI-property
+     *
      * @param string|null $namespaceURI
      * @return void
      */
@@ -117,6 +132,7 @@ class Chunk implements \Serializable
 
     /**
      * Set the value of the xml-property
+     *
      * @param \DOMelement $xml
      * @return void
      */
@@ -136,11 +152,11 @@ class Chunk implements \Serializable
         return serialize($this->xml->ownerDocument->saveXML($this->xml));
     }
 
-
+    
     /**
      * Un-serialize this XML chunk.
      *
-     * @param string          $serialized The serialized chunk.
+     * @param string $serialized The serialized chunk.
      * @return void
      *
      * Type hint not possible due to upstream method signature

--- a/src/SAML2/XML/Chunk.php
+++ b/src/SAML2/XML/Chunk.php
@@ -120,29 +120,6 @@ class Chunk implements \Serializable
 
 
     /**
-     * Get this \DOMElement.
-     *
-     * @return \DOMElement This element.
-     */
-    public function getXml() : \DOMElement
-    {
-        return $this->xml;
-    }
-
-
-    /**
-     * Set the value of the xml-property
-     *
-     * @param \DOMelement $xml
-     * @return void
-     */
-    private function setXml(\DOMElement $xml)
-    {
-        $this->xml = $xml;
-    }
-
-
-    /**
      * Serialize this XML chunk.
      *
      * @return string The serialized chunk.

--- a/src/SAML2/XML/alg/DigestMethod.php
+++ b/src/SAML2/XML/alg/DigestMethod.php
@@ -75,7 +75,7 @@ class DigestMethod
      */
     public function toXML(\DOMElement $parent) : \DOMElement
     {
-        Assertion::notNull($this->Algorithm, 'Cannot convert DigestMethod to XML without an Algorithm set.');
+        Assert::notNull($this->Algorithm, 'Cannot convert DigestMethod to XML without an Algorithm set.');
 
         $doc = $parent->ownerDocument;
         $e = $doc->createElementNS(Common::NS, 'alg:DigestMethod');

--- a/src/SAML2/XML/alg/DigestMethod.php
+++ b/src/SAML2/XML/alg/DigestMethod.php
@@ -48,7 +48,7 @@ class DigestMethod
      *
      * @return string|null
      */
-    public function getAlgorithm() : string
+    public function getAlgorithm()
     {
         return $this->Algorithm;
     }
@@ -80,6 +80,7 @@ class DigestMethod
         $doc = $parent->ownerDocument;
         $e = $doc->createElementNS(Common::NS, 'alg:DigestMethod');
         $parent->appendChild($e);
+        /** @psalm-suppress PossiblyNullArgument */
         $e->setAttribute('Algorithm', $this->Algorithm);
 
         return $e;

--- a/src/SAML2/XML/alg/DigestMethod.php
+++ b/src/SAML2/XML/alg/DigestMethod.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SAML2\XML\alg;
 
+use Webmozart\Assert\Assert;
+
 /**
  * Class for handling the alg:DigestMethod element.
  *
@@ -16,9 +18,9 @@ class DigestMethod
     /**
      * An URI identifying an algorithm supported for digest operations.
      *
-     * @var string
+     * @var string|null
      */
-    public $Algorithm;
+    private $Algorithm = null;
 
 
     /**
@@ -43,7 +45,8 @@ class DigestMethod
 
     /**
      * Collect the value of the algorithm-property
-     * @return string
+     *
+     * @return string|null
      */
     public function getAlgorithm() : string
     {
@@ -53,6 +56,7 @@ class DigestMethod
 
     /**
      * Set the value of the Algorithm-property
+     *
      * @param string $algorithm
      * @return void
      */
@@ -67,13 +71,16 @@ class DigestMethod
      *
      * @param \DOMElement $parent The element we should append to.
      * @return \DOMElement
+     * @throws \Exception
      */
     public function toXML(\DOMElement $parent) : \DOMElement
     {
+        Assertion::notNull($this->Algorithm, 'Cannot convert DigestMethod to XML without an Algorithm set.');
+
         $doc = $parent->ownerDocument;
         $e = $doc->createElementNS(Common::NS, 'alg:DigestMethod');
         $parent->appendChild($e);
-        $e->setAttribute('Algorithm', $this->getAlgorithm());
+        $e->setAttribute('Algorithm', $this->Algorithm);
 
         return $e;
     }

--- a/src/SAML2/XML/alg/SigningMethod.php
+++ b/src/SAML2/XML/alg/SigningMethod.php
@@ -70,9 +70,9 @@ class SigningMethod
     /**
      * Collect the value of the Algorithm-property
      *
-     * @return string
+     * @return string|null
      */
-    public function getAlgorithm() : string
+    public function getAlgorithm()
     {
         return $this->Algorithm;
     }
@@ -152,6 +152,7 @@ class SigningMethod
         $doc = $parent->ownerDocument;
         $e = $doc->createElementNS(Common::NS, 'alg:SigningMethod');
         $parent->appendChild($e);
+        /** @psalm-suppress PossiblyNullArgument */
         $e->setAttribute('Algorithm', $this->Algorithm);
 
         if ($this->MinKeySize !== null) {

--- a/src/SAML2/XML/alg/SigningMethod.php
+++ b/src/SAML2/XML/alg/SigningMethod.php
@@ -18,10 +18,9 @@ class SigningMethod
     /**
      * An URI identifying the algorithm supported for XML signature operations.
      *
-     * @var string
+     * @var string|null
      */
-    public $Algorithm;
-
+    private $Algorithm = null;
 
     /**
      * The smallest key size, in bits, that the entity supports in conjunction with the algorithm. If omitted, no
@@ -29,8 +28,7 @@ class SigningMethod
      *
      * @var int|null
      */
-    public $MinKeySize;
-
+    private $MinKeySize = null;
 
     /**
      * The largest key size, in bits, that the entity supports in conjunction with the algorithm. If omitted, no
@@ -38,11 +36,40 @@ class SigningMethod
      *
      * @var int|null
      */
-    public $MaxKeySize;
+    private $MaxKeySize = null;
+
+
+    /**
+     * Create/parse an alg:SigningMethod element.
+     *
+     * @param \DOMElement|null $xml The XML element we should load or null to create a new one from scratch.
+     *
+     * @throws \Exception
+     */
+    public function __construct(\DOMElement $xml = null)
+    {
+        if ($xml === null) {
+            return;
+        }
+
+        if (!$xml->hasAttribute('Algorithm')) {
+            throw new \Exception('Missing required attribute "Algorithm" in alg:SigningMethod element.');
+        }
+        $this->Algorithm = $xml->getAttribute('Algorithm');
+
+        if ($xml->hasAttribute('MinKeySize')) {
+            $this->MinKeySize = intval($xml->getAttribute('MinKeySize'));
+        }
+
+        if ($xml->hasAttribute('MaxKeySize')) {
+            $this->MaxKeySize = intval($xml->getAttribute('MaxKeySize'));
+        }
+    }
 
 
     /**
      * Collect the value of the Algorithm-property
+     *
      * @return string
      */
     public function getAlgorithm() : string
@@ -53,6 +80,7 @@ class SigningMethod
 
     /**
      * Set the value of the Algorithm-property
+     *
      * @param string $algorithm
      * @return void
      */
@@ -64,6 +92,7 @@ class SigningMethod
 
     /**
      * Collect the value of the MinKeySize-property
+     *
      * @return int|null
      */
     public function getMinKeySize()
@@ -74,6 +103,7 @@ class SigningMethod
 
     /**
      * Set the value of the MinKeySize-property
+     *
      * @param int|null $minKeySize
      * @return void
      */
@@ -85,6 +115,7 @@ class SigningMethod
 
     /**
      * Collect the value of the MaxKeySize-property
+     *
      * @return int|null
      */
     public function getMaxKeySize()
@@ -95,6 +126,7 @@ class SigningMethod
 
     /**
      * Set the value of the MaxKeySize-property
+     *
      * @param int|null $maxKeySize
      * @return void
      */
@@ -105,41 +137,15 @@ class SigningMethod
 
 
     /**
-     * Create/parse an alg:SigningMethod element.
-     *
-     * @param \DOMElement|null $xml The XML element we should load or null to create a new one from scratch.
-     * @throws \Exception
-     * @return void
-     */
-    public function __construct(\DOMElement $xml = null)
-    {
-        if ($xml === null) {
-            return;
-        }
-
-        if (!$xml->hasAttribute('Algorithm')) {
-            throw new \Exception('Missing required attribute "Algorithm" in alg:SigningMethod element.');
-        }
-        $this->setAlgorithm($xml->getAttribute('Algorithm'));
-
-        if ($xml->hasAttribute('MinKeySize')) {
-            $this->setMinKeySize(intval($xml->getAttribute('MinKeySize')));
-        }
-
-        if ($xml->hasAttribute('MaxKeySize')) {
-            $this->setMaxKeySize(intval($xml->getAttribute('MaxKeySize')));
-        }
-    }
-
-
-    /**
      * Convert this element to XML.
      *
      * @param \DOMElement $parent The element we should append to.
      * @return \DOMElement
+     * @throws \Exception
      */
     public function toXML(\DOMElement $parent) : \DOMElement
     {
+        Assert::notNull($this->Algorithm, 'Cannot convert SigningMethod to XML without an Algorithm set.');
         Assert::nullOrInteger($this->MinKeySize);
         Assert::nullOrInteger($this->MaxKeySize);
 

--- a/src/SAML2/XML/ds/KeyInfo.php
+++ b/src/SAML2/XML/ds/KeyInfo.php
@@ -128,8 +128,11 @@ class KeyInfo
      */
     public function addInfo($info)
     {
-        Assert::isInstanceOfAny($info, [Chunk::class, KeyName::class, X509Data::class],
-            'KeyInfo can only contain instances of KeyName, X509Data or Chunk.');
+        Assert::isInstanceOfAny(
+            $info,
+            [Chunk::class, KeyName::class, X509Data::class],
+            'KeyInfo can only contain instances of KeyName, X509Data or Chunk.'
+        );
         $this->info[] = $info;
     }
 

--- a/src/SAML2/XML/ds/KeyInfo.php
+++ b/src/SAML2/XML/ds/KeyInfo.php
@@ -49,7 +49,7 @@ class KeyInfo
             $this->Id = $xml->getAttribute('Id');
         }
 
-        for ($n = $xml->firstChild; $n instanceof \DOMNode; $n = $n->nextSibling) {
+        foreach ($xml->childNodes as $n) {
             if (!($n instanceof \DOMElement)) {
                 continue;
             }

--- a/src/SAML2/XML/ds/KeyName.php
+++ b/src/SAML2/XML/ds/KeyName.php
@@ -40,6 +40,7 @@ class KeyName
 
     /**
      * Collect the value of the name-property
+     *
      * @return string
      */
     public function getName() : string
@@ -50,6 +51,7 @@ class KeyName
 
     /**
      * Set the value of the name-property
+     *
      * @param string $name
      * @return void
      */
@@ -57,6 +59,7 @@ class KeyName
     {
         $this->name = $name;
     }
+
 
     /**
      * Convert this KeyName element to XML.

--- a/src/SAML2/XML/ds/X509Certificate.php
+++ b/src/SAML2/XML/ds/X509Certificate.php
@@ -40,6 +40,7 @@ class X509Certificate
 
     /**
      * Collect the value of the certificate-property
+     *
      * @return string
      */
     public function getCertificate() : string
@@ -50,6 +51,7 @@ class X509Certificate
 
     /**
      * Set the value of the certificate-property
+     *
      * @param string $certificate
      * @return void
      */

--- a/src/SAML2/XML/ds/X509Data.php
+++ b/src/SAML2/XML/ds/X509Data.php
@@ -39,7 +39,7 @@ class X509Data
             return;
         }
 
-        for ($n = $xml->firstChild; $n !== null; $n = $n->nextSibling) {
+        for ($n = $xml->firstChild;; $n = $n->nextSibling) {
             if (!($n instanceof \DOMElement)) {
                 continue;
             }
@@ -62,6 +62,7 @@ class X509Data
 
     /**
      * Collect the value of the data-property
+     *
      * @return array
      */
     public function getData() : array
@@ -72,6 +73,7 @@ class X509Data
 
     /**
      * Set the value of the data-property
+     *
      * @param array $data
      * @return void
      */
@@ -83,6 +85,7 @@ class X509Data
 
     /**
      * Add the value to the data-property
+     *
      * @param \SAML2\XML\Chunk|\SAML2\XML\ds\X509Certificate $data
      * @return void
      */

--- a/src/SAML2/XML/ecp/Response.php
+++ b/src/SAML2/XML/ecp/Response.php
@@ -57,6 +57,7 @@ class Response
 
     /**
      * Collect the value of the AssertionConsumerServiceURL-property
+     *
      * @return string
      */
     public function getAssertionConsumerServiceURL() : string
@@ -67,6 +68,7 @@ class Response
 
     /**
      * Set the value of the AssertionConsumerServiceURL-property
+     *
      * @param string $assertionConsumerServiceURL
      * @throws InvalidArgumentException
      * @return void

--- a/src/SAML2/XML/md/AdditionalMetadataLocation.php
+++ b/src/SAML2/XML/md/AdditionalMetadataLocation.php
@@ -52,6 +52,7 @@ class AdditionalMetadataLocation
 
     /**
      * Collect the value of the namespace-property
+     *
      * @return string
      */
     public function getNamespace() : string
@@ -62,6 +63,7 @@ class AdditionalMetadataLocation
 
     /**
      * Set the value of the namespace-property
+     *
      * @param string $namespace
      * @return void
      */
@@ -73,6 +75,7 @@ class AdditionalMetadataLocation
 
     /**
      * Collect the value of the location-property
+     *
      * @return string
      */
     public function getLocation() : string
@@ -83,6 +86,7 @@ class AdditionalMetadataLocation
 
     /**
      * Set the value of the location-property
+     *
      * @param string $location
      * @return void
      */

--- a/src/SAML2/XML/md/AffiliationDescriptor.php
+++ b/src/SAML2/XML/md/AffiliationDescriptor.php
@@ -29,28 +29,14 @@ class AffiliationDescriptor extends SignedElementHelper
      *
      * @var string|null
      */
-    public $ID = null;
-
-    /**
-     * How long this element is valid, as a unix timestamp.
-     *
-     * @var int|null
-     */
-    public $validUntil = null;
-
-    /**
-     * The length of time this element can be cached, as string.
-     *
-     * @var string|null
-     */
-    public $cacheDuration = null;
+    private $ID = null;
 
     /**
      * Extensions on this element.
      *
      * Array of extension elements.
      *
-     * @var \SAML2\XML\Chunk[]
+     * @var array
      */
     public $Extensions = [];
 
@@ -119,6 +105,7 @@ class AffiliationDescriptor extends SignedElementHelper
 
     /**
      * Collect the value of the affiliationOwnerId-property
+     *
      * @return string
      */
     public function getAffiliationOwnerID() : string
@@ -129,6 +116,7 @@ class AffiliationDescriptor extends SignedElementHelper
 
     /**
      * Set the value of the affiliationOwnerId-property
+     *
      * @param string $affiliationOwnerId
      * @return void
      */
@@ -140,6 +128,7 @@ class AffiliationDescriptor extends SignedElementHelper
 
     /**
      * Collect the value of the ID-property
+     *
      * @return string|null
      */
     public function getID()
@@ -150,6 +139,7 @@ class AffiliationDescriptor extends SignedElementHelper
 
     /**
      * Set the value of the ID-property
+     *
      * @param string|null $Id
      * @return void
      */
@@ -160,49 +150,8 @@ class AffiliationDescriptor extends SignedElementHelper
 
 
     /**
-     * Collect the value of the validUntil-property
-     * @return int|null
-     */
-    public function getValidUntil()
-    {
-        return $this->validUntil;
-    }
-
-
-    /**
-     * Set the value of the validUntil-property
-     * @param int|null $validUntil
-     * @return void
-     */
-    public function setValidUntil(int $validUntil = null)
-    {
-        $this->validUntil = $validUntil;
-    }
-
-
-    /**
-     * Collect the value of the cacheDuration-property
-     * @return string|null
-     */
-    public function getCacheDuration()
-    {
-        return $this->cacheDuration;
-    }
-
-
-    /**
-     * Set the value of the cacheDuration-property
-     * @param string|null $cacheDuration
-     * @return void
-     */
-    public function setCacheDuration(string $cacheDuration = null)
-    {
-        $this->cacheDuration = $cacheDuration;
-    }
-
-
-    /**
      * Collect the value of the Extensions-property
+     *
      * @return \SAML2\XML\Chunk[]
      */
     public function getExtensions() : array
@@ -213,6 +162,7 @@ class AffiliationDescriptor extends SignedElementHelper
 
     /**
      * Set the value of the Extensions-property
+     *
      * @param array $extensions
      * @return void
      */
@@ -225,7 +175,7 @@ class AffiliationDescriptor extends SignedElementHelper
     /**
      * Add an Extension.
      *
-     * @param \SAML2\XML\Chunk $extensions The Extensions
+     * @param Extensions $extensions The Extensions
      * @return void
      */
     public function addExtension(Extensions $extension)
@@ -236,6 +186,7 @@ class AffiliationDescriptor extends SignedElementHelper
 
     /**
      * Collect the value of the AffiliateMember-property
+     *
      * @return array
      */
     public function getAffiliateMember() : array
@@ -246,6 +197,7 @@ class AffiliationDescriptor extends SignedElementHelper
 
     /**
      * Set the value of the AffiliateMember-property
+     *
      * @param array $affiliateMember
      * @return void
      */
@@ -257,6 +209,7 @@ class AffiliationDescriptor extends SignedElementHelper
 
     /**
      * Collect the value of the KeyDescriptor-property
+     *
      * @return \SAML2\XML\md\KeyDescriptor[]
      */
     public function getKeyDescriptor() : array
@@ -267,6 +220,7 @@ class AffiliationDescriptor extends SignedElementHelper
 
     /**
      * Set the value of the KeyDescriptor-property
+     *
      * @param array $keyDescriptor
      * @return void
      */
@@ -278,6 +232,7 @@ class AffiliationDescriptor extends SignedElementHelper
 
     /**
      * Add the value to the KeyDescriptor-property
+     *
      * @param \SAML2\XML\md\KeyDescriptor $keyDescriptor
      * @return void
      */

--- a/src/SAML2/XML/md/AffiliationDescriptor.php
+++ b/src/SAML2/XML/md/AffiliationDescriptor.php
@@ -97,6 +97,7 @@ class AffiliationDescriptor extends SignedElementHelper
             throw new \Exception('Missing AffiliateMember in AffiliationDescriptor.');
         }
 
+        /** @var \DOMElement $kd */
         foreach (Utils::xpQuery($xml, './saml_metadata:KeyDescriptor') as $kd) {
             $this->addKeyDescriptor(new KeyDescriptor($kd));
         }

--- a/src/SAML2/XML/md/AttributeAuthorityDescriptor.php
+++ b/src/SAML2/XML/md/AttributeAuthorityDescriptor.php
@@ -77,6 +77,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
             return;
         }
 
+        /** @var \DOMElement $ep */
         foreach (Utils::xpQuery($xml, './saml_metadata:AttributeService') as $ep) {
             $this->addAttributeService(new EndpointType($ep));
         }
@@ -84,6 +85,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
             throw new \Exception('Must have at least one AttributeService in AttributeAuthorityDescriptor.');
         }
 
+        /** @var \DOMElement $ep */
         foreach (Utils::xpQuery($xml, './saml_metadata:AssertionIDRequestService') as $ep) {
             $this->addAssertionIDRequestService(new EndpointType($ep));
         }
@@ -92,6 +94,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
 
         $this->setAttributeProfile(Utils::extractStrings($xml, Constants::NS_MD, 'AttributeProfile'));
 
+        /** @var \DOMElement $a */
         foreach (Utils::xpQuery($xml, './saml_assertion:Attribute') as $a) {
             $this->addAttribute(new Attribute($a));
         }

--- a/src/SAML2/XML/md/AttributeAuthorityDescriptor.php
+++ b/src/SAML2/XML/md/AttributeAuthorityDescriptor.php
@@ -100,6 +100,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Collect the value of the AttributeService-property
+     *
      * @return \SAML2\XML\md\EndpointType[]
      */
     public function getAttributeService() : array
@@ -110,6 +111,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Set the value of the AttributeService-property
+     *
      * @param \SAML2\XML\md\EndpointType[] $attributeService
      * @return void
      */
@@ -121,6 +123,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Add the value to the AttributeService-property
+     *
      * @param \SAML2\XML\md\EndpointType $attributeService
      * @return void
      */
@@ -132,6 +135,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Collect the value of the NameIDFormat-property
+     *
      * @return string[]
      */
     public function getNameIDFormat() : array
@@ -142,6 +146,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Set the value of the NameIDFormat-property
+     *
      * @param string[] $nameIDFormat
      * @return void
      */
@@ -153,6 +158,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Collect the value of the AssertionIDRequestService-property
+     *
      * @return \SAML2\XML\md\EndpointType[]
      */
     public function getAssertionIDRequestService() : array
@@ -163,6 +169,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Set the value of the AssertionIDRequestService-property
+     *
      * @param \SAML2\XML\md\EndpointType[] $assertionIDRequestService
      * @return void
      */
@@ -174,6 +181,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Add the value to the AssertionIDRequestService-property
+     *
      * @param \SAML2\XML\md\EndpointType $assertionIDRequestService
      * @return void
      */
@@ -185,6 +193,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Collect the value of the AttributeProfile-property
+     *
      * @return string[]
      */
     public function getAttributeProfile() : array
@@ -195,6 +204,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Set the value of the AttributeProfile-property
+     *
      * @param string[] $attributeProfile
      * @return void
      */
@@ -206,6 +216,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Collect the value of the Attribute-property
+     *
      * @return \SAML2\XML\saml\Attribute[]
      */
     public function getAttribute() : array
@@ -216,6 +227,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Set the value of the Attribute-property
+     *
      * @param \SAML2\XML\saml\Attribute[] $attribute
      * @return void
      */
@@ -227,6 +239,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Add the value to the Attribute-property
+     *
      * @param \SAML2\XML\saml\Attribute $attribute
      * @return void
      */

--- a/src/SAML2/XML/md/AttributeAuthorityDescriptor.php
+++ b/src/SAML2/XML/md/AttributeAuthorityDescriptor.php
@@ -260,7 +260,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
      */
     public function toXML(\DOMElement $parent) : \DOMElement
     {
-        Assert::notEmpty($this->attributeService);
+        Assert::notEmpty($this->AttributeService);
 
         $e = parent::toXML($parent);
 

--- a/src/SAML2/XML/md/AttributeConsumingService.php
+++ b/src/SAML2/XML/md/AttributeConsumingService.php
@@ -82,6 +82,7 @@ class AttributeConsumingService
 
         $this->setServiceDescription(Utils::extractLocalizedStrings($xml, Constants::NS_MD, 'ServiceDescription'));
 
+        /** @var \DOMElement $ra */
         foreach (Utils::xpQuery($xml, './saml_metadata:RequestedAttribute') as $ra) {
             $this->addRequestedAttribute(new RequestedAttribute($ra));
         }

--- a/src/SAML2/XML/md/AttributeConsumingService.php
+++ b/src/SAML2/XML/md/AttributeConsumingService.php
@@ -90,6 +90,7 @@ class AttributeConsumingService
 
     /**
      * Collect the value of the index-property
+     *
      * @return int
      */
     public function getIndex() : int
@@ -100,6 +101,7 @@ class AttributeConsumingService
 
     /**
      * Set the value of the index-property
+     *
      * @param int $index
      * @return void
      */
@@ -111,6 +113,7 @@ class AttributeConsumingService
 
     /**
      * Collect the value of the isDefault-property
+     *
      * @return bool|null
      */
     public function getIsDefault()
@@ -121,6 +124,7 @@ class AttributeConsumingService
 
     /**
      * Set the value of the isDefault-property
+     *
      * @param bool|null $flag
      * @return void
      */
@@ -132,6 +136,7 @@ class AttributeConsumingService
 
     /**
      * Collect the value of the ServiceName-property
+     *
      * @return string[]
      */
     public function getServiceName() : array
@@ -142,6 +147,7 @@ class AttributeConsumingService
 
     /**
      * Set the value of the ServiceName-property
+     *
      * @param string[] $serviceName
      * @return void
      */
@@ -153,6 +159,7 @@ class AttributeConsumingService
 
     /**
      * Collect the value of the ServiceDescription-property
+     *
      * @return string[]
      */
     public function getServiceDescription() : array
@@ -163,6 +170,7 @@ class AttributeConsumingService
 
     /**
      * Set the value of the ServiceDescription-property
+     *
      * @param string[] $serviceDescription
      * @return void
      */
@@ -174,6 +182,7 @@ class AttributeConsumingService
 
     /**
      * Collect the value of the RequestedAttribute-property
+     *
      * @return \SAML2\XML\md\RequestedAttribute[]
      */
     public function getRequestedAttribute() : array
@@ -184,6 +193,7 @@ class AttributeConsumingService
 
     /**
      * Set the value of the RequestedAttribute-property
+     *
      * @param \SAML2\XML\md\RequestedAttribute[] $requestedAttribute
      * @return void
      */
@@ -195,6 +205,7 @@ class AttributeConsumingService
 
     /**
      * Add the value to the RequestedAttribute-property
+     *
      * @param \SAML2\XML\md\RequestedAttribute $requestedAttribute
      * @return void
      */

--- a/src/SAML2/XML/md/AuthnAuthorityDescriptor.php
+++ b/src/SAML2/XML/md/AuthnAuthorityDescriptor.php
@@ -58,6 +58,7 @@ class AuthnAuthorityDescriptor extends RoleDescriptor
             return;
         }
 
+        /** @var \DOMElement $ep */
         foreach (Utils::xpQuery($xml, './saml_metadata:AuthnQueryService') as $ep) {
             $this->addAuthnQueryService(new EndpointType($ep));
         }
@@ -65,6 +66,7 @@ class AuthnAuthorityDescriptor extends RoleDescriptor
             throw new \Exception('Must have at least one AuthnQueryService in AuthnAuthorityDescriptor.');
         }
 
+        /** @var \DOMElement $ep */
         foreach (Utils::xpQuery($xml, './saml_metadata:AssertionIDRequestService') as $ep) {
             $this->addAssertionIDRequestService(new EndpointType($ep));
         }

--- a/src/SAML2/XML/md/AuthnAuthorityDescriptor.php
+++ b/src/SAML2/XML/md/AuthnAuthorityDescriptor.php
@@ -75,6 +75,7 @@ class AuthnAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Collect the value of the AuthnQueryService-property
+     *
      * @return \SAML2\XML\md\EndpointType[]
      */
     public function getAuthnQueryService() : array
@@ -85,6 +86,7 @@ class AuthnAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Set the value of the AuthnQueryService-property
+     *
      * @param \SAML2\XML\md\EndpointType[] $authnQueryService
      * @return void
      */
@@ -96,6 +98,7 @@ class AuthnAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Add the value to the AuthnQueryService-property
+     *
      * @param \SAML2\XML\md\EndpointType $authnQueryService
      * @return void
      */
@@ -107,6 +110,7 @@ class AuthnAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Collect the value of the AssertionIDRequestService-property
+     *
      * @return \SAML2\XML\md\EndpointType[]
      */
     public function getAssertionIDRequestService() : array
@@ -117,6 +121,7 @@ class AuthnAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Set the value of the AssertionIDRequestService-property
+     *
      * @param \SAML2\XML\md\EndpointType[] $assertionIDRequestService
      * @return void
      */
@@ -128,6 +133,7 @@ class AuthnAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Add the value to the AssertionIDRequestService-property
+     *
      * @param \SAML2\XML\md\EndpointType $assertionIDRequestService
      * @return void
      */
@@ -139,6 +145,7 @@ class AuthnAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Collect the value of the NameIDFormat-property
+     *
      * @return string[]
      */
     public function getNameIDFormat() : array
@@ -149,6 +156,7 @@ class AuthnAuthorityDescriptor extends RoleDescriptor
 
     /**
      * Set the value of the NameIDFormat-property
+     *
      * @param string[] $nameIDFormat
      * @return void
      */

--- a/src/SAML2/XML/md/ContactPerson.php
+++ b/src/SAML2/XML/md/ContactPerson.php
@@ -34,23 +34,23 @@ class ContactPerson
     /**
      * The Company of this contact.
      *
-     * @var string
+     * @var string|null
      */
-    public $Company = null;
+    private $Company = null;
 
     /**
      * The GivenName of this contact.
      *
-     * @var string
+     * @var string|null
      */
-    public $GivenName = null;
+    private $GivenName = null;
 
     /**
      * The SurName of this contact.
      *
-     * @var string
+     * @var string|null
      */
-    public $SurName = null;
+    private $SurName = null;
 
     /**
      * The EmailAddresses of this contact.
@@ -153,6 +153,7 @@ class ContactPerson
 
     /**
      * Collect the value of the contactType-property
+     *
      * @return string
      */
     public function getContactType() : string
@@ -163,6 +164,7 @@ class ContactPerson
 
     /**
      * Set the value of the contactType-property
+     *
      * @param string $contactType
      * @return void
      */
@@ -174,6 +176,7 @@ class ContactPerson
 
     /**
      * Collect the value of the Company-property
+     *
      * @return string|null
      */
     public function getCompany()
@@ -184,6 +187,7 @@ class ContactPerson
 
     /**
      * Set the value of the Company-property
+     *
      * @param string|null $company
      * @return void
      */
@@ -195,6 +199,7 @@ class ContactPerson
 
     /**
      * Collect the value of the GivenName-property
+     *
      * @return string|null
      */
     public function getGivenName()
@@ -205,6 +210,7 @@ class ContactPerson
 
     /**
      * Set the value of the GivenName-property
+     *
      * @param string|null $givenName
      * @return void
      */
@@ -216,6 +222,7 @@ class ContactPerson
 
     /**
      * Collect the value of the SurName-property
+     *
      * @return string|null
      */
     public function getSurName()
@@ -226,6 +233,7 @@ class ContactPerson
 
     /**
      * Set the value of the SurName-property
+     *
      * @param string|null $surName
      * @return void
      */
@@ -237,6 +245,7 @@ class ContactPerson
 
     /**
      * Collect the value of the EmailAddress-property
+     *
      * @return string[]
      */
     public function getEmailAddress() : array
@@ -247,6 +256,7 @@ class ContactPerson
 
     /**
      * Set the value of the EmailAddress-property
+     *
      * @param string[] $emailAddress
      * @return void
      */
@@ -258,6 +268,7 @@ class ContactPerson
 
     /**
      * Add the value to the EmailAddress-property
+     *
      * @param string $emailAddress
      * @return void
      */
@@ -269,6 +280,7 @@ class ContactPerson
 
     /**
      * Collect the value of the TelephoneNumber-property
+     *
      * @return string[]
      */
     public function getTelephoneNumber() : array
@@ -279,6 +291,7 @@ class ContactPerson
 
     /**
      * Set the value of the TelephoneNumber-property
+     *
      * @param string[] $telephoneNumber
      * @return void
      */
@@ -290,6 +303,7 @@ class ContactPerson
 
     /**
      * Add the value to the TelephoneNumber-property
+     *
      * @param string $telephoneNumber
      * @return void
      */
@@ -301,6 +315,7 @@ class ContactPerson
 
     /**
      * Collect the value of the Extensions-property
+     *
      * @return \SAML2\XML\Chunk[]
      */
     public function getExtensions() : array
@@ -311,6 +326,7 @@ class ContactPerson
 
     /**
      * Set the value of the Extensions-property
+     *
      * @param array $extensions
      * @return void
      */
@@ -334,6 +350,7 @@ class ContactPerson
 
     /**
      * Collect the value of the ContactPersonAttributes-property
+     *
      * @return string[]
      */
     public function getContactPersonAttributes() : array
@@ -344,6 +361,7 @@ class ContactPerson
 
     /**
      * Set the value of the ContactPersonAttributes-property
+     *
      * @param string[] $contactPersonAttributes
      * @return void
      */
@@ -355,6 +373,7 @@ class ContactPerson
 
     /**
      * Add the key/value of the ContactPersonAttributes-property
+     *
      * @param string $attr
      * @param string $value
      * @return void
@@ -386,19 +405,19 @@ class ContactPerson
 
         Extensions::addList($e, $this->getExtensions());
 
-        if ($this->getCompany() !== null) {
-            Utils::addString($e, Constants::NS_MD, 'md:Company', $this->getCompany());
+        if ($this->Company !== null) {
+            Utils::addString($e, Constants::NS_MD, 'md:Company', $this->Company);
         }
-        if ($this->getGivenName() !== null) {
-            Utils::addString($e, Constants::NS_MD, 'md:GivenName', $this->getGivenName());
+        if ($this->GivenName !== null) {
+            Utils::addString($e, Constants::NS_MD, 'md:GivenName', $this->GivenName);
         }
-        if ($this->getSurName() !== null) {
-            Utils::addString($e, Constants::NS_MD, 'md:SurName', $this->getSurName());
+        if ($this->SurName !== null) {
+            Utils::addString($e, Constants::NS_MD, 'md:SurName', $this->SurName);
         }
-        if ($this->getEmailAddress() !== null) {
+        if (!empty($this->getEmailAddress())) {
             Utils::addStrings($e, Constants::NS_MD, 'md:EmailAddress', false, $this->getEmailAddress());
         }
-        if ($this->getTelephoneNumber() !== null) {
+        if (!empty($this->getTelephoneNumber())) {
             Utils::addStrings($e, Constants::NS_MD, 'md:TelephoneNumber', false, $this->getTelephoneNumber());
         }
 

--- a/src/SAML2/XML/md/EndpointType.php
+++ b/src/SAML2/XML/md/EndpointType.php
@@ -161,7 +161,7 @@ class EndpointType
      *
      * @return string|null
      */
-    public function getBinding() : string
+    public function getBinding()
     {
         return $this->Binding;
     }

--- a/src/SAML2/XML/md/EndpointType.php
+++ b/src/SAML2/XML/md/EndpointType.php
@@ -16,16 +16,16 @@ class EndpointType
     /**
      * The binding for this endpoint.
      *
-     * @var string
+     * @var string|null
      */
-    public $Binding;
+    private $Binding = null;
 
     /**
      * The URI to this endpoint.
      *
-     * @var string
+     * @var string|null
      */
-    public $Location;
+    private $Location = null;
 
     /**
      * The URI where responses can be delivered.
@@ -57,15 +57,15 @@ class EndpointType
         if (!$xml->hasAttribute('Binding')) {
             throw new \Exception('Missing Binding on '.$xml->tagName);
         }
-        $this->setBinding($xml->getAttribute('Binding'));
+        $this->Binding = $xml->getAttribute('Binding');
 
         if (!$xml->hasAttribute('Location')) {
             throw new \Exception('Missing Location on '.$xml->tagName);
         }
-        $this->setLocation($xml->getAttribute('Location'));
+        $this->Location = $xml->getAttribute('Location');
 
         if ($xml->hasAttribute('ResponseLocation')) {
-            $this->setResponseLocation($xml->getAttribute('ResponseLocation'));
+            $this->ResponseLocation = $xml->getAttribute('ResponseLocation');
         }
 
         foreach ($xml->attributes as $a) {
@@ -85,8 +85,8 @@ class EndpointType
     /**
      * Check if a namespace-qualified attribute exists.
      *
-     * @param  string  $namespaceURI The namespace URI.
-     * @param  string  $localName    The local name.
+     * @param string $namespaceURI The namespace URI.
+     * @param string $localName The local name.
      * @return bool true if the attribute exists, false if not.
      */
     public function hasAttributeNS(string $namespaceURI, string $localName) : bool
@@ -100,8 +100,8 @@ class EndpointType
     /**
      * Get a namespace-qualified attribute.
      *
-     * @param  string $namespaceURI The namespace URI.
-     * @param  string $localName    The local name.
+     * @param string $namespaceURI The namespace URI.
+     * @param string $localName The local name.
      * @return string The value of the attribute, or an empty string if the attribute does not exist.
      */
     public function getAttributeNS(string $namespaceURI, string $localName) : string
@@ -120,7 +120,8 @@ class EndpointType
      *
      * @param string $namespaceURI  The namespace URI.
      * @param string $qualifiedName The local name.
-     * @param string $value         The attribute value.
+     * @param string $value The attribute value.
+     * @return void
      * @throws \Exception
      * @return void
      */
@@ -145,7 +146,7 @@ class EndpointType
      * Remove a namespace-qualified attribute.
      *
      * @param string $namespaceURI The namespace URI.
-     * @param string $localName    The local name.
+     * @param string $localName The local name.
      * @return void
      */
     public function removeAttributeNS(string $namespaceURI, string $localName)
@@ -156,8 +157,9 @@ class EndpointType
 
 
     /**
-     * Collect the value of the Binding-property
-     * @return string
+     * Collect the value of the Binding property.
+     *
+     * @return string|null
      */
     public function getBinding() : string
     {
@@ -166,7 +168,8 @@ class EndpointType
 
 
     /**
-     * Set the value of the Binding-property
+     * Set the value of the Binding property.
+     *
      * @param string $binding
      * @return void
      */
@@ -177,7 +180,8 @@ class EndpointType
 
 
     /**
-     * Collect the value of the Location-property
+     * Collect the value of the Location property.
+     *
      * @return string|null
      */
     public function getLocation()
@@ -187,7 +191,7 @@ class EndpointType
 
 
     /**
-     * Set the value of the Location-property
+     * Set the value of the Location-property.
      * @param string|null $location
      * @return void
      */
@@ -198,7 +202,8 @@ class EndpointType
 
 
     /**
-     * Collect the value of the ResponseLocation-property
+     * Collect the value of the ResponseLocation property.
+     *
      * @return string|null
      */
     public function getResponseLocation()
@@ -208,7 +213,8 @@ class EndpointType
 
 
     /**
-     * Set the value of the ResponseLocation-property
+     * Set the value of the ResponseLocation property.
+     *
      * @param string|null $responseLocation
      * @return void
      */
@@ -222,7 +228,7 @@ class EndpointType
      * Add this endpoint to an XML element.
      *
      * @param \DOMElement $parent The element we should append this endpoint to.
-     * @param string     $name   The name of the element we should create.
+     * @param string $name The name of the element we should create.
      * @return \DOMElement
      */
     public function toXML(\DOMElement $parent, string $name) : \DOMElement
@@ -230,11 +236,18 @@ class EndpointType
         $e = $parent->ownerDocument->createElementNS(Constants::NS_MD, $name);
         $parent->appendChild($e);
 
-        $e->setAttribute('Binding', $this->getBinding());
-        $e->setAttribute('Location', $this->getLocation());
+        if (empty($this->Binding)) {
+            throw new \Exception('Cannot convert endpoint to XML without a Binding set.');
+        }
+        if (empty($this->Location)) {
+            throw new \Exception('Cannot convert endpoint to XML without a Location set.');
+        }
 
-        if ($this->getResponseLocation() !== null) {
-            $e->setAttribute('ResponseLocation', $this->getResponseLocation());
+        $e->setAttribute('Binding', $this->Binding);
+        $e->setAttribute('Location', $this->Location);
+
+        if ($this->ResponseLocation !== null) {
+            $e->setAttribute('ResponseLocation', $this->ResponseLocation);
         }
 
         foreach ($this->attributes as $a) {

--- a/src/SAML2/XML/md/EntitiesDescriptor.php
+++ b/src/SAML2/XML/md/EntitiesDescriptor.php
@@ -78,6 +78,7 @@ class EntitiesDescriptor extends SignedElementHelper
 
         $this->Extensions = Extensions::getList($xml);
 
+        /** @var \DOMElement $node */
         foreach (Utils::xpQuery($xml, './saml_metadata:EntityDescriptor|./saml_metadata:EntitiesDescriptor') as $node) {
             if ($node->localName === 'EntityDescriptor') {
                 $this->children[] = new EntityDescriptor($node);

--- a/src/SAML2/XML/md/EntitiesDescriptor.php
+++ b/src/SAML2/XML/md/EntitiesDescriptor.php
@@ -24,28 +24,14 @@ class EntitiesDescriptor extends SignedElementHelper
      *
      * @var string|null
      */
-    public $ID = null;
-
-    /**
-     * How long this element is valid, as a unix timestamp.
-     *
-     * @var int|null
-     */
-    public $validUntil;
-
-    /**
-     * The length of time this element can be cached, as string.
-     *
-     * @var string|null
-     */
-    public $cacheDuration;
+    private $ID = null;
 
     /**
      * The name of this entity collection.
      *
      * @var string|null
      */
-    public $Name = null;
+    private $Name = null;
 
     /**
      * Extensions on this element.
@@ -78,19 +64,19 @@ class EntitiesDescriptor extends SignedElementHelper
         }
 
         if ($xml->hasAttribute('ID')) {
-            $this->setID($xml->getAttribute('ID'));
+            $this->ID = $xml->getAttribute('ID');
         }
         if ($xml->hasAttribute('validUntil')) {
-            $this->setValidUntil(Utils::xsDateTimeToTimestamp($xml->getAttribute('validUntil')));
+            $this->validUntil = Utils::xsDateTimeToTimestamp($xml->getAttribute('validUntil'));
         }
         if ($xml->hasAttribute('cacheDuration')) {
-            $this->setCacheDuration($xml->getAttribute('cacheDuration'));
+            $this->cacheDuration = $xml->getAttribute('cacheDuration');
         }
         if ($xml->hasAttribute('Name')) {
-            $this->setName($xml->getAttribute('Name'));
+            $this->Name = $xml->getAttribute('Name');
         }
 
-        $this->setExtensions(Extensions::getList($xml));
+        $this->Extensions = Extensions::getList($xml);
 
         foreach (Utils::xpQuery($xml, './saml_metadata:EntityDescriptor|./saml_metadata:EntitiesDescriptor') as $node) {
             if ($node->localName === 'EntityDescriptor') {
@@ -103,7 +89,8 @@ class EntitiesDescriptor extends SignedElementHelper
 
 
     /**
-     * Collect the value of the Name-property
+     * Collect the value of the Name property.
+     *
      * @return string|null
      */
     public function getName()
@@ -113,7 +100,8 @@ class EntitiesDescriptor extends SignedElementHelper
 
 
     /**
-     * Set the value of the Name-property
+     * Set the value of the Name property.
+     *
      * @param string|null $name
      * @return void
      */
@@ -124,7 +112,8 @@ class EntitiesDescriptor extends SignedElementHelper
 
 
     /**
-     * Collect the value of the ID-property
+     * Collect the value of the ID property.
+     *
      * @return string|null
      */
     public function getID()
@@ -134,7 +123,8 @@ class EntitiesDescriptor extends SignedElementHelper
 
 
     /**
-     * Set the value of the ID-property
+     * Set the value of the ID property.
+     *
      * @param string|null $Id
      * @return void
      */
@@ -187,7 +177,8 @@ class EntitiesDescriptor extends SignedElementHelper
 
 
     /**
-     * Collect the value of the Extensions-property
+     * Collect the value of the Extensions property.
+     *
      * @return \SAML2\XML\Chunk[]
      */
     public function getExtensions() : array
@@ -197,7 +188,8 @@ class EntitiesDescriptor extends SignedElementHelper
 
 
     /**
-     * Set the value of the Extensions-property
+     * Set the value of the Extensions property.
+     *
      * @param array $extensions
      * @return void
      */
@@ -220,7 +212,8 @@ class EntitiesDescriptor extends SignedElementHelper
 
 
     /**
-     * Collect the value of the children-property
+     * Collect the value of the children property.
+     *
      * @return (\SAML2\XML\md\EntityDescriptor|\SAML2\XML\md\EntitiesDescriptor)[]
      */
     public function getChildren() : array
@@ -230,7 +223,8 @@ class EntitiesDescriptor extends SignedElementHelper
 
 
     /**
-     * Set the value of the childen-property
+     * Set the value of the childen property.
+     *
      * @param array $children
      * @return void
      */
@@ -241,7 +235,8 @@ class EntitiesDescriptor extends SignedElementHelper
 
 
     /**
-     * Add the value to the children-property
+     * Add the value to the children property.
+     *
      * @param \SAML2\XML\md\EntityDescriptor|\SAML2\XML\md\EntitiesDescriptor $child
      * @return void
      */
@@ -269,26 +264,26 @@ class EntitiesDescriptor extends SignedElementHelper
             $parent->appendChild($e);
         }
 
-        if ($this->getID() !== null) {
-            $e->setAttribute('ID', $this->getID());
+        if ($this->ID !== null) {
+            $e->setAttribute('ID', $this->ID);
         }
 
-        if ($this->getValidUntil() !== null) {
-            $e->setAttribute('validUntil', gmdate('Y-m-d\TH:i:s\Z', $this->getValidUntil()));
+        if ($this->validUntil !== null) {
+            $e->setAttribute('validUntil', gmdate('Y-m-d\TH:i:s\Z', $this->validUntil));
         }
 
-        if ($this->getCacheDuration() !== null) {
-            $e->setAttribute('cacheDuration', $this->getCacheDuration());
+        if ($this->cacheDuration !== null) {
+            $e->setAttribute('cacheDuration', $this->cacheDuration);
         }
 
-        if ($this->getName() !== null) {
-            $e->setAttribute('Name', $this->getName());
+        if ($this->Name !== null) {
+            $e->setAttribute('Name', $this->Name);
         }
 
-        Extensions::addList($e, $this->getExtensions());
+        Extensions::addList($e, $this->Extensions);
 
         /** @var \SAML2\XML\md\EntityDescriptor|\SAML2\XML\md\EntitiesDescriptor $node */
-        foreach ($this->getChildren() as $node) {
+        foreach ($this->children as $node) {
             $node->toXML($e);
         }
 

--- a/src/SAML2/XML/md/EntityDescriptor.php
+++ b/src/SAML2/XML/md/EntityDescriptor.php
@@ -20,30 +20,16 @@ class EntityDescriptor extends SignedElementHelper
     /**
      * The entityID this EntityDescriptor represents.
      *
-     * @var string
+     * @var string|null
      */
-    public $entityID;
+    private $entityID = null;
 
     /**
      * The ID of this element.
      *
      * @var string|null
      */
-    public $ID = null;
-
-    /**
-     * How long this element is valid, as a unix timestamp.
-     *
-     * @var int|null
-     */
-    public $validUntil = null;
-
-    /**
-     * The length of time this element can be cached, as string.
-     *
-     * @var string|null
-     */
-    public $cacheDuration = null;
+    private $ID = null;
 
     /**
      * Extensions on this element.
@@ -202,10 +188,10 @@ class EntityDescriptor extends SignedElementHelper
 
     /**
      * Set the value of the entityID-property
-     * @param string|null $entityId
+     * @param string $entityId
      * @return void
      */
-    public function setEntityID(string $entityId = null)
+    public function setEntityID(string $entityId)
     {
         $this->entityID = $entityId;
     }

--- a/src/SAML2/XML/md/EntityDescriptor.php
+++ b/src/SAML2/XML/md/EntityDescriptor.php
@@ -180,7 +180,7 @@ class EntityDescriptor extends SignedElementHelper
      *
      * @return string|null
      */
-    public function getEntityID() : string
+    public function getEntityID()
     {
         return $this->entityID;
     }

--- a/src/SAML2/XML/md/EntityDescriptor.php
+++ b/src/SAML2/XML/md/EntityDescriptor.php
@@ -128,7 +128,7 @@ class EntityDescriptor extends SignedElementHelper
 
         $this->Extensions = Extensions::getList($xml);
 
-        for ($node = $xml->firstChild; $node instanceof \DOMNode; $node = $node->nextSibling) {
+        foreach ($xml->childNodes as $node) {
             if (!($node instanceof \DOMElement)) {
                 continue;
             }

--- a/src/SAML2/XML/md/Extensions.php
+++ b/src/SAML2/XML/md/Extensions.php
@@ -57,6 +57,7 @@ class Extensions
             ],
         ];
 
+        /** @var \DOMElement $node */
         foreach (Utils::xpQuery($parent, './saml_metadata:Extensions/*') as $node) {
             if (array_key_exists($node->namespaceURI, $supported) &&
                 array_key_exists($node->localName, $supported[$node->namespaceURI])

--- a/src/SAML2/XML/md/Extensions.php
+++ b/src/SAML2/XML/md/Extensions.php
@@ -7,10 +7,16 @@ namespace SAML2\XML\md;
 use SAML2\Constants;
 use SAML2\Utils;
 use SAML2\XML\alg\Common as ALG;
+use SAML2\XML\alg\DigestMethod;
+use SAML2\XML\alg\SigningMethod;
 use SAML2\XML\Chunk;
 use SAML2\XML\mdattr\EntityAttributes;
 use SAML2\XML\mdrpi\Common as MDRPI;
+use SAML2\XML\mdrpi\PublicationInfo;
+use SAML2\XML\mdrpi\RegistrationInfo;
 use SAML2\XML\mdui\Common as MDUI;
+use SAML2\XML\mdui\DiscoHints;
+use SAML2\XML\mdui\UIInfo;
 use SAML2\XML\shibmd\Scope;
 
 /**
@@ -38,22 +44,22 @@ class Extensions
         $ret = [];
         $supported = [
             Scope::NS => [
-                'Scope' => '\SAML2\XML\shibmd\Scope',
+                'Scope' => Scope::class,
             ],
             EntityAttributes::NS => [
-                'EntityAttributes' => '\SAML2\XML\mdattr\EntityAttributes',
+                'EntityAttributes' => EntityAttributes::class,
             ],
             MDRPI::NS_MDRPI => [
-                'RegistrationInfo' => '\SAML2\XML\mdrpi\RegistrationInfo',
-                'PublicationInfo' => '\SAML2\XML\mdrpi\PublicationInfo',
+                'RegistrationInfo' => RegistrationInfo::class,
+                'PublicationInfo' => PublicationInfo::class,
             ],
             MDUI::NS => [
-                'UIInfo' => '\SAML2\XML\mdui\UIInfo',
-                'DiscoHints' => '\SAML2\XML\mdui\DiscoHints',
+                'UIInfo' => UIInfo::class,
+                'DiscoHints' => DiscoHints::class,
             ],
             ALG::NS => [
-                'DigestMethod' => '\SAML2\XML\alg\DigestMethod',
-                'SigningMethod' => '\SAML2\XML\alg\SigningMethod',
+                'DigestMethod' => DigestMethod::class,
+                'SigningMethod' => SigningMethod::class,
             ],
         ];
 

--- a/src/SAML2/XML/md/Extensions.php
+++ b/src/SAML2/XML/md/Extensions.php
@@ -22,8 +22,16 @@ class Extensions
     /**
      * Get a list of Extensions in the given element.
      *
-     * @param  \DOMElement $parent The element that may contain the md:Extensions element.
-     * @return \SAML2\XML\Chunk[]  Array of extensions.
+     * @param \DOMElement $parent The element that may contain the md:Extensions element.
+     * @return (\SAML2\XML\shibmd\Scope|
+     *          \SAML2\XML\mdattr\EntityAttributes|
+     *          \SAML2\XML\mdrpi\RegistrationInfo|
+     *          \SAML2\XML\mdrpi\PublicationInfo|
+     *          \SAML2\XML\mdui\UIInfo|
+     *          \SAML2\XML\mdui\DiscoHints|
+     *          \SAML2\XML\alg\DigestMethod|
+     *          \SAML2\XML\alg\SigningMethod|
+     *          \SAML2\XML\Chunk)[]  Array of extensions.
      */
     public static function getList(\DOMElement $parent) : array
     {
@@ -66,7 +74,7 @@ class Extensions
     /**
      * Add a list of Extensions to the given element.
      *
-     * @param \DOMElement        $parent     The element we should add the extensions to.
+     * @param \DOMElement $parent The element we should add the extensions to.
      * @param \SAML2\XML\Chunk[] $extensions List of extension objects.
      * @return void
      */

--- a/src/SAML2/XML/md/IDPSSODescriptor.php
+++ b/src/SAML2/XML/md/IDPSSODescriptor.php
@@ -83,20 +83,24 @@ class IDPSSODescriptor extends SSODescriptorType
 
         $this->WantAuthnRequestsSigned = Utils::parseBoolean($xml, 'WantAuthnRequestsSigned', null);
 
+        /** @var \DOMElement $ep */
         foreach (Utils::xpQuery($xml, './saml_metadata:SingleSignOnService') as $ep) {
             $this->SingleSignOnService[] = new EndpointType($ep);
         }
 
+        /** @var \DOMElement $ep */
         foreach (Utils::xpQuery($xml, './saml_metadata:NameIDMappingService') as $ep) {
             $this->NameIDMappingService[] = new EndpointType($ep);
         }
 
+        /** @var \DOMElement $ep */
         foreach (Utils::xpQuery($xml, './saml_metadata:AssertionIDRequestService') as $ep) {
             $this->AssertionIDRequestService[] = new EndpointType($ep);
         }
 
         $this->AttributeProfile = Utils::extractStrings($xml, Constants::NS_MD, 'AttributeProfile');
 
+        /** @var \DOMElement $a */
         foreach (Utils::xpQuery($xml, './saml_assertion:Attribute') as $a) {
             $this->Attribute[] = new Attribute($a);
         }

--- a/src/SAML2/XML/md/IDPSSODescriptor.php
+++ b/src/SAML2/XML/md/IDPSSODescriptor.php
@@ -81,30 +81,31 @@ class IDPSSODescriptor extends SSODescriptorType
             return;
         }
 
-        $this->setWantAuthnRequestsSigned(Utils::parseBoolean($xml, 'WantAuthnRequestsSigned', null));
+        $this->WantAuthnRequestsSigned = Utils::parseBoolean($xml, 'WantAuthnRequestsSigned', null);
 
         foreach (Utils::xpQuery($xml, './saml_metadata:SingleSignOnService') as $ep) {
-            $this->addSingleSignOnService(new EndpointType($ep));
+            $this->SingleSignOnService[] = new EndpointType($ep);
         }
 
         foreach (Utils::xpQuery($xml, './saml_metadata:NameIDMappingService') as $ep) {
-            $this->addNameIDMappingService(new EndpointType($ep));
+            $this->NameIDMappingService[] = new EndpointType($ep);
         }
 
         foreach (Utils::xpQuery($xml, './saml_metadata:AssertionIDRequestService') as $ep) {
-            $this->addAssertionIDRequestService(new EndpointType($ep));
+            $this->AssertionIDRequestService[] = new EndpointType($ep);
         }
 
-        $this->setAttributeProfile(Utils::extractStrings($xml, Constants::NS_MD, 'AttributeProfile'));
+        $this->AttributeProfile = Utils::extractStrings($xml, Constants::NS_MD, 'AttributeProfile');
 
         foreach (Utils::xpQuery($xml, './saml_assertion:Attribute') as $a) {
-            $this->addAttribute(new Attribute($a));
+            $this->Attribute[] = new Attribute($a);
         }
     }
 
 
     /**
      * Collect the value of the WantAuthnRequestsSigned-property
+     *
      * @return bool|null
      */
     public function wantAuthnRequestsSigned()
@@ -115,6 +116,7 @@ class IDPSSODescriptor extends SSODescriptorType
 
     /**
      * Set the value of the WantAuthnRequestsSigned-property
+     *
      * @param bool|null $flag
      * @return void
      */
@@ -126,6 +128,7 @@ class IDPSSODescriptor extends SSODescriptorType
 
     /**
      * Collect the value of the SingleSignOnService-property
+     *
      * @return \SAML2\XML\md\EndpointType[]
      */
     public function getSingleSignOnService() : array
@@ -136,6 +139,7 @@ class IDPSSODescriptor extends SSODescriptorType
 
     /**
      * Set the value of the SingleSignOnService-property
+     *
      * @param array $singleSignOnService
      * @return void
      */
@@ -147,6 +151,7 @@ class IDPSSODescriptor extends SSODescriptorType
 
     /**
      * Add the value to the SingleSignOnService-property
+     *
      * @param \SAML2\XML\md\EndpointType $singleSignOnService
      * @return void
      */
@@ -158,6 +163,7 @@ class IDPSSODescriptor extends SSODescriptorType
 
     /**
      * Collect the value of the NameIDMappingService-property
+     *
      * @return \SAML2\XML\md\EndpointType[]
      */
     public function getNameIDMappingService() : array
@@ -168,6 +174,7 @@ class IDPSSODescriptor extends SSODescriptorType
 
     /**
      * Set the value of the NameIDMappingService-property
+     *
      * @param array $nameIDMappingService
      * @return void
      */
@@ -179,6 +186,7 @@ class IDPSSODescriptor extends SSODescriptorType
 
     /**
      * Add the value to the NameIDMappingService-property
+     *
      * @param \SAML2\XML\md\EndpointType $nameIDMappingService
      * @return void
      */
@@ -190,6 +198,7 @@ class IDPSSODescriptor extends SSODescriptorType
 
     /**
      * Collect the value of the AssertionIDRequestService-property
+     *
      * @return \SAML2\XML\md\EndpointType[]
      */
     public function getAssertionIDRequestService() : array
@@ -200,6 +209,7 @@ class IDPSSODescriptor extends SSODescriptorType
 
     /**
      * Set the value of the AssertionIDRequestService-property
+     *
      * @param array $assertionIDRequestService
      * @return void
      */
@@ -211,6 +221,7 @@ class IDPSSODescriptor extends SSODescriptorType
 
     /**
      * Add the value to the AssertionIDRequestService-property
+     *
      * @param \SAML2\XML\md\EndpointType $assertionIDRequestService
      * @return void
      */
@@ -232,6 +243,7 @@ class IDPSSODescriptor extends SSODescriptorType
 
     /**
      * Set the value of the AttributeProfile-property
+     *
      * @param array $attributeProfile
      * @return void
      */
@@ -243,6 +255,7 @@ class IDPSSODescriptor extends SSODescriptorType
 
     /**
      * Collect the value of the Attribute-property
+     *
      * @return \SAML2\XML\saml\Attribute[]
      */
     public function getAttribute() : array
@@ -253,6 +266,7 @@ class IDPSSODescriptor extends SSODescriptorType
 
     /**
      * Set the value of the Attribute-property
+     *
      * @param array $attribute
      * @return void
      */
@@ -264,6 +278,7 @@ class IDPSSODescriptor extends SSODescriptorType
 
     /**
      * Addthe value to the Attribute-property
+     *
      * @param \SAML2\XML\saml\Attribute $attribute
      * @return void
      */
@@ -283,27 +298,25 @@ class IDPSSODescriptor extends SSODescriptorType
     {
         $e = parent::toXML($parent);
 
-        if ($this->WantAuthnRequestsSigned() === true) {
-            $e->setAttribute('WantAuthnRequestsSigned', 'true');
-        } elseif ($this->WantAuthnRequestsSigned() === false) {
-            $e->setAttribute('WantAuthnRequestsSigned', 'false');
+        if (is_bool($this->WantAuthnRequestsSigned)) {
+            $e->setAttribute('WantAuthnRequestsSigned', $this->WantAuthnRequestsSigned ? 'true' : 'false');
         }
 
-        foreach ($this->getSingleSignOnService() as $ep) {
+        foreach ($this->SingleSignOnService as $ep) {
             $ep->toXML($e, 'md:SingleSignOnService');
         }
 
-        foreach ($this->getNameIDMappingService() as $ep) {
+        foreach ($this->NameIDMappingService as $ep) {
             $ep->toXML($e, 'md:NameIDMappingService');
         }
 
-        foreach ($this->getAssertionIDRequestService() as $ep) {
+        foreach ($this->AssertionIDRequestService as $ep) {
             $ep->toXML($e, 'md:AssertionIDRequestService');
         }
 
-        Utils::addStrings($e, Constants::NS_MD, 'md:AttributeProfile', false, $this->getAttributeProfile());
+        Utils::addStrings($e, Constants::NS_MD, 'md:AttributeProfile', false, $this->AttributeProfile);
 
-        foreach ($this->getAttribute() as $a) {
+        foreach ($this->Attribute as $a) {
             $a->toXML($e);
         }
 

--- a/src/SAML2/XML/md/IndexedEndpointType.php
+++ b/src/SAML2/XML/md/IndexedEndpointType.php
@@ -18,7 +18,7 @@ class IndexedEndpointType extends EndpointType
      *
      * @var int
      */
-    public $index;
+    private $index = 0;
 
     /**
      * Whether this endpoint is the default.
@@ -45,14 +45,15 @@ class IndexedEndpointType extends EndpointType
         if (!$xml->hasAttribute('index')) {
             throw new \Exception('Missing index on '.$xml->tagName);
         }
-        $this->setIndex(intval($xml->getAttribute('index')));
+        $this->index = intval($xml->getAttribute('index'));
 
-        $this->setIsDefault(Utils::parseBoolean($xml, 'isDefault', null));
+        $this->isDefault = Utils::parseBoolean($xml, 'isDefault', null);
     }
 
 
     /**
-     * Collect the value of the index-property
+     * Collect the value of the index property.
+     *
      * @return int
      */
     public function getIndex() : int
@@ -62,7 +63,8 @@ class IndexedEndpointType extends EndpointType
 
 
     /**
-     * Set the value of the index-property
+     * Set the value of the index property.
+     *
      * @param int $index
      * @return void
      */
@@ -73,7 +75,8 @@ class IndexedEndpointType extends EndpointType
 
 
     /**
-     * Collect the value of the isDefault-property
+     * Collect the value of the isDefault property.
+     *
      * @return bool|null
      */
     public function getIsDefault()
@@ -83,7 +86,8 @@ class IndexedEndpointType extends EndpointType
 
 
     /**
-     * Set the value of the isDefault-property
+     * Set the value of the isDefault property.
+     *
      * @param bool|null $flag
      * @return void
      */
@@ -97,18 +101,16 @@ class IndexedEndpointType extends EndpointType
      * Add this endpoint to an XML element.
      *
      * @param \DOMElement $parent The element we should append this endpoint to.
-     * @param string     $name   The name of the element we should create.
+     * @param string $name The name of the element we should create.
      * @return \DOMElement
      */
     public function toXML(\DOMElement $parent, string $name) : \DOMElement
     {
         $e = parent::toXML($parent, $name);
-        $e->setAttribute('index', (string) $this->getIndex());
+        $e->setAttribute('index', strval($this->index));
 
-        if ($this->getIsDefault() === true) {
-            $e->setAttribute('isDefault', 'true');
-        } elseif ($this->getIsDefault() === false) {
-            $e->setAttribute('isDefault', 'false');
+        if (is_bool($this->isDefault)) {
+            $e->setAttribute('isDefault', $this->isDefault ? 'true' : 'false');
         }
 
         return $e;

--- a/src/SAML2/XML/md/KeyDescriptor.php
+++ b/src/SAML2/XML/md/KeyDescriptor.php
@@ -104,7 +104,7 @@ class KeyDescriptor
      *
      * @return \SAML2\XML\ds\KeyInfo|null
      */
-    public function getKeyInfo() : KeyInfo
+    public function getKeyInfo()
     {
         return $this->KeyInfo;
     }
@@ -165,7 +165,11 @@ class KeyDescriptor
      */
     public function toXML(\DOMElement $parent) : \DOMElement
     {
-        Assert::isInstanceOf($this->KeyInfo, KeyInfo::class, 'Cannot convert KeyDescriptor to XML without KeyInfo set.');
+        Assert::isInstanceOf(
+            $this->KeyInfo,
+            KeyInfo::class,
+            'Cannot convert KeyDescriptor to XML without KeyInfo set.'
+        );
 
         $doc = $parent->ownerDocument;
 
@@ -176,6 +180,7 @@ class KeyDescriptor
             $e->setAttribute('use', $this->use);
         }
 
+        /** @psalm-suppress PossiblyNullReference */
         $this->KeyInfo->toXML($e);
 
         foreach ($this->EncryptionMethod as $em) {

--- a/src/SAML2/XML/md/KeyDescriptor.php
+++ b/src/SAML2/XML/md/KeyDescriptor.php
@@ -66,8 +66,10 @@ class KeyDescriptor
         } elseif (empty($keyInfo)) {
             throw new \Exception('No ds:KeyInfo in the KeyDescriptor.');
         }
+        /** @var \DOMElement $keyInfo[0] */
         $this->KeyInfo = new KeyInfo($keyInfo[0]);
 
+        /** @var \DOMElement $em */
         foreach (Utils::xpQuery($xml, './saml_metadata:EncryptionMethod') as $em) {
             $this->EncryptionMethod[] = new Chunk($em);
         }

--- a/src/SAML2/XML/md/KeyDescriptor.php
+++ b/src/SAML2/XML/md/KeyDescriptor.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SAML2\XML\md;
 
+use Webmozart\Assert\Assert;
+
 use SAML2\Constants;
 use SAML2\Utils;
 use SAML2\XML\Chunk;
@@ -23,14 +25,14 @@ class KeyDescriptor
      *
      * @var string|null
      */
-    public $use = null;
+    private $use = null;
 
     /**
      * The KeyInfo for this key.
      *
-     * @var \SAML2\XML\ds\KeyInfo
+     * @var \SAML2\XML\ds\KeyInfo|null
      */
-    public $KeyInfo;
+    private $KeyInfo = null;
 
     /**
      * Supported EncryptionMethods.
@@ -55,7 +57,7 @@ class KeyDescriptor
         }
 
         if ($xml->hasAttribute('use')) {
-            $this->setUse($xml->getAttribute('use'));
+            $this->use = $xml->getAttribute('use');
         }
 
         $keyInfo = Utils::xpQuery($xml, './ds:KeyInfo');
@@ -64,16 +66,17 @@ class KeyDescriptor
         } elseif (empty($keyInfo)) {
             throw new \Exception('No ds:KeyInfo in the KeyDescriptor.');
         }
-        $this->setKeyInfo(new KeyInfo($keyInfo[0]));
+        $this->KeyInfo = new KeyInfo($keyInfo[0]);
 
         foreach (Utils::xpQuery($xml, './saml_metadata:EncryptionMethod') as $em) {
-            $this->addEncryptionMethod(new Chunk($em));
+            $this->EncryptionMethod[] = new Chunk($em);
         }
     }
 
 
     /**
-     * Collect the value of the use-property
+     * Collect the value of the use property.
+     *
      * @return string|null
      */
     public function getUse()
@@ -83,7 +86,8 @@ class KeyDescriptor
 
 
     /**
-     * Set the value of the use-property
+     * Set the value of the use property.
+     *
      * @param string|null $use
      * @return void
      */
@@ -94,8 +98,9 @@ class KeyDescriptor
 
 
     /**
-     * Collect the value of the KeyInfo-property
-     * @return \SAML2\XML\ds\KeyInfo
+     * Collect the value of the KeyInfo property.
+     *
+     * @return \SAML2\XML\ds\KeyInfo|null
      */
     public function getKeyInfo() : KeyInfo
     {
@@ -104,7 +109,8 @@ class KeyDescriptor
 
 
     /**
-     * Set the value of the KeyInfo-property
+     * Set the value of the KeyInfo property.
+     *
      * @param \SAML2\XML\ds\KeyInfo $keyInfo
      * @return void
      */
@@ -115,7 +121,8 @@ class KeyDescriptor
 
 
     /**
-     * Collect the value of the EncryptionMethod-property
+     * Collect the value of the EncryptionMethod property.
+     *
      * @return \SAML2\XML\Chunk[]
      */
     public function getEncryptionMethod() : array
@@ -125,7 +132,8 @@ class KeyDescriptor
 
 
     /**
-     * Set the value of the EncryptionMethod-property
+     * Set the value of the EncryptionMethod property.
+     *
      * @param \SAML2\XML\Chunk[] $encryptionMethod
      * @return void
      */
@@ -136,7 +144,8 @@ class KeyDescriptor
 
 
     /**
-     * Add the value to the EncryptionMethod-property
+     * Add the value to the EncryptionMethod property.
+     *
      * @param \SAML2\XML\Chunk $encryptionMethod
      * @return void
      */
@@ -154,18 +163,20 @@ class KeyDescriptor
      */
     public function toXML(\DOMElement $parent) : \DOMElement
     {
+        Assert::isInstanceOf($this->KeyInfo, KeyInfo::class, 'Cannot convert KeyDescriptor to XML without KeyInfo set.');
+
         $doc = $parent->ownerDocument;
 
         $e = $doc->createElementNS(Constants::NS_MD, 'md:KeyDescriptor');
         $parent->appendChild($e);
 
-        if ($this->getUse() !== null) {
-            $e->setAttribute('use', $this->getUse());
+        if ($this->use !== null) {
+            $e->setAttribute('use', $this->use);
         }
 
-        $this->getKeyInfo()->toXML($e);
+        $this->KeyInfo->toXML($e);
 
-        foreach ($this->getEncryptionMethod() as $em) {
+        foreach ($this->EncryptionMethod as $em) {
             $em->toXML($e);
         }
 

--- a/src/SAML2/XML/md/Organization.php
+++ b/src/SAML2/XML/md/Organization.php
@@ -59,30 +59,32 @@ class Organization
             return;
         }
 
-        $this->setExtensions(Extensions::getList($xml));
+        $this->Extensions = Extensions::getList($xml);
 
-        $this->setOrganizationName(Utils::extractLocalizedStrings($xml, Constants::NS_MD, 'OrganizationName'));
-        $organizationName = $this->getOrganizationName();
-        if (empty($organizationName)) {
-            $this->setOrganizationName(['invalid' => '']);
+        $this->OrganizationName = Utils::extractLocalizedStrings($xml, Constants::NS_MD, 'OrganizationName');
+        if (empty($this->OrganizationName)) {
+            $this->OrganizationName = ['invalid' => ''];
         }
 
-        $this->setOrganizationDisplayName(Utils::extractLocalizedStrings($xml, Constants::NS_MD, 'OrganizationDisplayName'));
-        $organizationDisplayName = $this->getOrganizationDisplayName();
-        if (empty($organizationDisplayName)) {
-            $this->setOrganizationDisplayName(['invalid' => '']);
+        $this->OrganizationDisplayName = Utils::extractLocalizedStrings(
+            $xml,
+            Constants::NS_MD,
+            'OrganizationDisplayName'
+        );
+        if (empty($this->OrganizationDisplayName)) {
+            $this->OrganizationDisplayName = ['invalid' => ''];
         }
 
-        $this->setOrganizationURL(Utils::extractLocalizedStrings($xml, Constants::NS_MD, 'OrganizationURL'));
-        $organizationURL = $this->getOrganizationURL();
-        if (empty($organizationURL)) {
-            $this->setOrganizationURL(['invalid' => '']);
+        $this->OrganizationURL = Utils::extractLocalizedStrings($xml, Constants::NS_MD, 'OrganizationURL');
+        if (empty($this->OrganizationURL)) {
+            $this->OrganizationURL = ['invalid' => ''];
         }
     }
 
 
     /**
-     * Collect the value of the Extensions-property
+     * Collect the value of the Extensions property.
+     *
      * @return \SAML2\XML\Chunk[]
      */
     public function getExtensions() : array
@@ -92,7 +94,8 @@ class Organization
 
 
     /**
-     * Set the value of the Extensions-property
+     * Set the value of the Extensions property.
+     *
      * @param array $extensions
      * @return void
      */
@@ -115,7 +118,8 @@ class Organization
 
 
     /**
-     * Collect the value of the OrganizationName-property
+     * Collect the value of the OrganizationName property.
+     *
      * @return string[]
      */
     public function getOrganizationName() : array
@@ -125,7 +129,8 @@ class Organization
 
 
     /**
-     * Set the value of the OrganizationName-property
+     * Set the value of the OrganizationName property.
+     *
      * @param array $organizationName
      * @return void
      */
@@ -136,7 +141,8 @@ class Organization
 
 
     /**
-     * Collect the value of the OrganizationDisplayName-property
+     * Collect the value of the OrganizationDisplayName property.
+     *
      * @return string[]
      */
     public function getOrganizationDisplayName() : array
@@ -146,7 +152,8 @@ class Organization
 
 
     /**
-     * Set the value of the OrganizationDisplayName-property
+     * Set the value of the OrganizationDisplayName property.
+     *
      * @param array $organizationDisplayName
      * @return void
      */
@@ -157,7 +164,8 @@ class Organization
 
 
     /**
-     * Collect the value of the OrganizationURL-property
+     * Collect the value of the OrganizationURL property.
+     *
      * @return string[]
      */
     public function getOrganizationURL() : array
@@ -167,7 +175,8 @@ class Organization
 
 
     /**
-     * Set the value of the OrganizationURL-property
+     * Set the value of the OrganizationURL property.
+     *
      * @param array $organizationURL
      * @return void
      */

--- a/src/SAML2/XML/md/PDPDescriptor.php
+++ b/src/SAML2/XML/md/PDPDescriptor.php
@@ -58,6 +58,7 @@ class PDPDescriptor extends RoleDescriptor
             return;
         }
 
+        /** @var \DOMElement $ep */
         foreach (Utils::xpQuery($xml, './saml_metadata:AuthzService') as $ep) {
             $this->AuthzService[] = new EndpointType($ep);
         }
@@ -65,6 +66,7 @@ class PDPDescriptor extends RoleDescriptor
             throw new \Exception('Must have at least one AuthzService in PDPDescriptor.');
         }
 
+        /** @var \DOMElement $ep */
         foreach (Utils::xpQuery($xml, './saml_metadata:AssertionIDRequestService') as $ep) {
             $this->AssertionIDRequestService[] = new EndpointType($ep);
         }

--- a/src/SAML2/XML/md/PDPDescriptor.php
+++ b/src/SAML2/XML/md/PDPDescriptor.php
@@ -59,22 +59,23 @@ class PDPDescriptor extends RoleDescriptor
         }
 
         foreach (Utils::xpQuery($xml, './saml_metadata:AuthzService') as $ep) {
-            $this->addAuthzService(new EndpointType($ep));
+            $this->AuthzService[] = new EndpointType($ep);
         }
         if ($this->getAuthzService() !== []) {
             throw new \Exception('Must have at least one AuthzService in PDPDescriptor.');
         }
 
         foreach (Utils::xpQuery($xml, './saml_metadata:AssertionIDRequestService') as $ep) {
-            $this->addAssertionIDRequestService(new EndpointType($ep));
+            $this->AssertionIDRequestService[] = new EndpointType($ep);
         }
 
-        $this->setNameIDFormat(Utils::extractStrings($xml, Constants::NS_MD, 'NameIDFormat'));
+        $this->NameIDFormat = Utils::extractStrings($xml, Constants::NS_MD, 'NameIDFormat');
     }
 
 
     /**
      * Collect the value of the AuthzService-property
+     *
      * @return \SAML2\XML\md\EndpointType[]
      */
     public function getAuthzService() : array
@@ -85,6 +86,7 @@ class PDPDescriptor extends RoleDescriptor
 
     /**
      * Set the value of the AuthzService-property
+     *
      * @param \SAML2\XML\md\EndpointType[] $authzService
      * @return void
      */
@@ -96,6 +98,7 @@ class PDPDescriptor extends RoleDescriptor
 
     /**
      * Add the value to the AuthzService-property
+     *
      * @param \SAML2\XML\md\EndpointType $authzService
      * @return void
      */
@@ -107,6 +110,7 @@ class PDPDescriptor extends RoleDescriptor
 
     /**
      * Collect the value of the AssertionIDRequestService-property
+     *
      * @return \SAML2\XML\md\EndpointType[]
      */
     public function getAssertionIDRequestService() : array
@@ -117,6 +121,7 @@ class PDPDescriptor extends RoleDescriptor
 
     /**
      * Set the value of the AssertionIDRequestService-property
+     *
      * @param \SAML2\XML\md\EndpointType[] $assertionIDRequestService
      * @return void
      */
@@ -128,6 +133,7 @@ class PDPDescriptor extends RoleDescriptor
 
     /**
      * Add the value to the AssertionIDRequestService-property
+     *
      * @param \SAML2\XML\md\EndpointType $assertionIDRequestService
      * @return void
      */
@@ -139,6 +145,7 @@ class PDPDescriptor extends RoleDescriptor
 
     /**
      * Collect the value of the NameIDFormat-property
+     *
      * @return string[]
      */
     public function getNameIDFormat() : array
@@ -149,6 +156,7 @@ class PDPDescriptor extends RoleDescriptor
 
     /**
      * Set the value of the NameIDFormat-property
+     *
      * @param string[] $nameIDFormat
      * @return void
      */

--- a/src/SAML2/XML/md/RequestedAttribute.php
+++ b/src/SAML2/XML/md/RequestedAttribute.php
@@ -36,12 +36,13 @@ class RequestedAttribute extends Attribute
             return;
         }
 
-        $this->setIsRequired(Utils::parseBoolean($xml, 'isRequired', null));
+        $this->isRequired = Utils::parseBoolean($xml, 'isRequired', null);
     }
 
 
     /**
      * Collect the value of the isRequired-property
+     *
      * @return bool|null
      */
     public function getIsRequired()
@@ -52,6 +53,7 @@ class RequestedAttribute extends Attribute
 
     /**
      * Set the value of the isRequired-property
+     *
      * @param boolean|null $flag
      * @return void
      */
@@ -71,10 +73,8 @@ class RequestedAttribute extends Attribute
     {
         $e = $this->toXMLInternal($parent, Constants::NS_MD, 'md:RequestedAttribute');
 
-        if ($this->getIsRequired() === true) {
-            $e->setAttribute('isRequired', 'true');
-        } elseif ($this->getIsRequired() === false) {
-            $e->setAttribute('isRequired', 'false');
+        if (is_bool($this->isRequired)) {
+            $e->setAttribute('isRequired', $this->isRequired ? 'true' : 'false');
         }
 
         return $e;

--- a/src/SAML2/XML/md/RoleDescriptor.php
+++ b/src/SAML2/XML/md/RoleDescriptor.php
@@ -28,21 +28,7 @@ class RoleDescriptor extends SignedElementHelper
      *
      * @var string|null
      */
-    public $ID = null;
-
-    /**
-     * How long this element is valid, as a unix timestamp.
-     *
-     * @var int|null
-     */
-    public $validUntil = null;
-
-    /**
-     * The length of time this element can be cached, as string.
-     *
-     * @var string|null
-     */
-    public $cacheDuration = null;
+    private $ID = null;
 
     /**
      * List of supported protocols.
@@ -56,7 +42,7 @@ class RoleDescriptor extends SignedElementHelper
      *
      * @var string|null
      */
-    public $errorURL = null;
+    private $errorURL = null;
 
     /**
      * Extensions on this element.
@@ -96,8 +82,8 @@ class RoleDescriptor extends SignedElementHelper
     /**
      * Initialize a RoleDescriptor.
      *
-     * @param string          $elementName The name of this element.
-     * @param \DOMElement|null $xml         The XML element we should load.
+     * @param string $elementName The name of this element.
+     * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
     protected function __construct(string $elementName, \DOMElement $xml = null)
@@ -110,45 +96,46 @@ class RoleDescriptor extends SignedElementHelper
         }
 
         if ($xml->hasAttribute('ID')) {
-            $this->setID($xml->getAttribute('ID'));
+            $this->ID = $xml->getAttribute('ID');
         }
         if ($xml->hasAttribute('validUntil')) {
-            $this->setValidUntil(Utils::xsDateTimeToTimestamp($xml->getAttribute('validUntil')));
+            $this->validUntil = Utils::xsDateTimeToTimestamp($xml->getAttribute('validUntil'));
         }
         if ($xml->hasAttribute('cacheDuration')) {
-            $this->setCacheDuration($xml->getAttribute('cacheDuration'));
+            $this->cacheDuration = $xml->getAttribute('cacheDuration');
         }
 
         if (!$xml->hasAttribute('protocolSupportEnumeration')) {
             throw new \Exception('Missing protocolSupportEnumeration attribute on '.$xml->localName);
         }
-        $this->setProtocolSupportEnumeration(preg_split('/[\s]+/', $xml->getAttribute('protocolSupportEnumeration')));
+        $this->protocolSupportEnumeration = preg_split('/[\s]+/', $xml->getAttribute('protocolSupportEnumeration'));
 
         if ($xml->hasAttribute('errorURL')) {
-            $this->setErrorURL($xml->getAttribute('errorURL'));
+            $this->errorURL = $xml->getAttribute('errorURL');
         }
 
-        $this->setExtensions(Extensions::getList($xml));
+        $this->Extensions = Extensions::getList($xml);
 
         foreach (Utils::xpQuery($xml, './saml_metadata:KeyDescriptor') as $kd) {
-            $this->addKeyDescriptor(new KeyDescriptor($kd));
+            $this->KeyDescriptor[] = new KeyDescriptor($kd);
         }
 
         $organization = Utils::xpQuery($xml, './saml_metadata:Organization');
         if (count($organization) > 1) {
             throw new \Exception('More than one Organization in the entity.');
         } elseif (!empty($organization)) {
-            $this->setOrganization(new Organization($organization[0]));
+            $this->Organization = new Organization($organization[0]);
         }
 
         foreach (Utils::xpQuery($xml, './saml_metadata:ContactPerson') as $cp) {
-            $this->addContactPerson(new ContactPerson($cp));
+            $this->ContactPerson[] = new ContactPerson($cp);
         }
     }
 
 
     /**
      * Collect the value of the ID-property
+     *
      * @return string|null
      */
     public function getID()
@@ -159,6 +146,7 @@ class RoleDescriptor extends SignedElementHelper
 
     /**
      * Set the value of the ID-property
+     *
      * @param string|null $Id
      * @return void
      */
@@ -212,6 +200,7 @@ class RoleDescriptor extends SignedElementHelper
 
     /**
      * Collect the value of the Extensions-property
+     *
      * @return \SAML2\XML\Chunk[]
      */
     public function getExtensions() : array
@@ -222,6 +211,7 @@ class RoleDescriptor extends SignedElementHelper
 
     /**
      * Set the value of the Extensions-property
+     *
      * @param array $extensions
      * @return void
      */
@@ -245,6 +235,7 @@ class RoleDescriptor extends SignedElementHelper
 
     /**
      * Set the value of the errorURL-property
+     *
      * @param string|null $errorURL
      * @return void
      */
@@ -259,6 +250,7 @@ class RoleDescriptor extends SignedElementHelper
 
     /**
      * Collect the value of the errorURL-property
+     *
      * @return string|null
      */
     public function getErrorURL()
@@ -269,6 +261,7 @@ class RoleDescriptor extends SignedElementHelper
 
     /**
      * Collect the value of the ProtocolSupportEnumeration-property
+     *
      * @return string[]
      */
     public function getProtocolSupportEnumeration() : array
@@ -279,6 +272,7 @@ class RoleDescriptor extends SignedElementHelper
 
     /**
      * Set the value of the ProtocolSupportEnumeration-property
+     *
      * @param array $protocols
      * @return void
      */
@@ -290,6 +284,7 @@ class RoleDescriptor extends SignedElementHelper
 
     /**
      * Add the value to the ProtocolSupportEnumeration-property
+     *
      * @param string $protocol
      * @return void
      */
@@ -301,6 +296,7 @@ class RoleDescriptor extends SignedElementHelper
 
     /**
      * Collect the value of the Organization-property
+     *
      * @return \SAML2\XML\md\Organization|null
      */
     public function getOrganization()
@@ -311,6 +307,7 @@ class RoleDescriptor extends SignedElementHelper
 
     /**
      * Set the value of the Organization-property
+     *
      * @param \SAML2\XML\md\Organization|null $organization
      * @return void
      */
@@ -322,6 +319,7 @@ class RoleDescriptor extends SignedElementHelper
 
     /**
      * Collect the value of the ContactPerson-property
+     *
      * @return \SAML2\XML\md\ContactPerson[]
      */
     public function getContactPerson() : array
@@ -332,6 +330,7 @@ class RoleDescriptor extends SignedElementHelper
 
     /**
      * Set the value of the ContactPerson-property
+     *
      * @param array $contactPerson
      * @return void
      */
@@ -343,6 +342,7 @@ class RoleDescriptor extends SignedElementHelper
 
     /**
      * Add the value to the ContactPerson-property
+     *
      * @param \SAML2\XML\md\ContactPerson $contactPerson
      * @return void
      */
@@ -354,6 +354,7 @@ class RoleDescriptor extends SignedElementHelper
 
     /**
      * Collect the value of the KeyDescriptor-property
+     *
      * @return \SAML2\XML\md\KeyDescriptor[]
      */
     public function getKeyDescriptor() : array
@@ -364,6 +365,7 @@ class RoleDescriptor extends SignedElementHelper
 
     /**
      * Set the value of the KeyDescriptor-property
+     *
      * @param array $keyDescriptor
      * @return void
      */
@@ -375,6 +377,7 @@ class RoleDescriptor extends SignedElementHelper
 
     /**
      * Add the value to the KeyDescriptor-property
+     *
      * @param \SAML2\XML\md\KeyDescriptor $keyDescriptor
      * @return void
      */
@@ -395,35 +398,35 @@ class RoleDescriptor extends SignedElementHelper
         $e = $parent->ownerDocument->createElementNS(Constants::NS_MD, $this->elementName);
         $parent->appendChild($e);
 
-        if ($this->getID() !== null) {
-            $e->setAttribute('ID', $this->getID());
+        if ($this->ID !== null) {
+            $e->setAttribute('ID', $this->ID);
         }
 
-        if ($this->getValidUntil() !== null) {
-            $e->setAttribute('validUntil', gmdate('Y-m-d\TH:i:s\Z', $this->getValidUntil()));
+        if ($this->validUntil !== null) {
+            $e->setAttribute('validUntil', gmdate('Y-m-d\TH:i:s\Z', $this->validUntil));
         }
 
-        if ($this->getCacheDuration() !== null) {
-            $e->setAttribute('cacheDuration', $this->getCacheDuration());
+        if ($this->cacheDuration !== null) {
+            $e->setAttribute('cacheDuration', $this->cacheDuration);
         }
 
-        $e->setAttribute('protocolSupportEnumeration', implode(' ', $this->getProtocolSupportEnumeration()));
+        $e->setAttribute('protocolSupportEnumeration', implode(' ', $this->protocolSupportEnumeration));
 
-        if ($this->getErrorURL() !== null) {
-            $e->setAttribute('errorURL', $this->getErrorURL());
+        if ($this->errorURL !== null) {
+            $e->setAttribute('errorURL', $this->errorURL);
         }
 
-        Extensions::addList($e, $this->getExtensions());
+        Extensions::addList($e, $this->Extensions);
 
-        foreach ($this->getKeyDescriptor() as $kd) {
+        foreach ($this->KeyDescriptor as $kd) {
             $kd->toXML($e);
         }
 
-        if ($this->getOrganization() !== null) {
-            $this->getOrganization()->toXML($e);
+        if ($this->Organization !== null) {
+            $this->Organization->toXML($e);
         }
 
-        foreach ($this->getContactPerson() as $cp) {
+        foreach ($this->ContactPerson as $cp) {
             $cp->toXML($e);
         }
 

--- a/src/SAML2/XML/md/RoleDescriptor.php
+++ b/src/SAML2/XML/md/RoleDescriptor.php
@@ -117,6 +117,7 @@ class RoleDescriptor extends SignedElementHelper
         $this->Extensions = Extensions::getList($xml);
 
         foreach (Utils::xpQuery($xml, './saml_metadata:KeyDescriptor') as $kd) {
+            /** @var \DOMElement $kd */
             $this->KeyDescriptor[] = new KeyDescriptor($kd);
         }
 
@@ -124,10 +125,12 @@ class RoleDescriptor extends SignedElementHelper
         if (count($organization) > 1) {
             throw new \Exception('More than one Organization in the entity.');
         } elseif (!empty($organization)) {
+            /** @var \DOMElement $organization[0] */
             $this->Organization = new Organization($organization[0]);
         }
 
         foreach (Utils::xpQuery($xml, './saml_metadata:ContactPerson') as $cp) {
+            /** @var \DOMElement $cp */
             $this->ContactPerson[] = new ContactPerson($cp);
         }
     }

--- a/src/SAML2/XML/md/RoleDescriptor.php
+++ b/src/SAML2/XML/md/RoleDescriptor.php
@@ -134,7 +134,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Collect the value of the ID-property
+     * Collect the value of the ID property.
      *
      * @return string|null
      */
@@ -145,7 +145,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Set the value of the ID-property
+     * Set the value of the ID property.
      *
      * @param string|null $Id
      * @return void
@@ -199,7 +199,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Collect the value of the Extensions-property
+     * Collect the value of the Extensions property.
      *
      * @return \SAML2\XML\Chunk[]
      */
@@ -210,7 +210,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Set the value of the Extensions-property
+     * Set the value of the Extensions property.
      *
      * @param array $extensions
      * @return void
@@ -234,7 +234,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Set the value of the errorURL-property
+     * Set the value of the errorURL property.
      *
      * @param string|null $errorURL
      * @return void
@@ -249,7 +249,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Collect the value of the errorURL-property
+     * Collect the value of the errorURL property.
      *
      * @return string|null
      */
@@ -260,7 +260,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Collect the value of the ProtocolSupportEnumeration-property
+     * Collect the value of the ProtocolSupportEnumeration property.
      *
      * @return string[]
      */
@@ -271,7 +271,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Set the value of the ProtocolSupportEnumeration-property
+     * Set the value of the ProtocolSupportEnumeration property.
      *
      * @param array $protocols
      * @return void
@@ -283,7 +283,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Add the value to the ProtocolSupportEnumeration-property
+     * Add the value to the ProtocolSupportEnumeration property.
      *
      * @param string $protocol
      * @return void
@@ -295,7 +295,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Collect the value of the Organization-property
+     * Collect the value of the Organization property.
      *
      * @return \SAML2\XML\md\Organization|null
      */
@@ -306,7 +306,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Set the value of the Organization-property
+     * Set the value of the Organization property.
      *
      * @param \SAML2\XML\md\Organization|null $organization
      * @return void
@@ -318,7 +318,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Collect the value of the ContactPerson-property
+     * Collect the value of the ContactPerson property.
      *
      * @return \SAML2\XML\md\ContactPerson[]
      */
@@ -329,7 +329,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Set the value of the ContactPerson-property
+     * Set the value of the ContactPerson property.
      *
      * @param array $contactPerson
      * @return void
@@ -341,7 +341,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Add the value to the ContactPerson-property
+     * Add the value to the ContactPerson property.
      *
      * @param \SAML2\XML\md\ContactPerson $contactPerson
      * @return void
@@ -353,7 +353,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Collect the value of the KeyDescriptor-property
+     * Collect the value of the KeyDescriptor property.
      *
      * @return \SAML2\XML\md\KeyDescriptor[]
      */
@@ -364,7 +364,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Set the value of the KeyDescriptor-property
+     * Set the value of the KeyDescriptor property.
      *
      * @param array $keyDescriptor
      * @return void
@@ -376,7 +376,7 @@ class RoleDescriptor extends SignedElementHelper
 
 
     /**
-     * Add the value to the KeyDescriptor-property
+     * Add the value to the KeyDescriptor property.
      *
      * @param \SAML2\XML\md\KeyDescriptor $keyDescriptor
      * @return void

--- a/src/SAML2/XML/md/SPSSODescriptor.php
+++ b/src/SAML2/XML/md/SPSSODescriptor.php
@@ -59,21 +59,22 @@ class SPSSODescriptor extends SSODescriptorType
             return;
         }
 
-        $this->setAuthnRequestsSigned(Utils::parseBoolean($xml, 'AuthnRequestsSigned', null));
-        $this->setWantAssertionsSigned(Utils::parseBoolean($xml, 'WantAssertionsSigned', null));
+        $this->AuthnRequestsSigned = Utils::parseBoolean($xml, 'AuthnRequestsSigned', null);
+        $this->WantAssertionsSigned = Utils::parseBoolean($xml, 'WantAssertionsSigned', null);
 
         foreach (Utils::xpQuery($xml, './saml_metadata:AssertionConsumerService') as $ep) {
-            $this->addAssertionConsumerService(new IndexedEndpointType($ep));
+            $this->AssertionConsumerService[] = new IndexedEndpointType($ep);
         }
 
         foreach (Utils::xpQuery($xml, './saml_metadata:AttributeConsumingService') as $acs) {
-            $this->addAttributeConsumingService(new AttributeConsumingService($acs));
+            $this->AttributeConsumingService[] = new AttributeConsumingService($acs);
         }
     }
 
 
     /**
      * Collect the value of the AuthnRequestsSigned-property
+     *
      * @return bool|null
      */
     public function getAuthnRequestsSigned()
@@ -84,6 +85,7 @@ class SPSSODescriptor extends SSODescriptorType
 
     /**
      * Set the value of the AuthnRequestsSigned-property
+     *
      * @param bool|null $flag
      * @return void
      */
@@ -95,6 +97,7 @@ class SPSSODescriptor extends SSODescriptorType
 
     /**
      * Collect the value of the WantAssertionsSigned-property
+     *
      * @return bool|null
      */
     public function wantAssertionsSigned()
@@ -104,7 +107,8 @@ class SPSSODescriptor extends SSODescriptorType
 
 
     /**
-     * Set the value of the WantAssertionsSigned-property
+     * Set the value of the WantAssertionsSigned-propert
+     *
      * @param bool|null $flag
      * @return void
      */
@@ -116,6 +120,7 @@ class SPSSODescriptor extends SSODescriptorType
 
     /**
      * Collect the value of the AssertionConsumerService-property
+     *
      * @return array
      */
     public function getAssertionConsumerService() : array
@@ -126,6 +131,7 @@ class SPSSODescriptor extends SSODescriptorType
 
     /**
      * Set the value of the AssertionConsumerService-property
+     *
      * @param array $acs
      * @return void
      */
@@ -137,6 +143,7 @@ class SPSSODescriptor extends SSODescriptorType
 
     /**
      * Add the value to the AssertionConsumerService-property
+     *
      * @param \SAML2\XML\md\IndexedEndpointType $acs
      * @return void
      */
@@ -148,6 +155,7 @@ class SPSSODescriptor extends SSODescriptorType
 
     /**
      * Collect the value of the AttributeConsumingService-property
+     *
      * @return array
      */
     public function getAttributeConsumingService() : array
@@ -158,6 +166,7 @@ class SPSSODescriptor extends SSODescriptorType
 
     /**
      * Add the value to the AttributeConsumingService-property
+     *
      * @param \SAML2\XML\md\AttributeConsumingService $acs
      * @return void
      */
@@ -169,6 +178,7 @@ class SPSSODescriptor extends SSODescriptorType
 
     /**
      * Set the value of the AttributeConsumingService-property
+     *
      * @param array $acs
      * @return void
      */
@@ -188,23 +198,19 @@ class SPSSODescriptor extends SSODescriptorType
     {
         $e = parent::toXML($parent);
 
-        if ($this->getAuthnRequestsSigned() === true) {
-            $e->setAttribute('AuthnRequestsSigned', 'true');
-        } elseif ($this->getAuthnRequestsSigned() === false) {
-            $e->setAttribute('AuthnRequestsSigned', 'false');
+        if (is_bool($this->AuthnRequestsSigned)) {
+            $e->setAttribute('AuthnRequestsSigned', $this->AuthnRequestsSigned ? 'true' : 'false');
         }
 
-        if ($this->wantAssertionsSigned() === true) {
-            $e->setAttribute('WantAssertionsSigned', 'true');
-        } elseif ($this->wantAssertionsSigned() === false) {
-            $e->setAttribute('WantAssertionsSigned', 'false');
+        if (is_bool($this->WantAssertionsSigned)) {
+            $e->setAttribute('WantAssertionsSigned', $this->WantAssertionsSigned ? 'true' : 'false');
         }
 
-        foreach ($this->getAssertionConsumerService() as $ep) {
+        foreach ($this->AssertionConsumerService as $ep) {
             $ep->toXML($e, 'md:AssertionConsumerService');
         }
 
-        foreach ($this->getAttributeConsumingService() as $acs) {
+        foreach ($this->AttributeConsumingService as $acs) {
             $acs->toXML($e);
         }
 

--- a/src/SAML2/XML/md/SPSSODescriptor.php
+++ b/src/SAML2/XML/md/SPSSODescriptor.php
@@ -62,10 +62,12 @@ class SPSSODescriptor extends SSODescriptorType
         $this->AuthnRequestsSigned = Utils::parseBoolean($xml, 'AuthnRequestsSigned', null);
         $this->WantAssertionsSigned = Utils::parseBoolean($xml, 'WantAssertionsSigned', null);
 
+        /** @var \DOMElement $ep */
         foreach (Utils::xpQuery($xml, './saml_metadata:AssertionConsumerService') as $ep) {
             $this->AssertionConsumerService[] = new IndexedEndpointType($ep);
         }
 
+        /** @var \DOMElement $acs */
         foreach (Utils::xpQuery($xml, './saml_metadata:AttributeConsumingService') as $acs) {
             $this->AttributeConsumingService[] = new AttributeConsumingService($acs);
         }

--- a/src/SAML2/XML/md/SPSSODescriptor.php
+++ b/src/SAML2/XML/md/SPSSODescriptor.php
@@ -107,7 +107,7 @@ class SPSSODescriptor extends SSODescriptorType
 
 
     /**
-     * Set the value of the WantAssertionsSigned-propert
+     * Set the value of the WantAssertionsSigned-property
      *
      * @param bool|null $flag
      * @return void

--- a/src/SAML2/XML/md/SSODescriptorType.php
+++ b/src/SAML2/XML/md/SSODescriptorType.php
@@ -65,14 +65,17 @@ abstract class SSODescriptorType extends RoleDescriptor
             return;
         }
 
+        /** @var \DOMElement $ep */
         foreach (Utils::xpQuery($xml, './saml_metadata:ArtifactResolutionService') as $ep) {
             $this->addArtifactResolutionService(new IndexedEndpointType($ep));
         }
 
+        /** @var \DOMElement $ep */
         foreach (Utils::xpQuery($xml, './saml_metadata:SingleLogoutService') as $ep) {
             $this->addSingleLogoutService(new EndpointType($ep));
         }
 
+        /** @var \DOMElement $ep */
         foreach (Utils::xpQuery($xml, './saml_metadata:ManageNameIDService') as $ep) {
             $this->addManageNameIDService(new EndpointType($ep));
         }

--- a/src/SAML2/XML/md/SSODescriptorType.php
+++ b/src/SAML2/XML/md/SSODescriptorType.php
@@ -54,8 +54,8 @@ abstract class SSODescriptorType extends RoleDescriptor
     /**
      * Initialize a SSODescriptor.
      *
-     * @param string          $elementName The name of this element.
-     * @param \DOMElement|null $xml         The XML element we should load.
+     * @param string $elementName The name of this element.
+     * @param \DOMElement|null $xml The XML element we should load.
      */
     protected function __construct(string $elementName, \DOMElement $xml = null)
     {
@@ -83,6 +83,7 @@ abstract class SSODescriptorType extends RoleDescriptor
 
     /**
      * Collect the value of the ArtifactResolutionService-property
+     *
      * @return \SAML2\XML\md\IndexedEndpointType[]
      */
     public function getArtifactResolutionService() : array
@@ -93,6 +94,7 @@ abstract class SSODescriptorType extends RoleDescriptor
 
     /**
      * Set the value of the ArtifactResolutionService-property
+     *
      * @param \SAML2\XML\md\IndexedEndpointType[] $artifactResolutionService
      * @return void
      */
@@ -104,6 +106,7 @@ abstract class SSODescriptorType extends RoleDescriptor
 
     /**
      * Add the value to the ArtifactResolutionService-property
+     *
      * @param \SAML2\XML\md\IndexedEndpointType $artifactResolutionService
      * @return void
      */
@@ -115,6 +118,7 @@ abstract class SSODescriptorType extends RoleDescriptor
 
     /**
      * Collect the value of the SingleLogoutService-property
+     *
      * @return \SAML2\XML\md\EndpointType[]
      */
     public function getSingleLogoutService() : array
@@ -125,6 +129,7 @@ abstract class SSODescriptorType extends RoleDescriptor
 
     /**
      * Set the value of the SingleLogoutService-property
+     *
      * @param \SAML2\XML\md\EndpointType[] $singleLogoutService
      * @return void
      */
@@ -136,6 +141,7 @@ abstract class SSODescriptorType extends RoleDescriptor
 
     /**
      * Add the value to the SingleLogoutService-property
+     *
      * @param \SAML2\XML\md\EndpointType $singleLogoutService
      * @return void
      */
@@ -147,6 +153,7 @@ abstract class SSODescriptorType extends RoleDescriptor
 
     /**
      * Collect the value of the ManageNameIDService-property
+     *
      * @return \SAML2\XML\md\EndpointType[]
      */
     public function getManageNameIDService() : array
@@ -157,6 +164,7 @@ abstract class SSODescriptorType extends RoleDescriptor
 
     /**
      * Set the value of the ManageNameIDService-property
+     *
      * @param \SAML2\XML\md\EndpointType[] $manageNameIDService
      * @return void
      */
@@ -168,6 +176,7 @@ abstract class SSODescriptorType extends RoleDescriptor
 
     /**
      * Add the value to the ManageNameIDService-property
+     *
      * @param \SAML2\XML\md\EndpointType $manageNameIDService
      * @return void
      */
@@ -179,6 +188,7 @@ abstract class SSODescriptorType extends RoleDescriptor
 
     /**
      * Collect the value of the NameIDFormat-property
+     *
      * @return string[]
      */
     public function getNameIDFormat() : array
@@ -189,6 +199,7 @@ abstract class SSODescriptorType extends RoleDescriptor
 
     /**
      * Set the value of the NameIDFormat-property
+     *
      * @param string[] $nameIDFormat
      * @return void
      */
@@ -208,19 +219,19 @@ abstract class SSODescriptorType extends RoleDescriptor
     {
         $e = parent::toXML($parent);
 
-        foreach ($this->getArtifactResolutionService() as $ep) {
+        foreach ($this->ArtifactResolutionService as $ep) {
             $ep->toXML($e, 'md:ArtifactResolutionService');
         }
 
-        foreach ($this->getSingleLogoutService() as $ep) {
+        foreach ($this->SingleLogoutService as $ep) {
             $ep->toXML($e, 'md:SingleLogoutService');
         }
 
-        foreach ($this->getManageNameIDService() as $ep) {
+        foreach ($this->ManageNameIDService as $ep) {
             $ep->toXML($e, 'md:ManageNameIDService');
         }
 
-        Utils::addStrings($e, Constants::NS_MD, 'md:NameIDFormat', false, $this->getNameIDFormat());
+        Utils::addStrings($e, Constants::NS_MD, 'md:NameIDFormat', false, $this->NameIDFormat);
 
         return $e;
     }

--- a/src/SAML2/XML/mdattr/EntityAttributes.php
+++ b/src/SAML2/XML/mdattr/EntityAttributes.php
@@ -30,7 +30,7 @@ class EntityAttributes
      *
      * @var (\SAML2\XML\saml\Attribute|\SAML2\XML\Chunk)[]
      */
-    public $children = [];
+    private $children = [];
 
 
     /**
@@ -46,9 +46,9 @@ class EntityAttributes
 
         foreach (Utils::xpQuery($xml, './saml_assertion:Attribute|./saml_assertion:Assertion') as $node) {
             if ($node->localName === 'Attribute') {
-                $this->addChildren(new Attribute($node));
+                $this->children[] = new Attribute($node);
             } else {
-                $this->addChildren(new Chunk($node));
+                $this->children[] = new Chunk($node);
             }
         }
     }
@@ -56,6 +56,7 @@ class EntityAttributes
 
     /**
      * Collect the value of the children-property
+     *
      * @return (\SAML2\XML\Chunk|\SAML2\XML\saml\Attribute)[]
      */
     public function getChildren() : array
@@ -66,6 +67,7 @@ class EntityAttributes
 
     /**
      * Set the value of the childen-property
+     *
      * @param array $children
      * @return void
      */
@@ -77,6 +79,7 @@ class EntityAttributes
 
     /**
      * Add the value to the children-property
+     *
      * @param \SAML2\XML\Chunk|\SAML2\XML\saml\Attribute $child
      * @return void
      */
@@ -101,7 +104,7 @@ class EntityAttributes
         $parent->appendChild($e);
 
         /** @var \SAML2\XML\saml\Attribute|\SAML2\XML\Chunk $child */
-        foreach ($this->getChildren() as $child) {
+        foreach ($this->children as $child) {
             $child->toXML($e);
         }
 

--- a/src/SAML2/XML/mdattr/EntityAttributes.php
+++ b/src/SAML2/XML/mdattr/EntityAttributes.php
@@ -44,6 +44,7 @@ class EntityAttributes
             return;
         }
 
+        /** @var \DOMElement $node */
         foreach (Utils::xpQuery($xml, './saml_assertion:Attribute|./saml_assertion:Assertion') as $node) {
             if ($node->localName === 'Attribute') {
                 $this->children[] = new Attribute($node);

--- a/src/SAML2/XML/mdrpi/PublicationInfo.php
+++ b/src/SAML2/XML/mdrpi/PublicationInfo.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SAML2\XML\mdrpi;
 
+use Webmozart\Assert\Assert;
+
 use SAML2\Utils;
 
 /**
@@ -19,21 +21,21 @@ class PublicationInfo
      *
      * @var string
      */
-    public $publisher;
+    private $publisher = '';
 
     /**
      * The creation timestamp for the metadata, as a UNIX timestamp.
      *
      * @var int|null
      */
-    public $creationInstant = null;
+    private $creationInstant = null;
 
     /**
      * Identifier for this metadata publication.
      *
      * @var string|null
      */
-    public $publicationId = null;
+    private $publicationId = null;
 
     /**
      * Link to usage policy for this metadata.
@@ -60,25 +62,26 @@ class PublicationInfo
         if (!$xml->hasAttribute('publisher')) {
             throw new \Exception('Missing required attribute "publisher" in mdrpi:PublicationInfo element.');
         }
-        $this->setPublisher($xml->getAttribute('publisher'));
+        $this->publisher = $xml->getAttribute('publisher');
 
         if ($xml->hasAttribute('creationInstant')) {
-            $this->setCreationInstant(Utils::xsDateTimeToTimestamp($xml->getAttribute('creationInstant')));
+            $this->creationInstant = Utils::xsDateTimeToTimestamp($xml->getAttribute('creationInstant'));
         }
 
         if ($xml->hasAttribute('publicationId')) {
-            $this->setPublicationId($xml->getAttribute('publicationId'));
+            $this->publicationId = $xml->getAttribute('publicationId');
         }
 
-        $this->setUsagePolicy(Utils::extractLocalizedStrings($xml, Common::NS_MDRPI, 'UsagePolicy'));
+        $this->UsagePolicy = Utils::extractLocalizedStrings($xml, Common::NS_MDRPI, 'UsagePolicy');
     }
 
 
     /**
      * Collect the value of the publisher-property
+     *
      * @return string
      */
-    public function getPublisher() : string
+    public function getPublisher()
     {
         return $this->publisher;
     }
@@ -86,6 +89,7 @@ class PublicationInfo
 
     /**
      * Collect the value of the creationInstant-property
+     *
      * @return int|null
      */
     public function getCreationInstant()
@@ -96,6 +100,7 @@ class PublicationInfo
 
     /**
      * Collect the value of the publicationId-property
+     *
      * @return string|null
      */
     public function getPublicationId()
@@ -106,6 +111,7 @@ class PublicationInfo
 
     /**
      * Collect the value of the UsagePolicy-property
+     *
      * @return array
      */
     public function getUsagePolicy() : array
@@ -116,6 +122,7 @@ class PublicationInfo
 
     /**
      * Set the value of the publisher-property
+     *
      * @param string $publisher
      * @return void
      */
@@ -127,6 +134,7 @@ class PublicationInfo
 
     /**
      * Set the value of the creationInstant-property
+     *
      * @param int|null $creationInstant
      * @return void
      */
@@ -138,6 +146,7 @@ class PublicationInfo
 
     /**
      * Set the value of the publicationId-property
+     *
      * @param string|null $publicationId
      * @return void
      */
@@ -149,6 +158,7 @@ class PublicationInfo
 
     /**
      * Set the value of the UsagePolicy-property
+     *
      * @param array $usagePolicy
      * @return void
      */
@@ -166,22 +176,24 @@ class PublicationInfo
      */
     public function toXML(\DOMElement $parent) : \DOMElement
     {
+        Assert::notEmpty($this->publisher, "Cannot convert PublicationInfo to XML without a publisher set.");
+
         $doc = $parent->ownerDocument;
 
         $e = $doc->createElementNS(Common::NS_MDRPI, 'mdrpi:PublicationInfo');
         $parent->appendChild($e);
 
-        $e->setAttribute('publisher', $this->getPublisher());
+        $e->setAttribute('publisher', $this->publisher);
 
-        if ($this->getCreationInstant() !== null) {
-            $e->setAttribute('creationInstant', gmdate('Y-m-d\TH:i:s\Z', $this->getCreationInstant()));
+        if ($this->creationInstant !== null) {
+            $e->setAttribute('creationInstant', gmdate('Y-m-d\TH:i:s\Z', $this->creationInstant));
         }
 
-        if ($this->getPublicationId() !== null) {
-            $e->setAttribute('publicationId', $this->getPublicationId());
+        if ($this->publicationId !== null) {
+            $e->setAttribute('publicationId', $this->publicationId);
         }
 
-        Utils::addStrings($e, Common::NS_MDRPI, 'mdrpi:UsagePolicy', true, $this->getUsagePolicy());
+        Utils::addStrings($e, Common::NS_MDRPI, 'mdrpi:UsagePolicy', true, $this->UsagePolicy);
 
         return $e;
     }

--- a/src/SAML2/XML/mdrpi/RegistrationInfo.php
+++ b/src/SAML2/XML/mdrpi/RegistrationInfo.php
@@ -17,16 +17,16 @@ class RegistrationInfo
     /**
      * The identifier of the metadata registration authority.
      *
-     * @var string
+     * @var string|null
      */
-    public $registrationAuthority;
+    private $registrationAuthority = null;
 
     /**
      * The registration timestamp for the metadata, as a UNIX timestamp.
      *
      * @var int|null
      */
-    public $registrationInstant = null;
+    private $registrationInstant = null;
 
     /**
      * Link to registration policy for this metadata.
@@ -53,19 +53,20 @@ class RegistrationInfo
         if (!$xml->hasAttribute('registrationAuthority')) {
             throw new \Exception('Missing required attribute "registrationAuthority" in mdrpi:RegistrationInfo element.');
         }
-        $this->setRegistrationAuthority($xml->getAttribute('registrationAuthority'));
+        $this->registrationAuthority = $xml->getAttribute('registrationAuthority');
 
         if ($xml->hasAttribute('registrationInstant')) {
-            $this->setRegistrationInstant(Utils::xsDateTimeToTimestamp($xml->getAttribute('registrationInstant')));
+            $this->registrationInstant = Utils::xsDateTimeToTimestamp($xml->getAttribute('registrationInstant'));
         }
 
-        $this->setRegistrationPolicy(Utils::extractLocalizedStrings($xml, Common::NS_MDRPI, 'RegistrationPolicy'));
+        $this->RegistrationPolicy = Utils::extractLocalizedStrings($xml, Common::NS_MDRPI, 'RegistrationPolicy');
     }
 
 
     /**
      * Collect the value of the RegistrationAuthority-property
-     * @return string
+     *
+     * @return string|null
      */
     public function getRegistrationAuthority() : string
     {
@@ -75,6 +76,7 @@ class RegistrationInfo
 
     /**
      * Set the value of the registrationAuthority-property
+     *
      * @param string $registrationAuthority
      * @return void
      */
@@ -86,6 +88,7 @@ class RegistrationInfo
 
     /**
      * Collect the value of the registrationInstant-property
+     *
      * @return int|null
      */
     public function getRegistrationInstant()
@@ -96,6 +99,7 @@ class RegistrationInfo
 
     /**
      * Set the value of the registrationInstant-property
+     *
      * @param int|null $registrationInstant
      * @return void
      */
@@ -107,6 +111,7 @@ class RegistrationInfo
 
     /**
      * Collect the value of the RegistrationPolicy-property
+     *
      * @return array
      */
     public function getRegistrationPolicy() : array
@@ -117,6 +122,7 @@ class RegistrationInfo
 
     /**
      * Set the value of the RegistrationPolicy-property
+     *
      * @param array $registrationPolicy
      * @return void
      */
@@ -134,8 +140,7 @@ class RegistrationInfo
      */
     public function toXML(\DOMElement $parent) : \DOMElement
     {
-        $registrationAuthority = $this->getRegistrationAuthority();
-        if (empty($registrationAuthority)) {
+        if (empty($this->registrationAuthority)) {
             throw new \Exception('Missing required registration authority.');
         }
 
@@ -144,13 +149,13 @@ class RegistrationInfo
         $e = $doc->createElementNS(Common::NS_MDRPI, 'mdrpi:RegistrationInfo');
         $parent->appendChild($e);
 
-        $e->setAttribute('registrationAuthority', $this->getRegistrationAuthority());
+        $e->setAttribute('registrationAuthority', $this->registrationAuthority);
 
-        if ($this->getRegistrationInstant() !== null) {
-            $e->setAttribute('registrationInstant', gmdate('Y-m-d\TH:i:s\Z', $this->getRegistrationInstant()));
+        if ($this->registrationInstant !== null) {
+            $e->setAttribute('registrationInstant', gmdate('Y-m-d\TH:i:s\Z', $this->registrationInstant));
         }
 
-        Utils::addStrings($e, Common::NS_MDRPI, 'mdrpi:RegistrationPolicy', true, $this->getRegistrationPolicy());
+        Utils::addStrings($e, Common::NS_MDRPI, 'mdrpi:RegistrationPolicy', true, $this->RegistrationPolicy);
 
         return $e;
     }

--- a/src/SAML2/XML/mdrpi/RegistrationInfo.php
+++ b/src/SAML2/XML/mdrpi/RegistrationInfo.php
@@ -51,7 +51,9 @@ class RegistrationInfo
         }
 
         if (!$xml->hasAttribute('registrationAuthority')) {
-            throw new \Exception('Missing required attribute "registrationAuthority" in mdrpi:RegistrationInfo element.');
+            throw new \Exception(
+                'Missing required attribute "registrationAuthority" in mdrpi:RegistrationInfo element.'
+            );
         }
         $this->registrationAuthority = $xml->getAttribute('registrationAuthority');
 
@@ -64,18 +66,18 @@ class RegistrationInfo
 
 
     /**
-     * Collect the value of the RegistrationAuthority-property
+     * Collect the value of the RegistrationAuthority property
      *
      * @return string|null
      */
-    public function getRegistrationAuthority() : string
+    public function getRegistrationAuthority()
     {
         return $this->registrationAuthority;
     }
 
 
     /**
-     * Set the value of the registrationAuthority-property
+     * Set the value of the registrationAuthority property
      *
      * @param string $registrationAuthority
      * @return void
@@ -87,7 +89,7 @@ class RegistrationInfo
 
 
     /**
-     * Collect the value of the registrationInstant-property
+     * Collect the value of the registrationInstant property
      *
      * @return int|null
      */
@@ -98,7 +100,7 @@ class RegistrationInfo
 
 
     /**
-     * Set the value of the registrationInstant-property
+     * Set the value of the registrationInstant property
      *
      * @param int|null $registrationInstant
      * @return void
@@ -110,7 +112,7 @@ class RegistrationInfo
 
 
     /**
-     * Collect the value of the RegistrationPolicy-property
+     * Collect the value of the RegistrationPolicy property
      *
      * @return array
      */
@@ -121,7 +123,7 @@ class RegistrationInfo
 
 
     /**
-     * Set the value of the RegistrationPolicy-property
+     * Set the value of the RegistrationPolicy property
      *
      * @param array $registrationPolicy
      * @return void

--- a/src/SAML2/XML/mdui/DiscoHints.php
+++ b/src/SAML2/XML/mdui/DiscoHints.php
@@ -57,18 +57,19 @@ class DiscoHints
             return;
         }
 
-        $this->setIPHint(Utils::extractStrings($xml, Common::NS, 'IPHint'));
-        $this->setDomainHint(Utils::extractStrings($xml, Common::NS, 'DomainHint'));
-        $this->setGeolocationHint(Utils::extractStrings($xml, Common::NS, 'GeolocationHint'));
+        $this->IPHint = Utils::extractStrings($xml, Common::NS, 'IPHint');
+        $this->DomainHint = Utils::extractStrings($xml, Common::NS, 'DomainHint');
+        $this->GeolocationHint = Utils::extractStrings($xml, Common::NS, 'GeolocationHint');
 
         foreach (Utils::xpQuery($xml, "./*[namespace-uri()!='".Common::NS."']") as $node) {
-            $this->addChildren(new Chunk($node));
+            $this->children[] = new Chunk($node);
         }
     }
 
 
     /**
      * Collect the value of the IPHint-property
+     *
      * @return string[]
      */
     public function getIPHint() : array
@@ -79,6 +80,7 @@ class DiscoHints
 
     /**
      * Set the value of the IPHint-property
+     *
      * @param string[] $hints
      * @return void
      */
@@ -90,6 +92,7 @@ class DiscoHints
 
     /**
      * Collect the value of the DomainHint-property
+     *
      * @return string[]
      */
     public function getDomainHint() : array
@@ -100,6 +103,7 @@ class DiscoHints
 
     /**
      * Set the value of the DomainHint-property
+     *
      * @param string[] $hints
      * @return void
      */
@@ -111,6 +115,7 @@ class DiscoHints
 
     /**
      * Collect the value of the GeolocationHint-property
+     *
      * @return string[]
      */
     public function getGeolocationHint() : array
@@ -121,6 +126,7 @@ class DiscoHints
 
     /**
      * Set the value of the GeolocationHint-property
+     *
      * @param string[] $hints
      * @return void
      */
@@ -132,6 +138,7 @@ class DiscoHints
 
     /**
      * Collect the value of the children-property
+     *
      * @return \SAML2\XML\Chunk[]
      */
     public function getChildren() : array
@@ -142,6 +149,7 @@ class DiscoHints
 
     /**
      * Set the value of the childen-property
+     *
      * @param array $children
      * @return void
      */
@@ -153,6 +161,7 @@ class DiscoHints
 
     /**
      * Add the value to the children-property
+     *
      * @param \SAML2\XML\Chunk $child
      * @return void
      */
@@ -173,21 +182,20 @@ class DiscoHints
         if (!empty($this->IPHint)
          || !empty($this->DomainHint)
          || !empty($this->GeolocationHint)
-         || !empty($this->children)) {
+         || !empty($this->children)
+        ) {
             $doc = $parent->ownerDocument;
 
             $e = $doc->createElementNS(Common::NS, 'mdui:DiscoHints');
             $parent->appendChild($e);
 
-            if (!empty($this->children)) {
-                foreach ($this->getChildren() as $child) {
-                    $child->toXML($e);
-                }
+            foreach ($this->getChildren() as $child) {
+                $child->toXML($e);
             }
 
-            Utils::addStrings($e, Common::NS, 'mdui:IPHint', false, $this->getIPHint());
-            Utils::addStrings($e, Common::NS, 'mdui:DomainHint', false, $this->getDomainHint());
-            Utils::addStrings($e, Common::NS, 'mdui:GeolocationHint', false, $this->getGeolocationHint());
+            Utils::addStrings($e, Common::NS, 'mdui:IPHint', false, $this->IPHint);
+            Utils::addStrings($e, Common::NS, 'mdui:DomainHint', false, $this->DomainHint);
+            Utils::addStrings($e, Common::NS, 'mdui:GeolocationHint', false, $this->GeolocationHint);
 
             return $e;
         }

--- a/src/SAML2/XML/mdui/DiscoHints.php
+++ b/src/SAML2/XML/mdui/DiscoHints.php
@@ -61,6 +61,7 @@ class DiscoHints
         $this->DomainHint = Utils::extractStrings($xml, Common::NS, 'DomainHint');
         $this->GeolocationHint = Utils::extractStrings($xml, Common::NS, 'GeolocationHint');
 
+        /** @var \DOMElement $node */
         foreach (Utils::xpQuery($xml, "./*[namespace-uri()!='".Common::NS."']") as $node) {
             $this->children[] = new Chunk($node);
         }

--- a/src/SAML2/XML/mdui/Keywords.php
+++ b/src/SAML2/XML/mdui/Keywords.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SAML2\XML\mdui;
 
+use Webmozart\Assert\Assert;
+
 /**
  * Class for handling the Keywords metadata extensions for login and discovery user interface
  *
@@ -19,14 +21,14 @@ class Keywords
      *
      * @var string[]
      */
-    public $Keywords = [];
+    private $Keywords = [];
 
     /**
      * The language of this item.
      *
      * @var string
      */
-    public $lang;
+    private $lang = '';
 
 
     /**
@@ -48,17 +50,18 @@ class Keywords
             throw new \Exception('Missing value for Keywords.');
         }
         foreach (explode(' ', $xml->textContent) as $keyword) {
-            $this->addKeyword(str_replace('+', ' ', $keyword));
+            $this->Keywords[] = str_replace('+', ' ', $keyword);
         }
-        $this->setLanguage($xml->getAttribute('xml:lang'));
+        $this->lang = $xml->getAttribute('xml:lang');
     }
 
 
     /**
      * Collect the value of the lang-property
+     *
      * @return string
      */
-    public function getLanguage()
+    public function getLanguage() : string
     {
         return $this->lang;
     }
@@ -66,6 +69,7 @@ class Keywords
 
     /**
      * Set the value of the lang-property
+     *
      * @param string $lang
      * @return void
      */
@@ -77,6 +81,7 @@ class Keywords
 
     /**
      * Collect the value of the Keywords-property
+     *
      * @return string[]
      */
     public function getKeywords() : array
@@ -87,6 +92,7 @@ class Keywords
 
     /**
      * Set the value of the Keywords-property
+     *
      * @param string[] $keywords
      * @return void
      */
@@ -98,6 +104,7 @@ class Keywords
 
     /**
      * Add the value to the Keywords-property
+     *
      * @param string $keyword
      * @return void
      */
@@ -116,12 +123,14 @@ class Keywords
      */
     public function toXML(\DOMElement $parent) : \DOMElement
     {
+        Assert::notEmpty($this->lang, "Cannot convert Keywords to XML without a language set.");
+
         $doc = $parent->ownerDocument;
 
         $e = $doc->createElementNS(Common::NS, 'mdui:Keywords');
-        $e->setAttribute('xml:lang', $this->getLanguage());
+        $e->setAttribute('xml:lang', $this->lang);
         $value = '';
-        foreach ($this->getKeywords() as $keyword) {
+        foreach ($this->Keywords as $keyword) {
             if (strpos($keyword, "+") !== false) {
                 throw new \Exception('Keywords may not contain a "+" character.');
             }

--- a/src/SAML2/XML/mdui/Logo.php
+++ b/src/SAML2/XML/mdui/Logo.php
@@ -38,7 +38,7 @@ class Logo
      *
      * @var string|null
      */
-    public $lang = null;
+    private $lang = null;
 
 
     /**
@@ -73,6 +73,7 @@ class Logo
 
     /**
      * Collect the value of the url-property
+     *
      * @return string
      */
     public function getUrl() : string
@@ -83,7 +84,9 @@ class Logo
 
     /**
      * Set the value of the url-property
+     *
      * @param string $url
+     * @return void
      */
     public function setUrl(string $url)
     {
@@ -96,6 +99,7 @@ class Logo
 
     /**
      * Collect the value of the lang-property
+     *
      * @return string|null
      */
     public function getLanguage()
@@ -106,6 +110,7 @@ class Logo
 
     /**
      * Set the value of the lang-property
+     *
      * @param string $lang
      * @return void
      */
@@ -117,6 +122,7 @@ class Logo
 
     /**
      * Collect the value of the height-property
+     *
      * @return int
      */
     public function getHeight() : int
@@ -127,6 +133,7 @@ class Logo
 
     /**
      * Set the value of the height-property
+     *
      * @param int $height
      * @return void
      */
@@ -138,6 +145,7 @@ class Logo
 
     /**
      * Collect the value of the width-property
+     *
      * @return int
      */
     public function getWidth() : int
@@ -148,6 +156,7 @@ class Logo
 
     /**
      * Set the value of the width-property
+     *
      * @param int $width
      * @return void
      */
@@ -168,11 +177,11 @@ class Logo
         $doc = $parent->ownerDocument;
 
         $e = $doc->createElementNS(Common::NS, 'mdui:Logo');
-        $e->appendChild($doc->createTextNode($this->getUrl()));
-        $e->setAttribute('width', strval($this->getWidth()));
-        $e->setAttribute('height', strval($this->getHeight()));
-        if ($this->getLanguage() !== null) {
-            $e->setAttribute('xml:lang', $this->getLanguage());
+        $e->appendChild($doc->createTextNode($this->url));
+        $e->setAttribute('width', strval($this->width));
+        $e->setAttribute('height', strval($this->height));
+        if ($this->lang !== null) {
+            $e->setAttribute('xml:lang', $this->lang);
         }
         $parent->appendChild($e);
 

--- a/src/SAML2/XML/mdui/UIInfo.php
+++ b/src/SAML2/XML/mdui/UIInfo.php
@@ -78,23 +78,23 @@ class UIInfo
             return;
         }
 
-        $this->setDisplayName(Utils::extractLocalizedStrings($xml, Common::NS, 'DisplayName'));
-        $this->setDescription(Utils::extractLocalizedStrings($xml, Common::NS, 'Description'));
-        $this->setInformationURL(Utils::extractLocalizedStrings($xml, Common::NS, 'InformationURL'));
-        $this->setPrivacyStatementURL(Utils::extractLocalizedStrings($xml, Common::NS, 'PrivacyStatementURL'));
+        $this->DisplayName = Utils::extractLocalizedStrings($xml, Common::NS, 'DisplayName');
+        $this->Description = Utils::extractLocalizedStrings($xml, Common::NS, 'Description');
+        $this->InformationURL = Utils::extractLocalizedStrings($xml, Common::NS, 'InformationURL');
+        $this->PrivacyStatementURL = Utils::extractLocalizedStrings($xml, Common::NS, 'PrivacyStatementURL');
 
         foreach (Utils::xpQuery($xml, './*') as $node) {
             if ($node->namespaceURI === Common::NS) {
                 switch ($node->localName) {
                     case 'Keywords':
-                        $this->addKeyword(new Keywords($node));
+                        $this->Keywords[] = new Keywords($node);
                         break;
                     case 'Logo':
-                        $this->addLogo(new Logo($node));
+                        $this->Logo[] = new Logo($node);
                         break;
                 }
             } else {
-                $this->addChildren(new Chunk($node));
+                $this->children[] = new Chunk($node);
             }
         }
     }
@@ -102,6 +102,7 @@ class UIInfo
 
     /**
      * Collect the value of the Keywords-property
+     *
      * @return \SAML2\XML\mdui\Keywords[]
      */
     public function getKeywords() : array
@@ -112,6 +113,7 @@ class UIInfo
 
     /**
      * Set the value of the Keywords-property
+     *
      * @param \SAML2\XML\mdui\Keywords[] $keywords
      * @return void
      */
@@ -123,6 +125,7 @@ class UIInfo
 
     /**
      * Add the value to the Keywords-property
+     *
      * @param \SAML2\XML\mdui\Keywords $keyword
      * @return void
      */
@@ -134,6 +137,7 @@ class UIInfo
 
     /**
      * Collect the value of the DisplayName-property
+     *
      * @return string[]
      */
     public function getDisplayName() : array
@@ -144,6 +148,7 @@ class UIInfo
 
     /**
      * Set the value of the DisplayName-property
+     *
      * @param array $displayName
      * @return void
      */
@@ -155,6 +160,7 @@ class UIInfo
 
     /**
      * Collect the value of the Description-property
+     *
      * @return string[]
      */
     public function getDescription() : array
@@ -165,6 +171,7 @@ class UIInfo
 
     /**
      * Set the value of the Description-property
+     *
      * @param array $description
      * @return void
      */
@@ -186,6 +193,7 @@ class UIInfo
 
     /**
      * Set the value of the InformationURL-property
+     *
      * @param array $informationURL
      * @return void
      */
@@ -197,6 +205,7 @@ class UIInfo
 
     /**
      * Collect the value of the PrivacyStatementURL-property
+     *
      * @return string[]
      */
     public function getPrivacyStatementURL() : array
@@ -207,6 +216,7 @@ class UIInfo
 
     /**
      * Set the value of the PrivacyStatementURL-property
+     *
      * @param array $privacyStatementURL
      * @return void
      */
@@ -218,6 +228,7 @@ class UIInfo
 
     /**
      * Collect the value of the Logo-property
+     *
      * @return \SAML2\XML\mdui\Logo[]
      */
     public function getLogo() : array
@@ -228,7 +239,8 @@ class UIInfo
 
     /**
      * Set the value of the Logo-property
-     * @param \SAML2\XML\mdui\Logo $logo
+     *
+     * @param \SAML2\XML\mdui\Logo[] $logo
      * @return void
      */
     public function setLogo(array $logo)
@@ -239,6 +251,7 @@ class UIInfo
 
     /**
      * Add the value to the Logo-property
+     *
      * @param \SAML2\XML\mdui\Logo $logo
      * @return void
      */
@@ -250,6 +263,7 @@ class UIInfo
 
     /**
      * Collect the value of the children-property
+     *
      * @return \SAML2\XML\Chunk[]
      */
     public function getChildren() : array
@@ -260,6 +274,7 @@ class UIInfo
 
     /**
      * Set the value of the childen-property
+     *
      * @param array $children
      * @return void
      */
@@ -271,6 +286,7 @@ class UIInfo
 
     /**
      * Add the value to the children-property
+     *
      * @param \SAML2\XML\Chunk $child
      * @return void
      */
@@ -295,7 +311,8 @@ class UIInfo
          || !empty($this->PrivacyStatementURL)
          || !empty($this->Keywords)
          || !empty($this->Logo)
-         || !empty($this->children)) {
+         || !empty($this->children)
+        ) {
             $doc = $parent->ownerDocument;
 
             $e = $doc->createElementNS(Common::NS, 'mdui:UIInfo');
@@ -306,22 +323,16 @@ class UIInfo
             Utils::addStrings($e, Common::NS, 'mdui:InformationURL', true, $this->InformationURL);
             Utils::addStrings($e, Common::NS, 'mdui:PrivacyStatementURL', true, $this->PrivacyStatementURL);
 
-            if ($this->Keywords !== null) {
-                foreach ($this->Keywords as $child) {
-                    $child->toXML($e);
-                }
+            foreach ($this->Keywords as $child) {
+                $child->toXML($e);
             }
 
-            if ($this->Logo !== null) {
-                foreach ($this->Logo as $child) {
-                    $child->toXML($e);
-                }
+            foreach ($this->Logo as $child) {
+                $child->toXML($e);
             }
 
-            if ($this->children !== null) {
-                foreach ($this->children as $child) {
-                    $child->toXML($e);
-                }
+            foreach ($this->children as $child) {
+                $child->toXML($e);
             }
         }
 

--- a/src/SAML2/XML/mdui/UIInfo.php
+++ b/src/SAML2/XML/mdui/UIInfo.php
@@ -83,6 +83,7 @@ class UIInfo
         $this->InformationURL = Utils::extractLocalizedStrings($xml, Common::NS, 'InformationURL');
         $this->PrivacyStatementURL = Utils::extractLocalizedStrings($xml, Common::NS, 'PrivacyStatementURL');
 
+        /** @var \DOMElement $node */
         foreach (Utils::xpQuery($xml, './*') as $node) {
             if ($node->namespaceURI === Common::NS) {
                 switch ($node->localName) {

--- a/src/SAML2/XML/saml/Attribute.php
+++ b/src/SAML2/XML/saml/Attribute.php
@@ -17,16 +17,16 @@ class Attribute
     /**
      * The Name of this attribute.
      *
-     * @var string
+     * @var string|null
      */
-    public $Name;
+    private $Name = null;
 
     /**
      * The NameFormat of this attribute.
      *
      * @var string|null
      */
-    public $NameFormat = null;
+    private $NameFormat = null;
 
     /**
      * The FriendlyName of this attribute.
@@ -78,7 +78,8 @@ class Attribute
 
     /**
      * Collect the value of the Name-property
-     * @return string
+     *
+     * @return string|null
      */
     public function getName() : string
     {
@@ -88,6 +89,7 @@ class Attribute
 
     /**
      * Set the value of the Name-property
+     *
      * @param string $name
      * @return void
      */
@@ -99,6 +101,7 @@ class Attribute
 
     /**
      * Collect the value of the NameFormat-property
+     *
      * @return string|null
      */
     public function getNameFormat()
@@ -109,6 +112,7 @@ class Attribute
 
     /**
      * Set the value of the NameFormat-property
+     *
      * @param string|null $nameFormat
      * @return void
      */
@@ -120,6 +124,7 @@ class Attribute
 
     /**
      * Collect the value of the FriendlyName-property
+     *
      * @return string|null
      */
     public function getFriendlyName()
@@ -130,6 +135,7 @@ class Attribute
 
     /**
      * Set the value of the FriendlyName-property
+     *
      * @param string|null $friendlyName
      * @return void
      */
@@ -141,6 +147,7 @@ class Attribute
 
     /**
      * Collect the value of the AttributeValue-property
+     *
      * @return \SAML2\XML\saml\AttributeValue[]
      */
     public function getAttributeValue() : array
@@ -151,6 +158,7 @@ class Attribute
 
     /**
      * Set the value of the AttributeValue-property
+     *
      * @param array $attributeValue
      * @return void
      */
@@ -162,6 +170,7 @@ class Attribute
 
     /**
      * Add the value to the AttributeValue-property
+     *
      * @param \SAML2\XML\saml\AttributeValue $attributeValue
      * @return void
      */
@@ -175,9 +184,9 @@ class Attribute
      * Internal implementation of toXML.
      * This function allows RequestedAttribute to specify the element name and namespace.
      *
-     * @param \DOMElement $parent    The element we should append this Attribute to.
-     * @param string     $namespace The namespace the element should be created in.
-     * @param string     $name      The name of the element.
+     * @param \DOMElement $parent The element we should append this Attribute to.
+     * @param string $namespace The namespace the element should be created in.
+     * @param string $name The name of the element.
      * @return \DOMElement
      */
     protected function toXMLInternal(\DOMElement $parent, string $namespace, string $name) : \DOMElement
@@ -185,17 +194,20 @@ class Attribute
         $e = $parent->ownerDocument->createElementNS($namespace, $name);
         $parent->appendChild($e);
 
-        $e->setAttribute('Name', $this->getName());
+        if ($this->Name === null) {
+            throw new \Exception('Cannot convert Attribute to XML with no Name set.');
+        }
+        $e->setAttribute('Name', $this->Name);
 
-        if ($this->getNameFormat() !== null) {
+        if ($this->NameFormat !== null) {
             $e->setAttribute('NameFormat', $this->NameFormat);
         }
 
         if ($this->FriendlyName !== null) {
-            $e->setAttribute('FriendlyName', $this->getFriendlyName());
+            $e->setAttribute('FriendlyName', $this->FriendlyName);
         }
 
-        foreach ($this->getAttributeValue() as $av) {
+        foreach ($this->AttributeValue as $av) {
             $av->toXML($e);
         }
 

--- a/src/SAML2/XML/saml/Attribute.php
+++ b/src/SAML2/XML/saml/Attribute.php
@@ -194,7 +194,7 @@ class Attribute
         $e = $parent->ownerDocument->createElementNS($namespace, $name);
         $parent->appendChild($e);
 
-        if ($this->Name === null) {
+        if (empty($this->Name)) {
             throw new \Exception('Cannot convert Attribute to XML with no Name set.');
         }
         $e->setAttribute('Name', $this->Name);

--- a/src/SAML2/XML/saml/Attribute.php
+++ b/src/SAML2/XML/saml/Attribute.php
@@ -81,7 +81,7 @@ class Attribute
      *
      * @return string|null
      */
-    public function getName() : string
+    public function getName()
     {
         return $this->Name;
     }

--- a/src/SAML2/XML/saml/AttributeValue.php
+++ b/src/SAML2/XML/saml/AttributeValue.php
@@ -39,29 +39,30 @@ class AttributeValue implements \Serializable
 
         if (is_string($value)) {
             $doc = DOMDocumentFactory::create();
-            $this->setElement($doc->createElementNS(Constants::NS_SAML, 'saml:AttributeValue'));
-            $this->getElement()->setAttributeNS(Constants::NS_XSI, 'xsi:type', 'xs:string');
-            $this->getElement()->appendChild($doc->createTextNode($value));
+            $this->element = $doc->createElementNS(Constants::NS_SAML, 'saml:AttributeValue');
+            $this->element->setAttributeNS(Constants::NS_XSI, 'xsi:type', 'xs:string');
+            $this->element->appendChild($doc->createTextNode($value));
 
             /* Make sure that the xs-namespace is available in the AttributeValue (for xs:string). */
-            $this->getElement()->setAttributeNS(Constants::NS_XS, 'xs:tmp', 'tmp');
-            $this->getElement()->removeAttributeNS(Constants::NS_XS, 'tmp');
+            $this->element->setAttributeNS(Constants::NS_XS, 'xs:tmp', 'tmp');
+            $this->element->removeAttributeNS(Constants::NS_XS, 'tmp');
             return;
         }
 
         if ($value->namespaceURI === Constants::NS_SAML && $value->localName === 'AttributeValue') {
-            $this->setElement(Utils::copyElement($value));
+            $this->element = Utils::copyElement($value);
             return;
         }
 
         $doc = DOMDocumentFactory::create();
-        $this->setElement($doc->createElementNS(Constants::NS_SAML, 'saml:AttributeValue'));
+        $this->element = $doc->createElementNS(Constants::NS_SAML, 'saml:AttributeValue');
         Utils::copyElement($value, $this->element);
     }
 
 
     /**
      * Collect the value of the element-property
+     *
      * @return \DOMElement
      */
     public function getElement() : \DOMElement
@@ -72,6 +73,7 @@ class AttributeValue implements \Serializable
 
     /**
      * Set the value of the element-property
+     *
      * @param \DOMElement $element
      * @return void
      */
@@ -92,12 +94,13 @@ class AttributeValue implements \Serializable
         Assert::same($this->getElement()->namespaceURI, Constants::NS_SAML);
         Assert::same($this->getElement()->localName, "AttributeValue");
 
-        return Utils::copyElement($this->getElement(), $parent);
+        return Utils::copyElement($this->element, $parent);
     }
 
 
     /**
      * Returns a plain text content of the attribute value.
+     *
      * @return string
      */
     public function getString() : string
@@ -115,10 +118,10 @@ class AttributeValue implements \Serializable
      */
     public function __toString() : string
     {
-        $doc = $this->getElement()->ownerDocument;
+        $doc = $this->element->ownerDocument;
 
         $ret = '';
-        foreach ($this->getElement()->childNodes as $c) {
+        foreach ($this->element->childNodes as $c) {
             $ret .= $doc->saveXML($c);
         }
 
@@ -133,7 +136,7 @@ class AttributeValue implements \Serializable
      */
     public function serialize() : string
     {
-        return serialize($this->getElement()->ownerDocument->saveXML($this->getElement()));
+        return serialize($this->element->ownerDocument->saveXML($this->element));
     }
 
 
@@ -148,6 +151,6 @@ class AttributeValue implements \Serializable
     public function unserialize($serialized)
     {
         $doc = DOMDocumentFactory::fromString(unserialize($serialized));
-        $this->setElement($doc->documentElement);
+        $this->element = $doc->documentElement;
     }
 }

--- a/src/SAML2/XML/saml/BaseIDType.php
+++ b/src/SAML2/XML/saml/BaseIDType.php
@@ -24,7 +24,7 @@ abstract class BaseIDType
      *
      * @var string|null
      */
-    public $NameQualifier = null;
+    protected $NameQualifier = null;
 
     /**
      * Further qualifies an identifier with the name of a service provider or affiliation of providers.
@@ -34,7 +34,7 @@ abstract class BaseIDType
      *
      * @var string|null
      */
-    public $SPNameQualifier = null;
+    protected $SPNameQualifier = null;
 
     /**
      * The name for this BaseID.
@@ -65,17 +65,18 @@ abstract class BaseIDType
         $this->element = $xml;
 
         if ($xml->hasAttribute('NameQualifier')) {
-            $this->setNameQualifier($xml->getAttribute('NameQualifier'));
+            $this->NameQualifier = $xml->getAttribute('NameQualifier');
         }
 
         if ($xml->hasAttribute('SPNameQualifier')) {
-            $this->setSPNameQualifier($xml->getAttribute('SPNameQualifier'));
+            $this->SPNameQualifier = $xml->getAttribute('SPNameQualifier');
         }
     }
 
 
     /**
      * Collect the value of the NameQualifier-property
+     *
      * @return string|null
      */
     public function getNameQualifier()
@@ -86,6 +87,7 @@ abstract class BaseIDType
 
     /**
      * Set the value of the NameQualifier-property
+     *
      * @param string|null $nameQualifier
      * @return void
      */
@@ -97,6 +99,7 @@ abstract class BaseIDType
 
     /**
      * Collect the value of the SPNameQualifier-property
+     *
      * @return string|null
      */
     public function getSPNameQualifier()
@@ -107,6 +110,7 @@ abstract class BaseIDType
 
     /**
      * Set the value of the SPNameQualifier-property
+     *
      * @param string|null $spNameQualifier
      * @return void
      */
@@ -133,12 +137,12 @@ abstract class BaseIDType
         $element = $doc->createElementNS(Constants::NS_SAML, $this->nodeName);
         $parent->appendChild($element);
 
-        if ($this->getNameQualifier() !== null) {
-            $element->setAttribute('NameQualifier', $this->getNameQualifier());
+        if ($this->NameQualifier !== null) {
+            $element->setAttribute('NameQualifier', $this->NameQualifier);
         }
 
-        if ($this->getSPNameQualifier() !== null) {
-            $element->setAttribute('SPNameQualifier', $this->getSPNameQualifier());
+        if ($this->SPNameQualifier !== null) {
+            $element->setAttribute('SPNameQualifier', $this->SPNameQualifier);
         }
 
         return $element;

--- a/src/SAML2/XML/saml/Issuer.php
+++ b/src/SAML2/XML/saml/Issuer.php
@@ -122,7 +122,7 @@ class Issuer extends NameIDType
         $element = $doc->createElementNS(Constants::NS_SAML, 'saml:Issuer');
         $parent->appendChild($element);
 
-        if ($this->value === null) {
+        if (empty($this->value)) {
             throw new \Exception("Cannot convert Issuer to XML with no value.");
         }
         $value = $element->ownerDocument->createTextNode($this->value);

--- a/src/SAML2/XML/saml/Issuer.php
+++ b/src/SAML2/XML/saml/Issuer.php
@@ -15,9 +15,8 @@ use SAML2\DOMDocumentFactory;
  */
 class Issuer extends NameIDType
 {
+
     /**
-     * Set the name of this XML element to "saml:Issuer"
-     *
      * @var string
      */
     protected $nodeName = 'saml:Issuer';
@@ -33,7 +32,7 @@ class Issuer extends NameIDType
      *
      * @var boolean
      */
-    public $Saml2IssuerShowAll = false; //setting true break saml-core-2.0-os 8.3.6
+    private $Saml2IssuerShowAll = false; //setting true breaks saml-core-2.0-os 8.3.6
 
 
     /**
@@ -48,15 +47,16 @@ class Issuer extends NameIDType
          *
          * Defaults to urn:oasis:names:tc:SAML:2.0:nameid-format:entity:
          *
-         * Indicates that the content of the element is the identifier of an entity that provides SAML-based services (such
-         * as a SAML authority, requester, or responder) or is a participant in SAML profiles (such as a service provider
-         * supporting the browser SSO profile). Such an identifier can be used in the <Issuer> element to identify the
-         * issuer of a SAML request, response, or assertion, or within the <NameID> element to make assertions about system
-         * entities that can issue SAML requests, responses, and assertions. It can also be used in other elements and
-         * attributes whose purpose is to identify a system entity in various protocol exchanges.
+         * Indicates that the content of the element is the identifier of an entity that provides SAML-based services
+         * (such as a SAML authority, requester, or responder) or is a participant in SAML profiles (such as a service
+         * provider supporting the browser SSO profile). Such an identifier can be used in the <Issuer> element to
+         * identify the issuer of a SAML request, response, or assertion, or within the <NameID> element to make
+         * assertions about system entities that can issue SAML requests, responses, and assertions. It can also be
+         * used in other elements and attributes whose purpose is to identify a system entity in various protocol
+         * exchanges.
          *
-         * The syntax of such an identifier is a URI of not more than 1024 characters in length. It is RECOMMENDED that a
-         * system entity use a URL containing its own domain name to identify itself.
+         * The syntax of such an identifier is a URI of not more than 1024 characters in length. It is RECOMMENDED that
+         * a system entity use a URL containing its own domain name to identify itself.
          *
          * @see saml-core-2.0-os
          *
@@ -70,6 +70,7 @@ class Issuer extends NameIDType
 
     /**
      * Collect the value of the Saml2IssuerShowAll-property
+     *
      * @return bool
      */
     public function isSaml2IssuerShowAll() : bool
@@ -80,6 +81,7 @@ class Issuer extends NameIDType
 
     /**
      * Set the value of the Saml2IssuerShowAll-property
+     *
      * @param bool $saml2IssuerShowAll
      * @return void
      */
@@ -93,23 +95,22 @@ class Issuer extends NameIDType
      * Convert this Issuer to XML.
      *
      * @param \DOMElement|null $parent The element we should append to.
-     *
      * @return \DOMElement The current Issuer object converted into a \DOMElement.
      */
     public function toXML(\DOMElement $parent = null) : \DOMElement
     {
-        if (($this->isSaml2IssuerShowAll() && ($this->getFormat() === Constants::NAMEID_ENTITY))
-            || ($this->getFormat() !== Constants::NAMEID_ENTITY)
+        if (($this->Saml2IssuerShowAll && ($this->Format === Constants::NAMEID_ENTITY))
+            || ($this->Format !== Constants::NAMEID_ENTITY)
         ) {
             return parent::toXML($parent);
         }
 
         /*
-         * if $this->isSaml2IssuerShowAll() is set false
+         * if $this->Saml2IssuerShowAll is set false
          * From saml-core-2.0-os 8.3.6, when the entity Format is used: "The NameQualifier, SPNameQualifier, and
          * SPProvidedID attributes MUST be omitted."
-         * if $this->isSaml2IssuerShowAll() is set true when the entity Format is used: "The NameQualifier, SPNameQualifier, and
-         * SPProvidedID attributes are not omitted."
+         * if $this->isSaml2IssuerShowAll() is set true when the entity Format is used: "The NameQualifier,
+         * SPNameQualifier, and SPProvidedID attributes are not omitted."
          */
 
         if ($parent === null) {
@@ -121,7 +122,10 @@ class Issuer extends NameIDType
         $element = $doc->createElementNS(Constants::NS_SAML, 'saml:Issuer');
         $parent->appendChild($element);
 
-        $value = $element->ownerDocument->createTextNode($this->getValue());
+        if ($this->value === null) {
+            throw new \Exception("Cannot convert Issuer to XML with no value.");
+        }
+        $value = $element->ownerDocument->createTextNode($this->value);
         $element->appendChild($value);
 
         return $element;

--- a/src/SAML2/XML/saml/NameIDType.php
+++ b/src/SAML2/XML/saml/NameIDType.php
@@ -28,7 +28,7 @@ abstract class NameIDType extends BaseIDType
      *
      * @see saml-core-2.0-os
      */
-    public $Format = null;
+    protected $Format = null;
 
     /**
      * A name identifier established by a service provider or affiliation of providers for the entity, if different from
@@ -40,14 +40,14 @@ abstract class NameIDType extends BaseIDType
      *
      * @see saml-core-2.0-os
      */
-    public $SPProvidedID = null;
+    protected $SPProvidedID = null;
 
     /**
      * The NameIDType complex type is used when an element serves to represent an entity by a string-valued name.
      *
      * @var string
      */
-    public $value = '';
+    protected $value = '';
 
 
     /**
@@ -64,19 +64,20 @@ abstract class NameIDType extends BaseIDType
         }
 
         if ($xml->hasAttribute('Format')) {
-            $this->setFormat($xml->getAttribute('Format'));
+            $this->Format = $xml->getAttribute('Format');
         }
 
         if ($xml->hasAttribute('SPProvidedID')) {
-            $this->setSPProvidedID($xml->getAttribute('SPProvidedID'));
+            $this->SPProvidedID = $xml->getAttribute('SPProvidedID');
         }
 
-        $this->setValue(trim($xml->textContent));
+        $this->value = trim($xml->textContent);
     }
 
 
     /**
      * Collect the value of the Format-property
+     *
      * @return string|null
      */
     public function getFormat()
@@ -87,6 +88,7 @@ abstract class NameIDType extends BaseIDType
 
     /**
      * Set the value of the Format-property
+     *
      * @param string|null $format
      * @return void
      */
@@ -98,6 +100,7 @@ abstract class NameIDType extends BaseIDType
 
     /**
      * Collect the value of the value-property
+     *
      * @return string
      */
     public function getValue()
@@ -109,6 +112,7 @@ abstract class NameIDType extends BaseIDType
     /**
      * Set the value of the value-property
      * @param string $value
+     *
      * @return void
      */
     public function setValue(string $value)
@@ -119,6 +123,7 @@ abstract class NameIDType extends BaseIDType
 
     /**
      * Collect the value of the SPProvidedID-property
+     *
      * @return string|null
      */
     public function getSPProvidedID()
@@ -129,6 +134,7 @@ abstract class NameIDType extends BaseIDType
 
     /**
      * Set the value of the SPProvidedID-property
+     *
      * @param string|null $spProvidedID
      * @return void
      */
@@ -148,15 +154,18 @@ abstract class NameIDType extends BaseIDType
     {
         $element = parent::toXML($parent);
 
-        if ($this->getFormat() !== null) {
-            $element->setAttribute('Format', $this->getFormat());
+        if ($this->Format !== null) {
+            $element->setAttribute('Format', $this->Format);
         }
 
-        if ($this->getSPProvidedID() !== null) {
-            $element->setAttribute('SPProvidedID', $this->getSPProvidedID());
+        if ($this->SPProvidedID !== null) {
+            $element->setAttribute('SPProvidedID', $this->SPProvidedID);
         }
 
-        $value = $element->ownerDocument->createTextNode($this->getValue());
+        if ($this->value === null) {
+            throw new \Exception("Cannot convert NameIDType to XML with no value.");
+        }
+        $value = $element->ownerDocument->createTextNode($this->value);
         $element->appendChild($value);
 
         return $element;

--- a/src/SAML2/XML/saml/NameIDType.php
+++ b/src/SAML2/XML/saml/NameIDType.php
@@ -162,9 +162,6 @@ abstract class NameIDType extends BaseIDType
             $element->setAttribute('SPProvidedID', $this->SPProvidedID);
         }
 
-        if ($this->value === null) {
-            throw new \Exception("Cannot convert NameIDType to XML with no value.");
-        }
         $value = $element->ownerDocument->createTextNode($this->value);
         $element->appendChild($value);
 

--- a/src/SAML2/XML/saml/SubjectConfirmation.php
+++ b/src/SAML2/XML/saml/SubjectConfirmation.php
@@ -78,7 +78,7 @@ class SubjectConfirmation
      *
      * @return string|null
      */
-    public function getMethod() : string
+    public function getMethod()
     {
         return $this->Method;
     }
@@ -155,6 +155,7 @@ class SubjectConfirmation
         $e = $parent->ownerDocument->createElementNS(Constants::NS_SAML, 'saml:SubjectConfirmation');
         $parent->appendChild($e);
 
+        /** @psalm-suppress PossiblyNullArgument */
         $e->setAttribute('Method', $this->Method);
 
         if ($this->NameID !== null) {

--- a/src/SAML2/XML/saml/SubjectConfirmation.php
+++ b/src/SAML2/XML/saml/SubjectConfirmation.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SAML2\XML\saml;
 
+use Webmozart\Assert\Assert;
+
 use SAML2\Constants;
 use SAML2\Utils;
 
@@ -17,23 +19,23 @@ class SubjectConfirmation
     /**
      * The method we can use to verify this Subject.
      *
-     * @var string
+     * @var string|null
      */
-    public $Method;
+    private $Method = null;
 
     /**
      * The NameID of the entity that can use this element to verify the Subject.
      *
      * @var \SAML2\XML\saml\NameID|null
      */
-    public $NameID = null;
+    private $NameID = null;
 
     /**
      * SubjectConfirmationData element with extra data for verification of the Subject.
      *
      * @var \SAML2\XML\saml\SubjectConfirmationData|null
      */
-    public $SubjectConfirmationData = null;
+    private $SubjectConfirmationData;
 
 
     /**
@@ -51,27 +53,28 @@ class SubjectConfirmation
         if (!$xml->hasAttribute('Method')) {
             throw new \Exception('SubjectConfirmation element without Method attribute.');
         }
-        $this->setMethod($xml->getAttribute('Method'));
+        $this->Method = $xml->getAttribute('Method');
 
         $nid = Utils::xpQuery($xml, './saml_assertion:NameID');
         if (count($nid) > 1) {
             throw new \Exception('More than one NameID in a SubjectConfirmation element.');
         } elseif (!empty($nid)) {
-            $this->setNameID(new NameID($nid[0]));
+            $this->NameID = new NameID($nid[0]);
         }
 
         $scd = Utils::xpQuery($xml, './saml_assertion:SubjectConfirmationData');
         if (count($scd) > 1) {
             throw new \Exception('More than one SubjectConfirmationData child in a SubjectConfirmation element.');
         } elseif (!empty($scd)) {
-            $this->setSubjectConfirmationData(new SubjectConfirmationData($scd[0]));
+            $this->SubjectConfirmationData = new SubjectConfirmationData($scd[0]);
         }
     }
 
 
     /**
      * Collect the value of the Method-property
-     * @return string
+     *
+     * @return string|null
      */
     public function getMethod() : string
     {
@@ -81,6 +84,7 @@ class SubjectConfirmation
 
     /**
      * Set the value of the Method-property
+     *
      * @param string $method
      * @return void
      */
@@ -92,6 +96,7 @@ class SubjectConfirmation
 
     /**
      * Collect the value of the NameID-property
+     *
      * @return \SAML2\XML\saml\NameID|null
      */
     public function getNameID()
@@ -102,7 +107,8 @@ class SubjectConfirmation
 
     /**
      * Set the value of the NameID-property
-     * @param \SAML2\XML\saml\NameID|null $nameId
+     *
+     * @param \SAML2\XML\saml\NameID $nameId
      * @return void
      */
     public function setNameID(NameID $nameId = null)
@@ -113,6 +119,7 @@ class SubjectConfirmation
 
     /**
      * Collect the value of the SubjectConfirmationData-property
+     *
      * @return \SAML2\XML\saml\SubjectConfirmationData|null
      */
     public function getSubjectConfirmationData()
@@ -123,6 +130,7 @@ class SubjectConfirmation
 
     /**
      * Set the value of the SubjectConfirmationData-property
+     *
      * @param \SAML2\XML\saml\SubjectConfirmationData|null $subjectConfirmationData
      * @return void
      */
@@ -140,16 +148,18 @@ class SubjectConfirmation
      */
     public function toXML(\DOMElement $parent) : \DOMElement
     {
+        Assert::notNull($this->Method, "Cannot convert SubjectConfirmation to XML without a Method set.");
+
         $e = $parent->ownerDocument->createElementNS(Constants::NS_SAML, 'saml:SubjectConfirmation');
         $parent->appendChild($e);
 
-        $e->setAttribute('Method', $this->getMethod());
+        $e->setAttribute('Method', $this->Method);
 
-        if ($this->getNameID() !== null) {
-            $this->getNameID()->toXML($e);
+        if ($this->NameID !== null) {
+            $this->NameID->toXML($e);
         }
-        if ($this->getSubjectConfirmationData() !== null) {
-            $this->getSubjectConfirmationData()->toXML($e);
+        if ($this->SubjectConfirmationData !== null) {
+            $this->SubjectConfirmationData->toXML($e);
         }
 
         return $e;

--- a/src/SAML2/XML/saml/SubjectConfirmation.php
+++ b/src/SAML2/XML/saml/SubjectConfirmation.php
@@ -55,6 +55,7 @@ class SubjectConfirmation
         }
         $this->Method = $xml->getAttribute('Method');
 
+        /** @var \DOMElement[] $nid */
         $nid = Utils::xpQuery($xml, './saml_assertion:NameID');
         if (count($nid) > 1) {
             throw new \Exception('More than one NameID in a SubjectConfirmation element.');
@@ -62,6 +63,7 @@ class SubjectConfirmation
             $this->NameID = new NameID($nid[0]);
         }
 
+        /** @var \DOMElement[] $scd */
         $scd = Utils::xpQuery($xml, './saml_assertion:SubjectConfirmationData');
         if (count($scd) > 1) {
             throw new \Exception('More than one SubjectConfirmationData child in a SubjectConfirmation element.');

--- a/src/SAML2/XML/saml/SubjectConfirmationData.php
+++ b/src/SAML2/XML/saml/SubjectConfirmationData.php
@@ -67,6 +67,7 @@ class SubjectConfirmationData
 
     /**
      * Collect the value of the NotBefore-property
+     *
      * @return int|null
      */
     public function getNotBefore()
@@ -77,6 +78,7 @@ class SubjectConfirmationData
 
     /**
      * Set the value of the NotBefore-property
+     *
      * @param int|null $notBefore
      * @return void
      */
@@ -88,6 +90,7 @@ class SubjectConfirmationData
 
     /**
      * Collect the value of the NotOnOrAfter-property
+     *
      * @return int|null
      */
     public function getNotOnOrAfter()
@@ -98,6 +101,7 @@ class SubjectConfirmationData
 
     /**
      * Set the value of the NotOnOrAfter-property
+     *
      * @param int|null $notOnOrAfter
      * @return void
      */
@@ -109,6 +113,7 @@ class SubjectConfirmationData
 
     /**
      * Collect the value of the Recipient-property
+     *
      * @return string|null
      */
     public function getRecipient()
@@ -119,6 +124,7 @@ class SubjectConfirmationData
 
     /**
      * Set the value of the Recipient-property
+     *
      * @param string|null $recipient
      * @return void
      */
@@ -130,6 +136,7 @@ class SubjectConfirmationData
 
     /**
      * Collect the value of the InResponseTo-property
+     *
      * @return string|null
      */
     public function getInResponseTo()
@@ -140,6 +147,7 @@ class SubjectConfirmationData
 
     /**
      * Set the value of the InResponseTo-property
+     *
      * @param string|null $inResponseTo
      * @return void
      */
@@ -151,6 +159,7 @@ class SubjectConfirmationData
 
     /**
      * Collect the value of the Address-property
+     *
      * @return string|null
      */
     public function getAddress()
@@ -161,6 +170,7 @@ class SubjectConfirmationData
 
     /**
      * Set the value of the Address-property
+     *
      * @param string|null $address
      * @return void
      */
@@ -175,6 +185,7 @@ class SubjectConfirmationData
 
     /**
      * Collect the value of the info-property
+     *
      * @return (\SAML2\XML\ds\KeyInfo|\SAML2\XML\Chunk)[]
      */
     public function getInfo() : array
@@ -185,6 +196,7 @@ class SubjectConfirmationData
 
     /**
      * Set the value of the info-property
+     *
      * @param (\SAML2\XML\ds\KeyInfo|\SAML2\XML\Chunk)[] $info
      * @return void
      */
@@ -196,6 +208,7 @@ class SubjectConfirmationData
 
     /**
      * Add the value to the info-property
+     *
      * @param \SAML2\XML\Chunk|\SAML2\XML\ds\KeyInfo $info
      * @return void
      */
@@ -232,7 +245,7 @@ class SubjectConfirmationData
         if ($xml->hasAttribute('Address')) {
             $this->setAddress($xml->getAttribute('Address'));
         }
-        for ($n = $xml->firstChild; $n !== null; $n = $n->nextSibling) {
+        for ($n = $xml->firstChild; $n instanceof \DOMNode; $n = $n->nextSibling) {
             if (!($n instanceof \DOMElement)) {
                 continue;
             }
@@ -263,20 +276,20 @@ class SubjectConfirmationData
         $e = $parent->ownerDocument->createElementNS(Constants::NS_SAML, 'saml:SubjectConfirmationData');
         $parent->appendChild($e);
 
-        if ($this->getNotBefore() !== null) {
-            $e->setAttribute('NotBefore', gmdate('Y-m-d\TH:i:s\Z', $this->getNotBefore()));
+        if ($this->NotBefore !== null) {
+            $e->setAttribute('NotBefore', gmdate('Y-m-d\TH:i:s\Z', $this->NotBefore));
         }
-        if ($this->getNotOnOrAfter() !== null) {
-            $e->setAttribute('NotOnOrAfter', gmdate('Y-m-d\TH:i:s\Z', $this->getNotOnOrAfter()));
+        if ($this->NotOnOrAfter !== null) {
+            $e->setAttribute('NotOnOrAfter', gmdate('Y-m-d\TH:i:s\Z', $this->NotOnOrAfter));
         }
-        if ($this->getRecipient() !== null) {
-            $e->setAttribute('Recipient', $this->getRecipient());
+        if ($this->Recipient !== null) {
+            $e->setAttribute('Recipient', $this->Recipient);
         }
-        if ($this->getInResponseTo() !== null) {
-            $e->setAttribute('InResponseTo', $this->getInResponseTo());
+        if ($this->InResponseTo !== null) {
+            $e->setAttribute('InResponseTo', $this->InResponseTo);
         }
-        if ($this->getAddress() !== null) {
-            $e->setAttribute('Address', $this->getAddress());
+        if ($this->Address !== null) {
+            $e->setAttribute('Address', $this->Address);
         }
         /** @var \SAML2\XML\ds\KeyInfo|\SAML2\XML\Chunk $n */
         foreach ($this->getInfo() as $n) {

--- a/src/SAML2/XML/saml/SubjectConfirmationData.php
+++ b/src/SAML2/XML/saml/SubjectConfirmationData.php
@@ -245,7 +245,7 @@ class SubjectConfirmationData
         if ($xml->hasAttribute('Address')) {
             $this->setAddress($xml->getAttribute('Address'));
         }
-        for ($n = $xml->firstChild; $n instanceof \DOMNode; $n = $n->nextSibling) {
+        foreach ($xml->childNodes as $n) {
             if (!($n instanceof \DOMElement)) {
                 continue;
             }

--- a/src/SAML2/XML/samlp/Extensions.php
+++ b/src/SAML2/XML/samlp/Extensions.php
@@ -24,6 +24,7 @@ class Extensions
     public static function getList(\DOMElement $parent) : array
     {
         $ret = [];
+        /** @var \DOMElement $node */
         foreach (Utils::xpQuery($parent, './saml_protocol:Extensions/*') as $node) {
             $ret[] = new Chunk($node);
         }

--- a/src/SAML2/XML/shibmd/Scope.php
+++ b/src/SAML2/XML/shibmd/Scope.php
@@ -47,13 +47,14 @@ class Scope
             return;
         }
 
-        $this->setScope($xml->textContent);
-        $this->setIsRegexpScope(Utils::parseBoolean($xml, 'regexp', false));
+        $this->scope = $xml->textContent;
+        $this->regexp = Utils::parseBoolean($xml, 'regexp', false);
     }
 
 
     /**
      * Collect the value of the scope-property
+     *
      * @return string
      */
     public function getScope() : string
@@ -64,6 +65,7 @@ class Scope
 
     /**
      * Set the value of the scope-property
+     *
      * @param string $scope
      * @return void
      */
@@ -75,6 +77,7 @@ class Scope
 
     /**
      * Collect the value of the regexp-property
+     *
      * @return bool
      */
     public function isRegexpScope() : bool
@@ -85,6 +88,7 @@ class Scope
 
     /**
      * Set the value of the regexp-property
+     *
      * @param bool $regexp
      * @return void
      */
@@ -103,6 +107,7 @@ class Scope
     public function toXML(\DOMElement $parent) : \DOMElement
     {
         Assert::notEmpty($this->scope);
+
         $doc = $parent->ownerDocument;
 
         $e = $doc->createElementNS(Scope::NS, 'shibmd:Scope');

--- a/tests/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationResponseToMatchesTest.php
+++ b/tests/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationResponseToMatchesTest.php
@@ -30,7 +30,7 @@ class SubjectConfirmationResponseToMatchesTest extends \Mockery\Adapter\Phpunit\
         parent::setUp();
         $this->subjectConfirmation = new \SAML2\XML\saml\SubjectConfirmation();
         $this->subjectConfirmationData = new \SAML2\XML\saml\SubjectConfirmationData();
-        $this->subjectConfirmation->SubjectConfirmationData = $this->getSubjectConfirmationData();
+        $this->subjectConfirmation->SubjectConfirmationData = $this->SubjectConfirmationData;
         $this->response = \Mockery::mock(\SAML2\Response::class);
     }
 

--- a/tests/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationResponseToMatchesTest.php
+++ b/tests/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationResponseToMatchesTest.php
@@ -30,7 +30,7 @@ class SubjectConfirmationResponseToMatchesTest extends \Mockery\Adapter\Phpunit\
         parent::setUp();
         $this->subjectConfirmation = new \SAML2\XML\saml\SubjectConfirmation();
         $this->subjectConfirmationData = new \SAML2\XML\saml\SubjectConfirmationData();
-        $this->subjectConfirmation->SubjectConfirmationData = $this->SubjectConfirmationData;
+        $this->subjectConfirmation->SubjectConfirmationData = $this->getSubjectConfirmationData();
         $this->response = \Mockery::mock(\SAML2\Response::class);
     }
 

--- a/tests/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationResponseToMatchesTest.php
+++ b/tests/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationResponseToMatchesTest.php
@@ -12,12 +12,12 @@ class SubjectConfirmationResponseToMatchesTest extends \Mockery\Adapter\Phpunit\
     /**
      * @var \Mockery\MockInterface
      */
-    private $subjectConfirmation;
+    private $SubjectConfirmation;
 
     /**
      * @var \Mockery\MockInterface
      */
-    private $subjectConfirmationData;
+    private $SubjectConfirmationData;
 
     /**
      * @var \Mockery\MockInterface
@@ -30,7 +30,7 @@ class SubjectConfirmationResponseToMatchesTest extends \Mockery\Adapter\Phpunit\
         parent::setUp();
         $this->subjectConfirmation = new \SAML2\XML\saml\SubjectConfirmation();
         $this->subjectConfirmationData = new \SAML2\XML\saml\SubjectConfirmationData();
-        $this->subjectConfirmation->SubjectConfirmationData = $this->subjectConfirmationData;
+        $this->subjectConfirmation->SubjectConfirmationData = $this->SubjectConfirmationData;
         $this->response = \Mockery::mock(\SAML2\Response::class);
     }
 
@@ -42,14 +42,14 @@ class SubjectConfirmationResponseToMatchesTest extends \Mockery\Adapter\Phpunit\
     public function when_the_response_responseto_is_null_the_subject_confirmation_is_valid()
     {
         $this->response->shouldReceive('getInResponseTo')->andReturnNull();
-        $this->subjectConfirmationData->setInResponseTo('someValue');
+        $this->SubjectConfirmationData->setInResponseTo('someValue');
 
         $validator = new SubjectConfirmationResponseToMatches(
             $this->response
         );
-        $result    = new Result();
+        $result = new Result();
 
-        $validator->validate($this->subjectConfirmation, $result);
+        $validator->validate($this->SubjectConfirmation, $result);
 
         $this->assertTrue($result->isValid());
     }
@@ -62,14 +62,14 @@ class SubjectConfirmationResponseToMatchesTest extends \Mockery\Adapter\Phpunit\
     public function when_the_subjectconfirmation_responseto_is_null_the_subjectconfirmation_is_valid()
     {
         $this->response->shouldReceive('getInResponseTo')->andReturn('someValue');
-        $this->subjectConfirmationData->setInResponseTo(null);
+        $this->SubjectConfirmationData->setInResponseTo(null);
 
         $validator = new SubjectConfirmationResponseToMatches(
             $this->response
         );
-        $result    = new Result();
+        $result = new Result();
 
-        $validator->validate($this->subjectConfirmation, $result);
+        $validator->validate($this->SubjectConfirmation, $result);
 
         $this->assertTrue($result->isValid());
     }
@@ -82,14 +82,14 @@ class SubjectConfirmationResponseToMatchesTest extends \Mockery\Adapter\Phpunit\
     public function when_the_subjectconfirmation_and_response_responseto_are_null_the_subjectconfirmation_is_valid()
     {
         $this->response->shouldReceive('getInResponseTo')->andReturnNull();
-        $this->subjectConfirmationData->setInResponseTo(null);
+        $this->SubjectConfirmationData->setInResponseTo(null);
 
         $validator = new SubjectConfirmationResponseToMatches(
             $this->response
         );
-        $result    = new Result();
+        $result = new Result();
 
-        $validator->validate($this->subjectConfirmation, $result);
+        $validator->validate($this->SubjectConfirmation, $result);
 
         $this->assertTrue($result->isValid());
     }
@@ -102,14 +102,14 @@ class SubjectConfirmationResponseToMatchesTest extends \Mockery\Adapter\Phpunit\
     public function when_the_subjectconfirmation_and_response_responseto_are_equal_the_subjectconfirmation_is_valid()
     {
         $this->response->shouldReceive('getInResponseTo')->andReturn('theSameValue');
-        $this->subjectConfirmationData->setInResponseTo('theSameValue');
+        $this->SubjectConfirmationData->setInResponseTo('theSameValue');
 
         $validator = new SubjectConfirmationResponseToMatches(
             $this->response
         );
-        $result    = new Result();
+        $result = new Result();
 
-        $validator->validate($this->subjectConfirmation, $result);
+        $validator->validate($this->SubjectConfirmation, $result);
 
         $this->assertTrue($result->isValid());
     }
@@ -122,14 +122,14 @@ class SubjectConfirmationResponseToMatchesTest extends \Mockery\Adapter\Phpunit\
     public function when_the_subjectconfirmation_and_response_responseto_differ_the_subjectconfirmation_is_invalid()
     {
         $this->response->shouldReceive('getInResponseTo')->andReturn('someValue');
-        $this->subjectConfirmationData->setInResponseTo('anotherValue');
+        $this->SubjectConfirmationData->setInResponseTo('anotherValue');
 
         $validator = new SubjectConfirmationResponseToMatches(
             $this->response
         );
-        $result    = new Result();
+        $result = new Result();
 
-        $validator->validate($this->subjectConfirmation, $result);
+        $validator->validate($this->SubjectConfirmation, $result);
 
         $this->assertFalse($result->isValid());
         $this->assertCount(1, $result->getErrors());

--- a/tests/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationResponseToMatchesTest.php
+++ b/tests/SAML2/Assertion/Validation/ConstraintValidator/SubjectConfirmationResponseToMatchesTest.php
@@ -7,7 +7,6 @@ namespace SAML2\Assertion\Validation\ConstraintValidator;
 use Mockery;
 
 use SAML2\Assertion\Validation\Result;
-use SAML2\Assertion\Validation\ConstraintValidator\SubjectConfirmationResponseToMatches;
 use SAML2\Response;
 use SAML2\XML\saml\SubjectConfirmation;
 use SAML2\XML\saml\SubjectConfirmationData;
@@ -17,12 +16,12 @@ class SubjectConfirmationResponseToMatchesTest extends \Mockery\Adapter\Phpunit\
     /**
      * @var \Mockery\MockInterface
      */
-    private $SubjectConfirmation;
+    private $subjectConfirmation;
 
     /**
      * @var \Mockery\MockInterface
      */
-    private $SubjectConfirmationData;
+    private $subjectConfirmationData;
 
     /**
      * @var \Mockery\MockInterface
@@ -48,14 +47,14 @@ class SubjectConfirmationResponseToMatchesTest extends \Mockery\Adapter\Phpunit\
     public function when_the_response_responseto_is_null_the_subject_confirmation_is_valid()
     {
         $this->response->shouldReceive('getInResponseTo')->andReturnNull();
-        $this->SubjectConfirmationData->setInResponseTo('someValue');
+        $this->subjectConfirmationData->setInResponseTo('someValue');
 
         $validator = new SubjectConfirmationResponseToMatches(
             $this->response
         );
         $result = new Result();
 
-        $validator->validate($this->SubjectConfirmation, $result);
+        $validator->validate($this->subjectConfirmation, $result);
 
         $this->assertTrue($result->isValid());
     }
@@ -68,14 +67,14 @@ class SubjectConfirmationResponseToMatchesTest extends \Mockery\Adapter\Phpunit\
     public function when_the_subjectconfirmation_responseto_is_null_the_subjectconfirmation_is_valid()
     {
         $this->response->shouldReceive('getInResponseTo')->andReturn('someValue');
-        $this->SubjectConfirmationData->setInResponseTo(null);
+        $this->subjectConfirmationData->setInResponseTo(null);
 
         $validator = new SubjectConfirmationResponseToMatches(
             $this->response
         );
         $result = new Result();
 
-        $validator->validate($this->SubjectConfirmation, $result);
+        $validator->validate($this->subjectConfirmation, $result);
 
         $this->assertTrue($result->isValid());
     }
@@ -88,14 +87,14 @@ class SubjectConfirmationResponseToMatchesTest extends \Mockery\Adapter\Phpunit\
     public function when_the_subjectconfirmation_and_response_responseto_are_null_the_subjectconfirmation_is_valid()
     {
         $this->response->shouldReceive('getInResponseTo')->andReturnNull();
-        $this->SubjectConfirmationData->setInResponseTo(null);
+        $this->subjectConfirmationData->setInResponseTo(null);
 
         $validator = new SubjectConfirmationResponseToMatches(
             $this->response
         );
         $result = new Result();
 
-        $validator->validate($this->SubjectConfirmation, $result);
+        $validator->validate($this->subjectConfirmation, $result);
 
         $this->assertTrue($result->isValid());
     }
@@ -108,14 +107,14 @@ class SubjectConfirmationResponseToMatchesTest extends \Mockery\Adapter\Phpunit\
     public function when_the_subjectconfirmation_and_response_responseto_are_equal_the_subjectconfirmation_is_valid()
     {
         $this->response->shouldReceive('getInResponseTo')->andReturn('theSameValue');
-        $this->SubjectConfirmationData->setInResponseTo('theSameValue');
+        $this->subjectConfirmationData->setInResponseTo('theSameValue');
 
         $validator = new SubjectConfirmationResponseToMatches(
             $this->response
         );
         $result = new Result();
 
-        $validator->validate($this->SubjectConfirmation, $result);
+        $validator->validate($this->subjectConfirmation, $result);
 
         $this->assertTrue($result->isValid());
     }
@@ -128,14 +127,14 @@ class SubjectConfirmationResponseToMatchesTest extends \Mockery\Adapter\Phpunit\
     public function when_the_subjectconfirmation_and_response_responseto_differ_the_subjectconfirmation_is_invalid()
     {
         $this->response->shouldReceive('getInResponseTo')->andReturn('someValue');
-        $this->SubjectConfirmationData->setInResponseTo('anotherValue');
+        $this->subjectConfirmationData->setInResponseTo('anotherValue');
 
         $validator = new SubjectConfirmationResponseToMatches(
             $this->response
         );
         $result = new Result();
 
-        $validator->validate($this->SubjectConfirmation, $result);
+        $validator->validate($this->subjectConfirmation, $result);
 
         $this->assertFalse($result->isValid());
         $this->assertCount(1, $result->getErrors());

--- a/tests/SAML2/AssertionTest.php
+++ b/tests/SAML2/AssertionTest.php
@@ -365,6 +365,9 @@ XML;
         $assertion = new Assertion();
 
         $assertion->setAuthnContextDecl(new Chunk($document->documentElement));
+        $issuer = new Issuer();
+        $issuer->setValue('example:issuer');
+        $assertion->setIssuer($issuer);
         $documentParent  = DOMDocumentFactory::fromString("<root />");
         $assertionElement = $assertion->toXML($documentParent->firstChild);
 

--- a/tests/SAML2/AssertionTest.php
+++ b/tests/SAML2/AssertionTest.php
@@ -396,7 +396,7 @@ XML;
         $xml_issuer = $xml_issuer[0];
 
         $this->assertFalse($xml_issuer->hasAttributes());
-        $this->assertEquals($issuer->value, $xml_issuer->textContent);
+        $this->assertEquals($issuer->getValue(), $xml_issuer->textContent);
 
         // now, try an Issuer with another format and attributes
         $issuer->setFormat(Constants::NAMEID_UNSPECIFIED);

--- a/tests/SAML2/AssertionTest.php
+++ b/tests/SAML2/AssertionTest.php
@@ -92,7 +92,7 @@ XML;
         $assertion = new Assertion($document->firstChild);
 
         // Was not signed
-        $this->assertFalse($assertion->getWasSignedAtConstruction());
+        $this->assertFalse($assertion->wasSignedAtConstruction());
 
         // Test for valid audiences
         $assertionValidAudiences = $assertion->getValidAudiences();
@@ -731,7 +731,7 @@ XML
         $unsignedAssertion = new Assertion($document->firstChild);
         $unsignedAssertion->setSignatureKey($privateKey);
         $unsignedAssertion->setCertificates([CertificatesMock::PUBLIC_KEY_PEM]);
-        $this->assertFalse($unsignedAssertion->getWasSignedAtConstruction());
+        $this->assertFalse($unsignedAssertion->wasSignedAtConstruction());
         $this->assertEquals($privateKey, $unsignedAssertion->getSignatureKey());
 
         $signedAssertion = new Assertion($unsignedAssertion->toXML());
@@ -740,7 +740,7 @@ XML
 
         $this->assertEquals($privateKey->getAlgorith(), $signatureMethod);
 
-        $this->assertTrue($signedAssertion->getWasSignedAtConstruction());
+        $this->assertTrue($signedAssertion->wasSignedAtConstruction());
 
     }
 
@@ -1106,7 +1106,7 @@ XML;
         $this->assertEquals(CertificatesMock::getPlainPublicKeyContents(), $certs[0]);
 
         // Was signed
-        $this->assertTrue($assertion->getWasSignedAtConstruction());
+        $this->assertTrue($assertion->wasSignedAtConstruction());
     }
 
 
@@ -1211,7 +1211,7 @@ XML;
         $assertion = new Assertion($document->firstChild);
 
         // Was not signed
-        $this->assertFalse($assertion->getWasSignedAtConstruction());
+        $this->assertFalse($assertion->wasSignedAtConstruction());
 
         $publicKey = CertificatesMock::getPublicKeySha256();
         $result = $assertion->validate($publicKey);

--- a/tests/SAML2/AuthnRequestTest.php
+++ b/tests/SAML2/AuthnRequestTest.php
@@ -124,11 +124,11 @@ AUTHNREQUEST;
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
     AssertionConsumerServiceIndex="1"
-    Destination="https://tiqr.stepup.org/idp/profile/saml2/Redirect/SSO"
+    Destination="https://tiqr.example.org/idp/profile/saml2/Redirect/SSO"
     ID="_2b0226190ca1c22de6f66e85f5c95158"
     IssueInstant="2014-09-22T13:42:00Z"
     Version="2.0">
-  <saml:Issuer>https://gateway.stepup.org/saml20/sp/metadata</saml:Issuer>
+  <saml:Issuer>https://gateway.example.org/saml20/sp/metadata</saml:Issuer>
   <saml:Subject>
         <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">user@example.org</saml:NameID>
   </saml:Subject>
@@ -166,8 +166,8 @@ AUTHNREQUEST;
     ID="123"
     Version="2.0"
     IssueInstant="2015-05-11T09:02:36Z"
-    Destination="https://tiqr.stepup.org/idp/profile/saml2/Redirect/SSO">
-    <saml:Issuer>https://gateway.stepup.org/saml20/sp/metadata</saml:Issuer>
+    Destination="https://tiqr.example.org/idp/profile/saml2/Redirect/SSO">
+    <saml:Issuer>https://gateway.example.org/saml20/sp/metadata</saml:Issuer>
     <saml:Subject>
         <saml:EncryptedID xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
             <xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" Type="http://www.w3.org/2001/04/xmlenc#Element">
@@ -216,10 +216,14 @@ AUTHNREQUEST;
         $issuer = new Issuer();
         $issuer->setValue('https://gateway.example.org/saml20/sp/metadata');
 
+        // the Issuer
+        $issuer = new XML\saml\Issuer();
+        $issuer->value = 'https://gateway.example.org/saml20/sp/metadata';
+
         // basic AuthnRequest
         $request = new AuthnRequest();
         $request->setIssuer($issuer);
-        $request->setDestination('https://tiqr.stepup.org/idp/profile/saml2/Redirect/SSO');
+        $request->setDestination('https://tiqr.example.org/idp/profile/saml2/Redirect/SSO');
         $request->setNameId($nameId);
 
         // encrypt the NameID

--- a/tests/SAML2/AuthnRequestTest.php
+++ b/tests/SAML2/AuthnRequestTest.php
@@ -138,8 +138,8 @@ AUTHNREQUEST;
         $authnRequest = new AuthnRequest(DOMDocumentFactory::fromString($xml)->documentElement);
 
         $nameId = $authnRequest->getNameId();
-        $this->assertEquals("user@example.org", $nameId->value);
-        $this->assertEquals("urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", $nameId->Format);
+        $this->assertEquals("user@example.org", $nameId->getValue());
+        $this->assertEquals("urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", $nameId->getFormat());
     }
 
 
@@ -195,8 +195,8 @@ AUTHNREQUEST;
         $authnRequest->decryptNameId($key);
 
         $nameId = $authnRequest->getNameId();
-        $this->assertEquals(md5('Arthur Dent'), $nameId->value);
-        $this->assertEquals(Constants::NAMEID_ENCRYPTED, $nameId->Format);
+        $this->assertEquals(md5('Arthur Dent'), $nameId->getValue());
+        $this->assertEquals(Constants::NAMEID_ENCRYPTED, $nameId->getFormat());
     }
 
 
@@ -215,10 +215,6 @@ AUTHNREQUEST;
         // the Issuer
         $issuer = new Issuer();
         $issuer->setValue('https://gateway.example.org/saml20/sp/metadata');
-
-        // the Issuer
-        $issuer = new XML\saml\Issuer();
-        $issuer->value = 'https://gateway.example.org/saml20/sp/metadata';
 
         // basic AuthnRequest
         $request = new AuthnRequest();

--- a/tests/SAML2/Certificate/KeyCollectionTest.php
+++ b/tests/SAML2/Certificate/KeyCollectionTest.php
@@ -16,7 +16,7 @@ class KeyCollectionTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testKeyCollectionAddWrongType()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $kc = new KeyCollection();
         $kc->add("not a key, just a string");
     }

--- a/tests/SAML2/Certificate/KeyCollectionTest.php
+++ b/tests/SAML2/Certificate/KeyCollectionTest.php
@@ -16,7 +16,7 @@ class KeyCollectionTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testKeyCollectionAddWrongType()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->setExpectedException(InvalidArgumentException::class);
         $kc = new KeyCollection();
         $kc->add("not a key, just a string");
     }

--- a/tests/SAML2/Certificate/KeyCollectionTest.php
+++ b/tests/SAML2/Certificate/KeyCollectionTest.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace SAML2\Certificate;
 
-use SAML2\Certificate\KeyCollection;
-use \SAML2\Exception\InvalidArgumentException;
-
 class KeyCollectionTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
 {
     /**
@@ -16,7 +13,7 @@ class KeyCollectionTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testKeyCollectionAddWrongType()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $kc = new KeyCollection();
         $kc->add("not a key, just a string");
     }

--- a/tests/SAML2/Certificate/KeyLoaderTest.php
+++ b/tests/SAML2/Certificate/KeyLoaderTest.php
@@ -104,7 +104,7 @@ class KeyLoaderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     public function loading_a_file_with_the_wrong_format_throws_an_exception()
     {
         $filePath = dirname(__FILE__) . '/File/';
-        $this->setExpectedException(InvalidCertificateStructureException::class);
+        $this->expectException(InvalidCertificateStructureException::class);
         $this->keyLoader->loadCertificateFile($filePath . 'not_a_key.crt');
     }
 
@@ -149,7 +149,7 @@ class KeyLoaderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
             ->once()
             ->andReturnNull();
 
-        $this->setExpectedException(NoKeysFoundException::class);
+        $this->expectException(NoKeysFoundException::class);
         $this->keyLoader->loadKeysFromConfiguration($this->configurationMock, null, true);
     }
 
@@ -202,7 +202,7 @@ class KeyLoaderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
             ->once()
             ->andReturn($file);
 
-        $this->setExpectedException(InvalidCertificateStructureException::class);
+        $this->expectException(InvalidCertificateStructureException::class);
         $loadedKeys = $this->keyLoader->loadKeysFromConfiguration($this->configurationMock);
     }
 }

--- a/tests/SAML2/Certificate/KeyLoaderTest.php
+++ b/tests/SAML2/Certificate/KeyLoaderTest.php
@@ -104,7 +104,7 @@ class KeyLoaderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     public function loading_a_file_with_the_wrong_format_throws_an_exception()
     {
         $filePath = dirname(__FILE__) . '/File/';
-        $this->expectException(InvalidCertificateStructureException::class);
+        $this->setExpectedException(InvalidCertificateStructureException::class);
         $this->keyLoader->loadCertificateFile($filePath . 'not_a_key.crt');
     }
 
@@ -149,7 +149,7 @@ class KeyLoaderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
             ->once()
             ->andReturnNull();
 
-        $this->expectException(NoKeysFoundException::class);
+        $this->setExpectedException(NoKeysFoundException::class);
         $this->keyLoader->loadKeysFromConfiguration($this->configurationMock, null, true);
     }
 
@@ -202,7 +202,7 @@ class KeyLoaderTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
             ->once()
             ->andReturn($file);
 
-        $this->expectException(InvalidCertificateStructureException::class);
+        $this->setExpectedException(InvalidCertificateStructureException::class);
         $loadedKeys = $this->keyLoader->loadKeysFromConfiguration($this->configurationMock);
     }
 }

--- a/tests/SAML2/Certificate/KeyTest.php
+++ b/tests/SAML2/Certificate/KeyTest.php
@@ -18,7 +18,7 @@ class KeyTest extends \PHPUnit\Framework\TestCase
     public function invalid_key_usage_should_throw_an_exception()
     {
         $key = new Key([Key::USAGE_SIGNING => true]);
-        $this->expectException(InvalidKeyUsageException::class);
+        $this->setExpectedException(InvalidKeyUsageException::class);
         $key->canBeUsedFor('foo');
     }
 
@@ -31,7 +31,7 @@ class KeyTest extends \PHPUnit\Framework\TestCase
     public function invalid_offset_type_should_throw_an_exception($function, $params)
     {
         $key = new Key([Key::USAGE_SIGNING => true]);
-        $this->expectException(InvalidArgumentException::class);
+        $this->setExpectedException(InvalidArgumentException::class);
         call_user_func_array([$key, $function], $params);
     }
 

--- a/tests/SAML2/Certificate/KeyTest.php
+++ b/tests/SAML2/Certificate/KeyTest.php
@@ -18,7 +18,7 @@ class KeyTest extends \PHPUnit\Framework\TestCase
     public function invalid_key_usage_should_throw_an_exception()
     {
         $key = new Key([Key::USAGE_SIGNING => true]);
-        $this->setExpectedException(InvalidKeyUsageException::class);
+        $this->expectException(InvalidKeyUsageException::class);
         $key->canBeUsedFor('foo');
     }
 
@@ -31,7 +31,7 @@ class KeyTest extends \PHPUnit\Framework\TestCase
     public function invalid_offset_type_should_throw_an_exception($function, $params)
     {
         $key = new Key([Key::USAGE_SIGNING => true]);
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         call_user_func_array([$key, $function], $params);
     }
 

--- a/tests/SAML2/DOMDocumentFactoryTest.php
+++ b/tests/SAML2/DOMDocumentFactoryTest.php
@@ -16,7 +16,7 @@ class DOMDocumentFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testNotXmlStringRaisesAnException()
     {
-        $this->setExpectedException(UnparseableXmlException::class);
+        $this->expectException(UnparseableXmlException::class);
         DOMDocumentFactory::fromString('this is not xml');
     }
 
@@ -38,7 +38,7 @@ class DOMDocumentFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testFileThatDoesNotExistIsNotAccepted()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $filename = 'DoesNotExist.ext';
         DOMDocumentFactory::fromFile($filename);
     }
@@ -49,7 +49,7 @@ class DOMDocumentFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testFileThatDoesNotContainXMLCannotBeLoaded()
     {
-        $this->setExpectedException(RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $file = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'domdocument_invalid_xml.xml';
         DOMDocumentFactory::fromFile($file);
     }
@@ -73,7 +73,7 @@ class DOMDocumentFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testFileThatContainsDocTypeIsNotAccepted()
     {
-        $this->setExpectedException(RuntimeException::class, 'Dangerous XML detected, DOCTYPE nodes are not allowed in the XML body');
+        $this->expectException(RuntimeException::class, 'Dangerous XML detected, DOCTYPE nodes are not allowed in the XML body');
         $file = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'domdocument_doctype.xml';
         $this->expectException(Exception\RuntimeException::class, 'Dangerous XML detected, DOCTYPE nodes are not allowed in the XML body');
         DOMDocumentFactory::fromFile($file);
@@ -85,7 +85,7 @@ class DOMDocumentFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testStringThatContainsDocTypeIsNotAccepted()
     {
-        $this->setExpectedException(RuntimeException::class, 'Dangerous XML detected, DOCTYPE nodes are not allowed in the XML body');
+        $this->expectException(RuntimeException::class, 'Dangerous XML detected, DOCTYPE nodes are not allowed in the XML body');
         $xml = '<!DOCTYPE foo [<!ELEMENT foo ANY > <!ENTITY xxe SYSTEM "file:///dev/random" >]><foo />';
         $this->expectException(Exception\RuntimeException::class, 'Dangerous XML detected, DOCTYPE nodes are not allowed in the XML body');
         DOMDocumentFactory::fromString($xml);
@@ -97,7 +97,7 @@ class DOMDocumentFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testEmptyFileIsNotValid()
     {
-        $this->setExpectedException(RuntimeException::class, 'does not have content');
+        $this->expectException(RuntimeException::class, 'does not have content');
         $file = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'domdocument_empty.xml';
         $this->expectException(Exception\RuntimeException::class, 'does not have content');
         DOMDocumentFactory::fromFile($file);
@@ -109,7 +109,7 @@ class DOMDocumentFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testEmptyStringIsNotValid()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Invalid Argument type: "non-empty string" expected, "string" given');
+        $this->expectException(InvalidArgumentException::class, 'Invalid Argument type: "non-empty string" expected, "string" given');
         DOMDocumentFactory::fromString("");
     }
 }

--- a/tests/SAML2/DOMDocumentFactoryTest.php
+++ b/tests/SAML2/DOMDocumentFactoryTest.php
@@ -16,7 +16,7 @@ class DOMDocumentFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testNotXmlStringRaisesAnException()
     {
-        $this->expectException(UnparseableXmlException::class);
+        $this->setExpectedException(UnparseableXmlException::class);
         DOMDocumentFactory::fromString('this is not xml');
     }
 
@@ -38,7 +38,7 @@ class DOMDocumentFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testFileThatDoesNotExistIsNotAccepted()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->setExpectedException(InvalidArgumentException::class);
         $filename = 'DoesNotExist.ext';
         DOMDocumentFactory::fromFile($filename);
     }
@@ -49,7 +49,7 @@ class DOMDocumentFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testFileThatDoesNotContainXMLCannotBeLoaded()
     {
-        $this->expectException(RuntimeException::class);
+        $this->setExpectedException(RuntimeException::class);
         $file = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'domdocument_invalid_xml.xml';
         DOMDocumentFactory::fromFile($file);
     }
@@ -73,7 +73,7 @@ class DOMDocumentFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testFileThatContainsDocTypeIsNotAccepted()
     {
-        $this->expectException(RuntimeException::class, 'Dangerous XML detected, DOCTYPE nodes are not allowed in the XML body');
+        $this->setExpectedException(RuntimeException::class, 'Dangerous XML detected, DOCTYPE nodes are not allowed in the XML body');
         $file = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'domdocument_doctype.xml';
         $this->expectException(Exception\RuntimeException::class, 'Dangerous XML detected, DOCTYPE nodes are not allowed in the XML body');
         DOMDocumentFactory::fromFile($file);
@@ -85,7 +85,7 @@ class DOMDocumentFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testStringThatContainsDocTypeIsNotAccepted()
     {
-        $this->expectException(RuntimeException::class, 'Dangerous XML detected, DOCTYPE nodes are not allowed in the XML body');
+        $this->setExpectedException(RuntimeException::class, 'Dangerous XML detected, DOCTYPE nodes are not allowed in the XML body');
         $xml = '<!DOCTYPE foo [<!ELEMENT foo ANY > <!ENTITY xxe SYSTEM "file:///dev/random" >]><foo />';
         $this->expectException(Exception\RuntimeException::class, 'Dangerous XML detected, DOCTYPE nodes are not allowed in the XML body');
         DOMDocumentFactory::fromString($xml);
@@ -97,7 +97,7 @@ class DOMDocumentFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testEmptyFileIsNotValid()
     {
-        $this->expectException(RuntimeException::class, 'does not have content');
+        $this->setExpectedException(RuntimeException::class, 'does not have content');
         $file = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'domdocument_empty.xml';
         $this->expectException(Exception\RuntimeException::class, 'does not have content');
         DOMDocumentFactory::fromFile($file);
@@ -109,7 +109,7 @@ class DOMDocumentFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testEmptyStringIsNotValid()
     {
-        $this->expectException(InvalidArgumentException::class, 'Invalid Argument type: "non-empty string" expected, "string" given');
+        $this->setExpectedException(InvalidArgumentException::class, 'Invalid Argument type: "non-empty string" expected, "string" given');
         DOMDocumentFactory::fromString("");
     }
 }

--- a/tests/SAML2/HTTPPostTest.php
+++ b/tests/SAML2/HTTPPostTest.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace SAML2;
 
+use PHPUnit_Framework_Error_Warning;
+use PHPUnit_Framework_TestCase;
+use SimpleSAML\Utils\HTTP;
+
 use SAML2\AuthnRequest;
 use SAML2\HTTPPost;
 use SAML2\Response;
 use SAML2\XML\saml\Issuer;
-
-use PHPUnit_Framework_Error_Warning;
-use PHPUnit_Framework_TestCase;
 
 class HTTPPostTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
 {
@@ -62,17 +63,42 @@ class HTTPPostTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $_POST = ['non' => 'sense'];
         $hp = new HTTPPost();
         $this->expectException(\Exception::class, 'Missing SAMLRequest or SAMLResponse parameter');
-        $msg = $hp->receive();
+        $hp->receive();
     }
 
 
     /**
-     * Construct an authnrequest and send it.
+     * Construct an authnrequest without a destination and try to send it.
      * @doesNotPerformAssertions
      */
-    public function testSendAuthnrequest()
+    public function testSendMissingDestination()
     {
         $request = new AuthnRequest();
+        $hp = new HTTPPost();
+        $this->setExpectedException('Exception', 'Cannot send message, no destination set.');
+        $hp->send($request);
+    }
+
+
+    /**
+     * Construct an authnrequest and send it to the destination set in the binding.
+     */
+    public function testSendAuthnRequestWithDestinationInBinding()
+    {
+        $request = new AuthnRequest();
+        $hp = new HTTPPost();
+        $hp->setDestination('https://example.org');
+        $hp->send($request);
+    }
+
+
+    /**
+     * Construct an authnrequest with a destination set and try to send it.
+     */
+    public function testSendAuthnRequestWithDestination()
+    {
+        $request = new AuthnRequest();
+        $request->setDestination('https://example.org');
         $hp = new HTTPPost();
         $hp->send($request);
     }

--- a/tests/SAML2/HTTPPostTest.php
+++ b/tests/SAML2/HTTPPostTest.php
@@ -82,6 +82,7 @@ class HTTPPostTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
 
     /**
      * Construct an authnrequest and send it to the destination set in the binding.
+     * @doesNotPerformAssertions
      */
     public function testSendAuthnRequestWithDestinationInBinding()
     {
@@ -94,6 +95,7 @@ class HTTPPostTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
 
     /**
      * Construct an authnrequest with a destination set and try to send it.
+     * @doesNotPerformAssertions
      */
     public function testSendAuthnRequestWithDestination()
     {

--- a/tests/SAML2/HTTPPostTest.php
+++ b/tests/SAML2/HTTPPostTest.php
@@ -75,7 +75,7 @@ class HTTPPostTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     {
         $request = new AuthnRequest();
         $hp = new HTTPPost();
-        $this->setExpectedException('Exception', 'Cannot send message, no destination set.');
+        $this->expectException('Exception', 'Cannot send message, no destination set.');
         $hp->send($request);
     }
 

--- a/tests/SAML2/HTTPRedirectTest.php
+++ b/tests/SAML2/HTTPRedirectTest.php
@@ -174,7 +174,19 @@ class HTTPRedirectTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
 
         $this->expectException(\Exception::class, 'Missing SAMLRequest or SAMLResponse parameter.');
         $hr = new HTTPRedirect();
-        $request = $hr->receive();
+        $hr->receive();
+    }
+
+
+    /**
+     * Construct an authnrequest and try to send it without a destination.
+     */
+    public function testSendWithoutDestination()
+    {
+        $request = new AuthnRequest();
+        $hr = new HTTPRedirect();
+        $this->setExpectedException('Exception', 'Cannot build a redirect URL, no destination set.');
+        $hr->send($request);
     }
 
 

--- a/tests/SAML2/HTTPRedirectTest.php
+++ b/tests/SAML2/HTTPRedirectTest.php
@@ -185,7 +185,7 @@ class HTTPRedirectTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
     {
         $request = new AuthnRequest();
         $hr = new HTTPRedirect();
-        $this->setExpectedException('Exception', 'Cannot build a redirect URL, no destination set.');
+        $this->expectException('Exception', 'Cannot build a redirect URL, no destination set.');
         $hr->send($request);
     }
 

--- a/tests/SAML2/LogoutRequestTest.php
+++ b/tests/SAML2/LogoutRequestTest.php
@@ -105,7 +105,7 @@ XML;
         $logoutRequest->decryptNameId(CertificatesMock::getPrivateKey());
 
         $nameId = $logoutRequest->getNameId();
-        $this->assertEquals('TheNameIDValue', $nameId->value);
+        $this->assertEquals('TheNameIDValue', $nameId->getValue());
     }
 
 
@@ -133,7 +133,7 @@ XML;
 
         $logoutRequest->decryptNameId(CertificatesMock::getPrivateKey());
         $nameId = $logoutRequest->getNameId();
-        $this->assertEquals('TheNameIDValue', $nameId->value);
+        $this->assertEquals('TheNameIDValue', $nameId->getValue());
     }
 
 
@@ -159,8 +159,8 @@ XML;
         $this->logoutRequestElement = $document->firstChild;
 
         $logoutRequest = new LogoutRequest($this->logoutRequestElement);
-        $this->assertEquals("frits", $logoutRequest->getNameId()->value);
-        $this->assertEquals("urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified", $logoutRequest->getNameId()->Format);
+        $this->assertEquals("frits", $logoutRequest->getNameId()->getValue());
+        $this->assertEquals("urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified", $logoutRequest->getNameId()->getFormat());
 
         $this->assertFalse($logoutRequest->isNameIdEncrypted());
         $this->assertNull($logoutRequest->decryptNameId(CertificatesMock::getPrivateKey()));

--- a/tests/SAML2/MessageTest.php
+++ b/tests/SAML2/MessageTest.php
@@ -102,7 +102,7 @@ AUTHNREQUEST
         $xml_issuer = $xml_issuer[0];
 
         $this->assertFalse($xml_issuer->hasAttributes());
-        $this->assertEquals($issuer->value, $xml_issuer->textContent);
+        $this->assertEquals($issuer->getValue(), $xml_issuer->textContent);
 
         // now, try an Issuer with another format and attributes
         $issuer->setFormat(Constants::NAMEID_UNSPECIFIED);

--- a/tests/SAML2/MyArtifactResponseTest.php
+++ b/tests/SAML2/MyArtifactResponseTest.php
@@ -31,11 +31,11 @@ class ArtifactResponseTest extends \PHPUnit\Framework\TestCase
 
         $artifactIssuer = Utils::xpQuery($artifactResponseElement, './saml:Issuer');
         $this->assertCount(1, $artifactIssuer);
-        $this->assertEquals($issuer1->value, $artifactIssuer[0]->textContent);
+        $this->assertEquals($issuer1->getValue(), $artifactIssuer[0]->textContent);
 
         $authnelement = Utils::xpQuery($artifactResponseElement, './saml_protocol:AuthnRequest/saml:Issuer');
         $this->assertCount(1, $authnelement);
-        $this->assertEquals($issuer2->value, $authnelement[0]->textContent);
+        $this->assertEquals($issuer2->getValue(), $authnelement[0]->textContent);
     }
 
 

--- a/tests/SAML2/Response/SignatureValidationTest.php
+++ b/tests/SAML2/Response/SignatureValidationTest.php
@@ -130,14 +130,12 @@ class SignatureValidationTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testThatAnUnsignedResponseWithNoSignedAssertionsThrowsAnException()
     {
-        $this->setExpectedException(UnsignedResponseException::class);
+        $this->expectException(UnsignedResponseException::class);
 
         // here the processAssertions may not be called as it should fail with an exception due to having no signature
         $this->assertionProcessor->shouldReceive('processAssertions')->never();
 
         $processor = new Response\Processor(new \Psr\Log\NullLogger());
-
-        $this->expectException(Exception\UnsignedResponseException::class);
         $processor->process(
             new ServiceProvider([]),
             new IdentityProvider([]),

--- a/tests/SAML2/Response/SignatureValidationTest.php
+++ b/tests/SAML2/Response/SignatureValidationTest.php
@@ -130,7 +130,7 @@ class SignatureValidationTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
      */
     public function testThatAnUnsignedResponseWithNoSignedAssertionsThrowsAnException()
     {
-        $this->expectException(UnsignedResponseException::class);
+        $this->setExpectedException(UnsignedResponseException::class);
 
         // here the processAssertions may not be called as it should fail with an exception due to having no signature
         $this->assertionProcessor->shouldReceive('processAssertions')->never();

--- a/tests/SAML2/SOAPTest.php
+++ b/tests/SAML2/SOAPTest.php
@@ -14,7 +14,7 @@ class SOAPTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
 {
     public function testRequestParsingEmptyMessage()
     {
-        $this->expectException(\Exception::class, 'Invalid message received');
+        $this->expectException(Exception::class, 'Invalid message received');
 
         $stub = $this->getStubWithInput('');
         $stub->receive();

--- a/tests/SAML2/SOAPTest.php
+++ b/tests/SAML2/SOAPTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace SAML2;
 
 use SAML2\Message;
-use SAML2\SOAP;
 use SAML2\ArtifactResolve;
 
 use Exception;
@@ -100,7 +99,7 @@ XML
 
 SOAP;
 
-        $soap = new SOAP;
+        $soap = new SOAP();
         $output = $soap->getOutputToSend($message);
 
         $this->assertEquals($expected, $output);

--- a/tests/SAML2/Utilities/ArrayCollectionTest.php
+++ b/tests/SAML2/Utilities/ArrayCollectionTest.php
@@ -101,7 +101,7 @@ class ArrayCollectionTest extends \PHPUnit\Framework\TestCase
 
     public function test_onlyelement_fail()
     {
-        $this->setExpectedException(RuntimeException::class, 'SAML2\Utilities\ArrayCollection::SAML2\Utilities\ArrayCollection::getOnlyElement requires that the collection has exactly one element, "2" elements found');
+        $this->expectException(RuntimeException::class, 'SAML2\Utilities\ArrayCollection::SAML2\Utilities\ArrayCollection::getOnlyElement requires that the collection has exactly one element, "2" elements found');
         $arc = new ArrayCollection(['aap', 'noot']);
         $arc->getOnlyElement();
     }

--- a/tests/SAML2/Utilities/ArrayCollectionTest.php
+++ b/tests/SAML2/Utilities/ArrayCollectionTest.php
@@ -105,7 +105,7 @@ class ArrayCollectionTest extends \PHPUnit\Framework\TestCase
 
     public function test_onlyelement_fail()
     {
-        $this->expectException(RuntimeException::class, 'SAML2\Utilities\ArrayCollection::SAML2\Utilities\ArrayCollection::getOnlyElement requires that the collection has exactly one element, "2" elements found');
+        $this->setExpectedException(RuntimeException::class, 'SAML2\Utilities\ArrayCollection::SAML2\Utilities\ArrayCollection::getOnlyElement requires that the collection has exactly one element, "2" elements found');
         $arc = new ArrayCollection(['aap', 'noot']);
         $arc->getOnlyElement();
     }

--- a/tests/SAML2/Utilities/ArrayCollectionTest.php
+++ b/tests/SAML2/Utilities/ArrayCollectionTest.php
@@ -36,29 +36,25 @@ class ArrayCollectionTest extends \PHPUnit\Framework\TestCase
     {
         $arc = new ArrayCollection(['aap', 'aap', 'noot', 'mies']);
 
-        $removed = $arc->remove('noot');
-        $this->assertEquals('noot', $removed);
+        $arc->remove('noot');
         $this->assertEquals($arc->get(0), 'aap');
         $this->assertEquals($arc->get(1), 'aap');
         $this->assertEquals($arc->get(2), null);
         $this->assertEquals($arc->get(3), 'mies');
 
-        $removed = $arc->remove('wim');
-        $this->assertFalse($removed);
+        $arc->remove('wim');
         $this->assertEquals($arc->get(0), 'aap');
         $this->assertEquals($arc->get(1), 'aap');
         $this->assertEquals($arc->get(2), null);
         $this->assertEquals($arc->get(3), 'mies');
 
-        $removed = $arc->remove('aap');
-        $this->assertEquals('aap', $removed);
+        $arc->remove('aap');
         $this->assertEquals($arc->get(0), null);
         $this->assertEquals($arc->get(1), 'aap');
         $this->assertEquals($arc->get(2), null);
         $this->assertEquals($arc->get(3), 'mies');
 
-        $removed = $arc->remove('aap');
-        $this->assertEquals('aap', $removed);
+        $arc->remove('aap');
         $this->assertEquals($arc->get(0), null);
         $this->assertEquals($arc->get(1), null);
         $this->assertEquals($arc->get(2), null);

--- a/tests/SAML2/Utilities/FileTest.php
+++ b/tests/SAML2/Utilities/FileTest.php
@@ -15,7 +15,7 @@ class FileTest extends \PHPUnit\Framework\TestCase
      */
     public function when_loading_a_non_existant_file_an_exception_is_thrown()
     {
-        $this->expectException(RuntimeException::class, 'File "/foo/bar/baz/quux" does not exist or is not readable');
+        $this->setExpectedException(RuntimeException::class, 'File "/foo/bar/baz/quux" does not exist or is not readable');
         File::getFileContents('/foo/bar/baz/quux');
     }
 

--- a/tests/SAML2/Utilities/FileTest.php
+++ b/tests/SAML2/Utilities/FileTest.php
@@ -15,7 +15,7 @@ class FileTest extends \PHPUnit\Framework\TestCase
      */
     public function when_loading_a_non_existant_file_an_exception_is_thrown()
     {
-        $this->setExpectedException(RuntimeException::class, 'File "/foo/bar/baz/quux" does not exist or is not readable');
+        $this->expectException(RuntimeException::class, 'File "/foo/bar/baz/quux" does not exist or is not readable');
         File::getFileContents('/foo/bar/baz/quux');
     }
 

--- a/tests/SAML2/XML/ChunkTest.php
+++ b/tests/SAML2/XML/ChunkTest.php
@@ -26,13 +26,13 @@ class ChunkTest extends \PHPUnit\Framework\TestCase
     public function setUp()
     {
         $attribute = new Attribute();
-        $attribute->Name = 'TheName';
-        $attribute->NameFormat = 'TheNameFormat';
-        $attribute->FriendlyName = 'TheFriendlyName';
-        $attribute->AttributeValue = [
+        $attribute->setName('TheName');
+        $attribute->setNameFormat('TheNameFormat');
+        $attribute->setFriendlyName('TheFriendlyName');
+        $attribute->setAttributeValue([
             new AttributeValue('FirstValue'),
             new AttributeValue('SecondValue'),
-        ];
+        ]);
 
         $document = DOMDocumentFactory::fromString('<root />');
         $attributeElement = $attribute->toXML($document->firstChild);


### PR DESCRIPTION
Covered by #152 
- [x] ~~Raised minimum PHP version to 7.0~~
- [x] ~~Upgraded dependencies~~
  - [x]  ~~sensiolabs/security-checker~~
  - [x]  ~~phpunit/phpunit~~
  - [x]  ~~sebastian/phpcpd~~
  - [x]  ~~mockery/mockery~~
- [x] ~~Replace PHPMD with Psalm~~
- [x] ~~Replace setExpectedException PHPdoc-annotations with actual code (after upgrading PHPunit)~~

Covered by #153:
- [x] ~~Removed all deprecated code:~~
  - [x] ~~Certificate fingerprints~~
  - [x] ~~Array-style NameId & Issuer~~
- [x] ~~Remove PSR-0 autoloader~~

Covered by #154
- [x] ~~Type declarations for scalar types~~

Covered by #155
- [x] ~~Strict types~~

Covered by #158
- [x] ~~Replace public properties with private ones~~

Remaining for this PR
- [x] PSR-2
- [x] Add more PHPdoc
- [x] Mark classes as final wherever possible
- [x] Fix remaining Psalm issues