### PR TITLE
Improve exception messages

### DIFF
--- a/src/SAML2/Assertion/Processor.php
+++ b/src/SAML2/Assertion/Processor.php
@@ -116,7 +116,9 @@ class Processor
             $this->logger->info(sprintf('Verifying signature of Assertion with id "%s"', $assertion->getId()));
 
             if (!$this->signatureValidator->hasValidSignature($assertion, $this->identityProviderConfiguration)) {
-                throw new InvalidSignatureException();
+                throw new InvalidSignatureException(
+                    sprintf('The assertion with id "%s" does not have a valid signature', $assertion->getId())
+                );
             }
         }
 
@@ -135,7 +137,7 @@ class Processor
     private function decryptAssertion($assertion) : Assertion
     {
         if ($this->decrypter->isEncryptionRequired() && $assertion instanceof Assertion) {
-            throw new UnencryptedAssertionFoundException();
+            throw new UnencryptedAssertionFoundException('The assertion should be encrypted, but it was not');
         }
 
         if ($assertion instanceof Assertion) {

--- a/src/SAML2/Binding.php
+++ b/src/SAML2/Binding.php
@@ -104,7 +104,7 @@ abstract class Binding
             $logger->warning('Content-Type: '.var_export($_SERVER['CONTENT_TYPE'], true));
         }
 
-        throw new \Exception('Unable to find the current binding.');
+        throw new \Exception('Unable to find the SAML 2 binding used for this request.');
     }
 
 

--- a/src/SAML2/Response/Processor.php
+++ b/src/SAML2/Response/Processor.php
@@ -134,7 +134,9 @@ class Processor
         $this->responseIsSigned = true;
 
         if (!$this->signatureValidator->hasValidSignature($response, $identityProviderConfiguration)) {
-            throw new InvalidResponseException();
+            throw new InvalidResponseException(
+                sprintf('The SAMLResponse with id "%s", does not have a valid signature', $response->getId())
+            );
         }
     }
 


### PR DESCRIPTION
I attempted to improve missing or unclear exception messages. My assumption that the SAML2 library contained hard to grasp exceptions was not valid at all. Most messages are very clear. It might depend on the way you use the library, how much sense the message makes in the context you are using it in, but that should be fixed by the implementor and not us.