### PR TITLE
Upgrade php_codesniffer to 3.2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "~1.4",
+        "squizlabs/php_codesniffer": "~3.2",
         "phpmd/phpmd": "~1.5",
         "sensiolabs/security-checker": "~1.1",
         "phpunit/phpunit": "~4",

--- a/src/SAML2/XML/saml/BaseIDType.php
+++ b/src/SAML2/XML/saml/BaseIDType.php
@@ -8,7 +8,6 @@
 
 namespace SAML2\XML\saml;
 
-
 use SAML2\Constants;
 use SAML2\DOMDocumentFactory;
 

--- a/src/SAML2/XML/saml/Issuer.php
+++ b/src/SAML2/XML/saml/Issuer.php
@@ -42,9 +42,8 @@ class Issuer extends NameIDType
      */
     protected $nodeName = 'saml:Issuer';
 
-    /*
-     *
-     * if $this->SAML2IssuerShowAll is set false   
+    /**
+     * if $this->SAML2IssuerShowAll is set false
      * From saml-core-2.0-os 8.3.6, when the entity Format is used: "The NameQualifier, SPNameQualifier, and
      * SPProvidedID attributes MUST be omitted."
      *

--- a/src/SAML2/XML/saml/NameID.php
+++ b/src/SAML2/XML/saml/NameID.php
@@ -2,7 +2,6 @@
 
 namespace SAML2\XML\saml;
 
-
 /**
  * Class representing the saml:NameID element.
  *

--- a/src/SAML2/XML/saml/NameIDType.php
+++ b/src/SAML2/XML/saml/NameIDType.php
@@ -8,7 +8,6 @@
 
 namespace SAML2\XML\saml;
 
-
 abstract class NameIDType extends BaseIDType
 {
     /**


### PR DESCRIPTION
Fixes arbitrary shell execution