### PR TITLE
Upgrade to PhpUnit 8 and fix deprecation warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "~3.4",
         "sensiolabs/security-checker": "~5.0",
-        "phpunit/phpunit": "^7.0",
         "sebastian/phpcpd": "~4.1",
-        "mockery/mockery": "~1.2"
+        "mockery/mockery": "~1.2",
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/SAML2/AssertionTest.php
+++ b/tests/SAML2/AssertionTest.php
@@ -977,8 +977,8 @@ XML;
         $assertion = new Assertion(DOMDocumentFactory::fromString($xml)->firstChild);
 
         $attributes = $assertion->getAttributes();
-        $this->assertInternalType('int', $attributes['urn:some:integer'][0]);
-        $this->assertInternalType('string', $attributes['urn:some:string'][0]);
+        $this->assertIsInt($attributes['urn:some:integer'][0]);
+        $this->assertIsString($attributes['urn:some:string'][0]);
         $this->assertXmlStringEqualsXmlString($xml, $assertion->toXML()->ownerDocument->saveXML());
     }
 
@@ -1073,8 +1073,8 @@ XML;
         $assertionToVerify->decryptAttributes(CertificatesMock::getPrivateKey());
         $attributes = $assertionToVerify->getAttributes();
 
-        $this->assertInternalType('int', $attributes['urn:some:integer'][0]);
-        $this->assertInternalType('string', $attributes['urn:some:string'][0]);
+        $this->assertIsInt($attributes['urn:some:integer'][0]);
+        $this->assertIsString($attributes['urn:some:string'][0]);
         $this->assertXmlStringEqualsXmlString($xml, $assertionToVerify->toXML()->ownerDocument->saveXML());
     }
 

--- a/tests/SAML2/AuthnRequestTest.php
+++ b/tests/SAML2/AuthnRequestTest.php
@@ -153,7 +153,7 @@ AUTHNREQUEST;
 
         $requestAsXML = $request->toUnsignedXML()->ownerDocument->saveXML();
         $expected = '<saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">user@example.org</saml:NameID></saml:Subject>';
-        $this->assertContains($expected, $requestAsXML);
+        $this->assertStringContainsString($expected, $requestAsXML);
     }
 
 


### PR DESCRIPTION
Since we require PHP 7.2, we can now also move to PhpUnit 8.

Only some deprecation warnings needed attention.