### PR TITLE
Provide support data: URLs for mdui:Logo

### DIFF
--- a/src/SAML2/XML/ecp/Response.php
+++ b/src/SAML2/XML/ecp/Response.php
@@ -68,7 +68,7 @@ class Response
     {
         assert(is_string($assertionConsumerServiceURL));
         if (!filter_var($assertionConsumerServiceURL, FILTER_VALIDATE_URL)) {
-            throw new \InvalidArgumentException('Provided argument is not a valid URL.');
+            throw new \InvalidArgumentException('AssertionConsumerServiceURL is not a valid URL.');
         }
         $this->AssertionConsumerServiceURL = $assertionConsumerServiceURL;
     }

--- a/src/SAML2/XML/md/RoleDescriptor.php
+++ b/src/SAML2/XML/md/RoleDescriptor.php
@@ -238,7 +238,7 @@ class RoleDescriptor extends SignedElementHelper
     {
         assert(is_string($errorURL) || is_null($errorURL));
         if (!is_null($errorURL) && !filter_var($errorURL, FILTER_VALIDATE_URL)) {
-            throw new \InvalidArgumentException('Provided argument is not a valid URL.');
+            throw new \InvalidArgumentException('RoleDescriptor errorURL is not a valid URL.');
         }
         $this->errorURL = $errorURL;
     }

--- a/src/SAML2/XML/mdui/Logo.php
+++ b/src/SAML2/XML/mdui/Logo.php
@@ -83,7 +83,7 @@ class Logo
     public function setUrl($url)
     {
         assert(is_string($url));
-        if (!filter_var($url, FILTER_VALIDATE_URL) && substr($url, 0, 5) !== 'data:') {
+        if (!filter_var(trim($url), FILTER_VALIDATE_URL) && substr(trim($url), 0, 5) !== 'data:') {
             throw new \InvalidArgumentException('mdui:Logo is not a valid URL.');
         }
         $this->url = $url;

--- a/src/SAML2/XML/mdui/Logo.php
+++ b/src/SAML2/XML/mdui/Logo.php
@@ -83,7 +83,7 @@ class Logo
     public function setUrl($url)
     {
         assert(is_string($url));
-        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+        if (!filter_var($url, FILTER_VALIDATE_URL) && substr($url, 0, 5) !== 'data:') {
             throw new \InvalidArgumentException('mdui:Logo is not a valid URL.');
         }
         $this->url = $url;

--- a/src/SAML2/XML/mdui/Logo.php
+++ b/src/SAML2/XML/mdui/Logo.php
@@ -84,7 +84,7 @@ class Logo
     {
         assert(is_string($url));
         if (!filter_var($url, FILTER_VALIDATE_URL)) {
-            throw new \InvalidArgumentException('Provided argument is not a valid URL.');
+            throw new \InvalidArgumentException('mdui:Logo is not a valid URL.');
         }
         $this->url = $url;
     }

--- a/tests/SAML2/XML/mdui/LogoTest.php
+++ b/tests/SAML2/XML/mdui/LogoTest.php
@@ -54,6 +54,22 @@ XML
     }
 
     /**
+     * Unmarshalling of a logo tag with a data: URL
+     */
+    public function testUnmarshallingDataURL()
+    {
+        $document = DOMDocumentFactory::fromString(<<<XML
+<mdui:Logo height="1" width="1">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=</mdui:Logo>
+XML
+        );
+
+        $logo = new Logo($document->firstChild);
+        $this->assertEquals(1, $logo->getWidth());
+        $this->assertEquals(1, $logo->getHeight());
+        $this->assertEquals("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=", $logo->getUrl());
+    }
+
+    /**
      * Unmarshalling fails if url attribute not present
      */
     public function testUnmarshallingFailsEmptyURL()


### PR DESCRIPTION
There are currently over 600 logos in the eduGAIN feed that are specified using RFC 2397 data: URLs. However, PHP's FILTER_VALIDATE_URL filter has no explicit support for data: URLs, and consequently makes the assumption that they must follow a `<scheme>:<host>` format. The result is that arbitrary limitations are placed on data: URLs, causing all but a very small number to fail this validation.

Ultimately this should be fixed in PHP. However, this has not happened as of 7.3.0, and even if that were to happen, we'd need to deal with the fact that the fix would be unlikely to be back ported to the earliest version supported by this library (5.4). Thus we need to have a workaround here to support data: urls in spite of PHP's bug.

cf https://github.com/php/php-src/blob/php-7.3.0/ext/filter/logical_filters.c#L587
