### PR TITLE
Add mailto:-prefix in EmailAddress property, if missing.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# Editor configuration normalization
+# @see http://editorconfig.org/
+
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/src/SAML2/XML/md/ContactPerson.php
+++ b/src/SAML2/XML/md/ContactPerson.php
@@ -266,7 +266,7 @@ class ContactPerson
      */
     private function removeEmailMailtoPrefix(string $emailAddress): string
     {
-        return substr(strtolower($emailAddress),0,7) === 'mailto:' ? substr($emailAddress,7) : $emailAddress;
+        return preg_replace('/^mailto:/i', '', $emailAddress);
     }
 
     /**
@@ -277,7 +277,7 @@ class ContactPerson
      */
     public function setEmailAddress(array $emailAddress): void
     {
-        $this->EmailAddress = array_map([$this,'removeEmailMailtoPrefix'], $emailAddress);
+        $this->EmailAddress = array_map([$this, 'removeEmailMailtoPrefix'], $emailAddress);
     }
 
     /**
@@ -433,8 +433,9 @@ class ContactPerson
             Utils::addString($e, Constants::NS_MD, 'md:SurName', $this->SurName);
         }
         if (!empty($this->EmailAddress)) {
-            Utils::addStrings($e, Constants::NS_MD, 'md:EmailAddress', false,
-                array_map(function(string $email) { return "mailto:$email"; }, $this->EmailAddress));
+            /** @var array $addresses */
+            $addresses = preg_filter('/^/', 'mailto:', $this->EmailAddress);
+            Utils::addStrings($e, Constants::NS_MD, 'md:EmailAddress', false, $addresses);
         }
         if (!empty($this->TelephoneNumber)) {
             Utils::addStrings($e, Constants::NS_MD, 'md:TelephoneNumber', false, $this->TelephoneNumber);

--- a/src/SAML2/XML/md/ContactPerson.php
+++ b/src/SAML2/XML/md/ContactPerson.php
@@ -248,9 +248,8 @@ class ContactPerson
         $this->SurName = $surName;
     }
 
-
     /**
-     * Collect the value of the EmailAddress-property
+     * Collect the value of the EmailAddress-property.
      *
      * @return string[]
      */
@@ -259,6 +258,16 @@ class ContactPerson
         return $this->EmailAddress;
     }
 
+    /**
+     * Remove a "mailto:" prefix on an emailaddress, if present.
+     *
+     * @param string $emailAddress
+     * @return string
+     */
+    private function removeEmailMailtoPrefix(string $emailAddress): string
+    {
+        return substr(strtolower($emailAddress),0,7) === 'mailto:' ? substr($emailAddress,7) : $emailAddress;
+    }
 
     /**
      * Set the value of the EmailAddress-property
@@ -268,9 +277,8 @@ class ContactPerson
      */
     public function setEmailAddress(array $emailAddress): void
     {
-        $this->EmailAddress = $emailAddress;
+        $this->EmailAddress = array_map([$this,'removeEmailMailtoPrefix'], $emailAddress);
     }
-
 
     /**
      * Add the value to the EmailAddress-property
@@ -278,11 +286,10 @@ class ContactPerson
      * @param string $emailAddress
      * @return void
      */
-    public function addEmailAddress($emailAddress): void
+    public function addEmailAddress(string $emailAddress): void
     {
-        $this->EmailAddress[] = $emailAddress;
+        $this->EmailAddress[] = $this->removeEmailMailtoPrefix($emailAddress);
     }
-
 
     /**
      * Collect the value of the TelephoneNumber-property
@@ -426,7 +433,8 @@ class ContactPerson
             Utils::addString($e, Constants::NS_MD, 'md:SurName', $this->SurName);
         }
         if (!empty($this->EmailAddress)) {
-            Utils::addStrings($e, Constants::NS_MD, 'md:EmailAddress', false, $this->EmailAddress);
+            Utils::addStrings($e, Constants::NS_MD, 'md:EmailAddress', false,
+                array_map(function(string $email) { return "mailto:$email"; }, $this->EmailAddress));
         }
         if (!empty($this->TelephoneNumber)) {
             Utils::addStrings($e, Constants::NS_MD, 'md:TelephoneNumber', false, $this->TelephoneNumber);

--- a/tests/SAML2/XML/md/ContactPersonTest.php
+++ b/tests/SAML2/XML/md/ContactPersonTest.php
@@ -15,6 +15,8 @@ use SAML2\Utils;
 class ContactPersonTest extends \PHPUnit\Framework\TestCase
 {
     /**
+     * Basic tests to set up a contactperson
+     *
      * @return void
      */
     public function testContactPerson(): void
@@ -23,7 +25,7 @@ class ContactPersonTest extends \PHPUnit\Framework\TestCase
         $Company = "Test Company";
         $GivenName = "John";
         $SurName = "Doe";
-        $EmailAddress = ['jdoe@test.company', 'john.doe@test.company'];
+        $EmailAddress = ['jdoe@test.company', 'mailto:john.doe@test.company'];
         $TelephoneNumber = ['1-234-567-8901'];
         $ContactPersonAttributes = ['testattr' => 'testval', 'testattr2' => 'testval2'];
 
@@ -53,7 +55,10 @@ XML
 
         $this->assertEquals(count($EmailAddress), $contactPersonElement->getElementsByTagName('EmailAddress')->length);
         foreach ($contactPersonElement->getElementsByTagName('EmailAddress') as $element) {
-            $this->assertTrue(in_array($element->nodeValue, $EmailAddress));
+            $this->assertTrue(
+                in_array($element->nodeValue, $EmailAddress) ||
+                in_array(preg_replace('/^mailto:/', '', $element->nodeValue), $EmailAddress)
+            );
         }
 
         $this->assertEquals(
@@ -65,6 +70,71 @@ XML
         }
 
         foreach ($ContactPersonAttributes as $attr => $val) {
+            $this->assertEquals($val, $contactPersonElement->getAttribute($attr));
+        }
+    }
+
+    /**
+     * Test more methods inside ContactPerson
+     *
+     * @return void
+     */
+    public function testContactPersonExtraMethods(): void
+    {
+        $contactType = "administrative";
+        $Company = "Test Company";
+        $GivenName = "John";
+        $SurName = "Doe";
+        $EmailAddress = ['jdoe@test.company', 'mailto:john.doe@test.company'];
+        $AnotherEmail = 'john@doe.xyz';
+        $TelephoneNumber = ['1-234-567-8901'];
+        $MoreTelephoneNumber = '+31-887874000';
+        $ContactPersonAttributes = ['testattr' => 'testval', 'testattr2' => 'testval2'];
+        $ExtraAttribute = ['another' => 'this'];
+
+        $mdNamespace = Constants::NS_MD;
+        $document = DOMDocumentFactory::fromString(<<<XML
+<md:Test xmlns:md="{$mdNamespace}" Binding="urn:something" Location="https://whatever/" xmlns:test="urn:test" test:attr="value">
+</md:Test>
+XML
+        );
+        $contactPerson = new ContactPerson();
+        $contactPerson->setContactType($contactType);
+        $contactPerson->setCompany($Company);
+        $contactPerson->setGivenName($GivenName);
+        $contactPerson->setSurName($SurName);
+        $contactPerson->setEmailAddress($EmailAddress);
+        $contactPerson->setTelephoneNumber($TelephoneNumber);
+        $contactPerson->setContactPersonAttributes($ContactPersonAttributes);
+
+        $contactPerson->addEmailAddress($AnotherEmail);
+        $contactPerson->addTelephoneNumber($MoreTelephoneNumber);
+        $contactPerson->addContactPersonAttributes(key($ExtraAttribute), array_pop($ExtraAttribute));
+
+        $contactPerson->toXML($document->firstChild);
+
+        $contactPersonElement = $document->getElementsByTagName('ContactPerson')->item(0);
+
+        $this->assertEquals(count($EmailAddress) + 1, $contactPersonElement->getElementsByTagName('EmailAddress')->length);
+        foreach ($contactPersonElement->getElementsByTagName('EmailAddress') as $element) {
+            $this->assertTrue(
+                in_array($element->nodeValue, $EmailAddress) ||
+                in_array(preg_replace('/^mailto:/', '', $element->nodeValue), $EmailAddress) ||
+                preg_replace('/^mailto:/', '', $element->nodeValue) === $AnotherEmail
+            );
+        }
+
+        $this->assertEquals(
+            count($TelephoneNumber) + 1,
+            $contactPersonElement->getElementsByTagName('TelephoneNumber')->length
+        );
+        foreach ($contactPersonElement->getElementsByTagName('TelephoneNumber') as $element) {
+            $this->assertTrue(in_array($element->nodeValue, $TelephoneNumber) ||
+                $element->nodeValue === $MoreTelephoneNumber
+            );
+        }
+
+        foreach ($ContactPersonAttributes + $ExtraAttribute as $attr => $val) {
             $this->assertEquals($val, $contactPersonElement->getAttribute($attr));
         }
     }
@@ -83,7 +153,7 @@ XML
         <md:Company>Test Company</md:Company>
         <md:GivenName>John</md:GivenName>
         <md:SurName>Doe</md:SurName>
-        <md:EmailAddress>jdoe@test.company</md:EmailAddress>
+        <md:EmailAddress>mailto:jdoe@test.company</md:EmailAddress>
         <md:EmailAddress>john.doe@test.company</md:EmailAddress>
         <md:TelephoneNumber>1-234-567-8901</md:TelephoneNumber>
     </md:ContactPerson>
@@ -96,6 +166,7 @@ XML
         $this->assertEquals('Test Company', $contactPerson->getCompany());
         $this->assertEquals('John', $contactPerson->getGivenName());
         $this->assertEquals('Doe', $contactPerson->getSurName());
+        $this->assertEquals('other', $contactPerson->getContactType());
         $this->assertTrue(in_array('jdoe@test.company', $contactPerson->getEmailAddress()));
         $this->assertTrue(in_array('john.doe@test.company', $contactPerson->getEmailAddress()));
         $this->assertTrue(in_array('1-234-567-8901', $contactPerson->getTelephoneNumber()));
@@ -118,8 +189,8 @@ XML
         <md:GivenName>John</md:GivenName>
         <md:GivenName>Jonathon</md:GivenName>
         <md:SurName>Doe</md:SurName>
-        <md:EmailAddress>jdoe@test.company</md:EmailAddress>
-        <md:EmailAddress>john.doe@test.company</md:EmailAddress>
+        <md:EmailAddress>mailto:jdoe@test.company</md:EmailAddress>
+        <md:EmailAddress>mailto:john.doe@test.company</md:EmailAddress>
         <md:TelephoneNumber>1-234-567-8901</md:TelephoneNumber>
     </md:ContactPerson>
 </md:Test>
@@ -144,8 +215,8 @@ XML
     <md:ContactPerson contactType="other">
         <md:Company>Test Company</md:Company>
         <md:GivenName>John</md:GivenName>
-        <md:EmailAddress>jdoe@test.company</md:EmailAddress>
-        <md:EmailAddress>john.doe@test.company</md:EmailAddress>
+        <md:EmailAddress>mailto:jdoe@test.company</md:EmailAddress>
+        <md:EmailAddress>mailto:john.doe@test.company</md:EmailAddress>
         <md:TelephoneNumber>1-234-567-8901</md:TelephoneNumber>
     </md:ContactPerson>
 </md:Test>


### PR DESCRIPTION
This is mandatory in the spec. It seems the role of the library to
add it, so users can continue to supply and receive bare email
addresses. The code is defensive in that it will also accept
incoming EmailAddress values that already sport the mailto:-prefix.

Also improve code coverage of ContactPerson