### PR TITLE
Fix Attribute + SubjectConfirmationData

### DIFF
--- a/src/SAML2/XML/ExtendableAttributesTrait.php
+++ b/src/SAML2/XML/ExtendableAttributesTrait.php
@@ -122,6 +122,7 @@ trait ExtendableAttributesTrait
 
         foreach ($attributes as $attribute) {
             Assert::stringNotEmpty($attribute->namespaceURI, 'Arbitrary XML attributes must be namespaced.');
+
             /** @psalm-suppress PossiblyNullArgument */
             $this->setAttributeNS($attribute->namespaceURI, $attribute->nodeName, $attribute->value);
         }

--- a/src/SAML2/XML/md/ContactPerson.php
+++ b/src/SAML2/XML/md/ContactPerson.php
@@ -21,9 +21,7 @@ use Webmozart\Assert\Assert;
 final class ContactPerson extends AbstractMdElement
 {
     use ExtendableElementTrait;
-    use ExtendableAttributesTrait {
-        ExtendableAttributesTrait::setAttributesNS as setAttributesNSConflict;
-    }
+    use ExtendableAttributesTrait;
 
     /**
      * The contact type.

--- a/src/SAML2/XML/saml/Assertion.php
+++ b/src/SAML2/XML/saml/Assertion.php
@@ -7,6 +7,7 @@ namespace SAML2\XML\saml;
 use DOMElement;
 use DOMNode;
 use DOMNodeList;
+use Exception;
 use RobRichards\XMLSecLibs\XMLSecEnc;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\Constants;
@@ -261,13 +262,13 @@ class Assertion implements SignedElementInterface
         }
 
         if (!$xml->hasAttribute('ID')) {
-            throw new \Exception('Missing ID attribute on SAML assertion.');
+            throw new Exception('Missing ID attribute on SAML assertion.');
         }
         $this->id = $xml->getAttribute('ID');
 
         if ($xml->getAttribute('Version') !== '2.0') {
             /* Currently a very strict check. */
-            throw new \Exception('Unsupported version: ' . $xml->getAttribute('Version'));
+            throw new Exception('Unsupported version: ' . $xml->getAttribute('Version'));
         }
 
         $this->issueInstant = Utils::xsDateTimeToTimestamp($xml->getAttribute('IssueInstant'));
@@ -275,7 +276,7 @@ class Assertion implements SignedElementInterface
         /** @var \DOMElement[] $issuer */
         $issuer = Utils::xpQuery($xml, './saml_assertion:Issuer');
         if (empty($issuer)) {
-            throw new \Exception('Missing <saml:Issuer> in assertion.');
+            throw new Exception('Missing <saml:Issuer> in assertion.');
         }
 
         $this->issuer = Issuer::fromXML($issuer[0]);
@@ -305,7 +306,7 @@ class Assertion implements SignedElementInterface
 
             return;
         } elseif (count($subject) > 1) {
-            throw new \Exception('More than one <saml:Subject> in <saml:Assertion>.');
+            throw new Exception('More than one <saml:Subject> in <saml:Assertion>.');
         }
         $subject = $subject[0];
 
@@ -315,7 +316,7 @@ class Assertion implements SignedElementInterface
             './saml_assertion:NameID | ./saml_assertion:EncryptedID/xenc:EncryptedData'
         );
         if (count($nameId) > 1) {
-            throw new \Exception('More than one <saml:NameID> or <saml:EncryptedID> in <saml:Subject>.');
+            throw new Exception('More than one <saml:NameID> or <saml:EncryptedID> in <saml:Subject>.');
         } elseif (!empty($nameId)) {
             $nameId = $nameId[0];
             if ($nameId->localName === 'EncryptedData') {
@@ -329,7 +330,7 @@ class Assertion implements SignedElementInterface
         /** @var \DOMElement[] $subjectConfirmation */
         $subjectConfirmation = Utils::xpQuery($subject, './saml_assertion:SubjectConfirmation');
         if (empty($subjectConfirmation) && empty($nameId)) {
-            throw new \Exception('Missing <saml:SubjectConfirmation> in <saml:Subject>.');
+            throw new Exception('Missing <saml:SubjectConfirmation> in <saml:Subject>.');
         }
 
         foreach ($subjectConfirmation as $sc) {
@@ -354,7 +355,7 @@ class Assertion implements SignedElementInterface
 
             return;
         } elseif (count($conditions) > 1) {
-            throw new \Exception('More than one <saml:Conditions> in <saml:Assertion>.');
+            throw new Exception('More than one <saml:Conditions> in <saml:Assertion>.');
         }
         $conditions = $conditions[0];
 
@@ -376,7 +377,7 @@ class Assertion implements SignedElementInterface
                 continue;
             }
             if ($node->namespaceURI !== Constants::NS_SAML) {
-                throw new \Exception('Unknown namespace of condition: ' . var_export($node->namespaceURI, true));
+                throw new Exception('Unknown namespace of condition: ' . var_export($node->namespaceURI, true));
             }
             switch ($node->localName) {
                 case 'AudienceRestriction':
@@ -399,7 +400,7 @@ class Assertion implements SignedElementInterface
                     /* Currently ignored. */
                     break;
                 default:
-                    throw new \Exception('Unknown condition: ' . var_export($node->localName, true));
+                    throw new Exception('Unknown condition: ' . var_export($node->localName, true));
             }
         }
     }
@@ -421,12 +422,12 @@ class Assertion implements SignedElementInterface
 
             return;
         } elseif (count($authnStatements) > 1) {
-            throw new \Exception('More than one <saml:AuthnStatement> in <saml:Assertion> not supported.');
+            throw new Exception('More than one <saml:AuthnStatement> in <saml:Assertion> not supported.');
         }
         $authnStatement = $authnStatements[0];
 
         if (!$authnStatement->hasAttribute('AuthnInstant')) {
-            throw new \Exception('Missing required AuthnInstant attribute on <saml:AuthnStatement>.');
+            throw new Exception('Missing required AuthnInstant attribute on <saml:AuthnStatement>.');
         }
         $this->authnInstant = Utils::xsDateTimeToTimestamp($authnStatement->getAttribute('AuthnInstant'));
 
@@ -457,9 +458,9 @@ class Assertion implements SignedElementInterface
         /** @var \DOMElement[] $authnContexts */
         $authnContexts = Utils::xpQuery($authnStatementEl, './saml_assertion:AuthnContext');
         if (count($authnContexts) > 1) {
-            throw new \Exception('More than one <saml:AuthnContext> in <saml:AuthnStatement>.');
+            throw new Exception('More than one <saml:AuthnContext> in <saml:AuthnStatement>.');
         } elseif (empty($authnContexts)) {
-            throw new \Exception('Missing required <saml:AuthnContext> in <saml:AuthnStatement>.');
+            throw new Exception('Missing required <saml:AuthnContext> in <saml:AuthnStatement>.');
         }
         $authnContextEl = $authnContexts[0];
 
@@ -467,7 +468,7 @@ class Assertion implements SignedElementInterface
         /** @var \DOMElement[] $authnContextDeclRefs */
         $authnContextDeclRefs = Utils::xpQuery($authnContextEl, './saml_assertion:AuthnContextDeclRef');
         if (count($authnContextDeclRefs) > 1) {
-            throw new \Exception(
+            throw new Exception(
                 'More than one <saml:AuthnContextDeclRef> found?'
             );
         } elseif (count($authnContextDeclRefs) === 1) {
@@ -478,7 +479,7 @@ class Assertion implements SignedElementInterface
         /** @var \DOMElement[] $authnContextDecls */
         $authnContextDecls = Utils::xpQuery($authnContextEl, './saml_assertion:AuthnContextDecl');
         if (count($authnContextDecls) > 1) {
-            throw new \Exception(
+            throw new Exception(
                 'More than one <saml:AuthnContextDecl> found?'
             );
         } elseif (count($authnContextDecls) === 1) {
@@ -489,14 +490,14 @@ class Assertion implements SignedElementInterface
         /** @var \DOMElement[] $authnContextClassRefs */
         $authnContextClassRefs = Utils::xpQuery($authnContextEl, './saml_assertion:AuthnContextClassRef');
         if (count($authnContextClassRefs) > 1) {
-            throw new \Exception('More than one <saml:AuthnContextClassRef> in <saml:AuthnContext>.');
+            throw new Exception('More than one <saml:AuthnContextClassRef> in <saml:AuthnContext>.');
         } elseif (count($authnContextClassRefs) === 1) {
             $this->setAuthnContextClassRef(trim($authnContextClassRefs[0]->textContent));
         }
 
         // Constraint from XSD: MUST have one of the three
         if (empty($this->authnContextClassRef) && empty($this->authnContextDecl) && empty($this->authnContextDeclRef)) {
-            throw new \Exception(
+            throw new Exception(
                 'Missing either <saml:AuthnContextClassRef> or <saml:AuthnContextDeclRef> or <saml:AuthnContextDecl>'
             );
         }
@@ -523,7 +524,7 @@ class Assertion implements SignedElementInterface
         $attributes = Utils::xpQuery($xml, './saml_assertion:AttributeStatement/saml_assertion:Attribute');
         foreach ($attributes as $attribute) {
             if (!$attribute->hasAttribute('Name')) {
-                throw new \Exception('Missing name on <saml:Attribute> element.');
+                throw new Exception('Missing name on <saml:Attribute> element.');
             }
             $name = $attribute->getAttribute('Name');
 
@@ -887,7 +888,7 @@ class Assertion implements SignedElementInterface
             );
 
             if (!$attribute->hasAttribute('Name')) {
-                throw new \Exception('Missing name on <saml:Attribute> element.');
+                throw new Exception('Missing name on <saml:Attribute> element.');
             }
             $name = $attribute->getAttribute('Name');
 
@@ -1160,7 +1161,7 @@ class Assertion implements SignedElementInterface
     public function setAuthnContextDecl(Chunk $authnContextDecl): void
     {
         if (!empty($this->authnContextDeclRef)) {
-            throw new \Exception(
+            throw new Exception(
                 'AuthnContextDeclRef is already registered! May only have either a Decl or a DeclRef, not both!'
             );
         }
@@ -1193,7 +1194,7 @@ class Assertion implements SignedElementInterface
     public function setAuthnContextDeclRef(string $authnContextDeclRef = null): void
     {
         if (!empty($this->authnContextDecl)) {
-            throw new \Exception(
+            throw new Exception(
                 'AuthnContextDecl is already registered! May only have either a Decl or a DeclRef, not both!'
             );
         }
@@ -1436,12 +1437,12 @@ class Assertion implements SignedElementInterface
     /**
      * Convert this assertion to an XML element.
      *
-     * @param  \DOMNode|null $parentElement The DOM node the assertion should be created in.
+     * @param  \DOMElement|null $parentElement The DOM node the assertion should be created in.
      * @return \DOMElement   This assertion.
      *
      * @throws \InvalidArgumentException if assertions are false
      */
-    public function toXML(\DOMNode $parentElement = null): DOMElement
+    public function toXML(DOMElement $parentElement = null): DOMElement
     {
         Assert::notEmpty($this->issuer, 'Cannot convert Assertion to XML without an Issuer set.');
 

--- a/src/SAML2/XML/saml/Attribute.php
+++ b/src/SAML2/XML/saml/Attribute.php
@@ -7,6 +7,7 @@ namespace SAML2\XML\saml;
 use DOMElement;
 use Exception;
 use SAML2\Constants;
+use SAML2\XML\ExtendableAttributesTrait;
 use Webmozart\Assert\Assert;
 
 /**
@@ -16,6 +17,8 @@ use Webmozart\Assert\Assert;
  */
 class Attribute extends AbstractSamlElement
 {
+    use ExtendableAttributesTrait;
+
     /**
      * The Name of this attribute.
      *
@@ -54,17 +57,20 @@ class Attribute extends AbstractSamlElement
      * @param string|null $NameFormat
      * @param string|null $FriendlyName
      * @param \SAML2\XML\saml\AttributeValue[] $AttributeValues
+     * @param \DOMAttr[] $namespacedAttributes
      */
     public function __construct(
         string $Name,
         ?string $NameFormat = null,
         ?string $FriendlyName = null,
-        array $AttributeValues = []
+        array $AttributeValues = [],
+        array $namespacedAttributes = []
     ) {
         $this->setName($Name);
         $this->setNameFormat($NameFormat);
         $this->setFriendlyName($FriendlyName);
         $this->setAttributeValues($AttributeValues);
+        $this->setAttributesNS($namespacedAttributes);
     }
 
 
@@ -185,7 +191,8 @@ class Attribute extends AbstractSamlElement
             $name,
             self::getAttribute($xml, 'NameFormat', null),
             self::getAttribute($xml, 'FriendlyName', null),
-            AttributeValue::getChildrenOfClass($xml)
+            AttributeValue::getChildrenOfClass($xml),
+            self::getAttributesNSFromXML($xml)
         );
     }
 
@@ -207,6 +214,10 @@ class Attribute extends AbstractSamlElement
 
         if ($this->FriendlyName !== null) {
             $e->setAttribute('FriendlyName', $this->FriendlyName);
+        }
+
+        foreach ($this->getAttributesNS() as $attr) {
+            $e->setAttributeNS($attr['namespaceURI'], $attr['qualifiedName'], $attr['value']);
         }
 
         foreach ($this->AttributeValues as $av) {

--- a/src/SAML2/XML/saml/SubjectConfirmationData.php
+++ b/src/SAML2/XML/saml/SubjectConfirmationData.php
@@ -10,6 +10,7 @@ use SAML2\Constants;
 use SAML2\Utils;
 use SAML2\XML\Chunk;
 use SAML2\XML\ds\KeyInfo;
+use SAML2\XML\ExtendableAttributesTrait;
 use Webmozart\Assert\Assert;
 
 /**
@@ -19,6 +20,8 @@ use Webmozart\Assert\Assert;
  */
 final class SubjectConfirmationData extends AbstractSamlElement
 {
+    use ExtendableAttributesTrait;
+
     /**
      * The time before this element is valid, as an unix timestamp.
      *
@@ -74,6 +77,7 @@ final class SubjectConfirmationData extends AbstractSamlElement
      * @param string|null $inResponseTo
      * @param string|null $address
      * @param (\SAML2\XML\ds\KeyInfo|\SAML2\XML\Chunk)[] $info
+     * @param \DOMAttr[] $namespacedAttributes
      */
     public function __construct(
         ?int $notBefore = null,
@@ -81,7 +85,8 @@ final class SubjectConfirmationData extends AbstractSamlElement
         ?string $recipient = null,
         ?string $inResponseTo = null,
         ?string $address = null,
-        array $info = []
+        array $info = [],
+        array $namespacedAttributes = []
     ) {
         $this->setNotBefore($notBefore);
         $this->setNotOnOrAfter($notOnOrAfter);
@@ -89,6 +94,7 @@ final class SubjectConfirmationData extends AbstractSamlElement
         $this->setInResponseTo($inResponseTo);
         $this->setAddress($address);
         $this->setInfo($info);
+        $this->setAttributesNS($namespacedAttributes);
     }
 
 
@@ -264,6 +270,7 @@ final class SubjectConfirmationData extends AbstractSamlElement
             && empty($this->InResponseTo)
             && empty($this->Address)
             && empty($this->info)
+            && empty($this->namespacedAttributes)
         );
     }
 
@@ -317,7 +324,8 @@ final class SubjectConfirmationData extends AbstractSamlElement
             $Recipient,
             $InResponseTo,
             $Address,
-            $info
+            $info,
+            self::getAttributesNSFromXML($xml)
         );
     }
 
@@ -346,6 +354,10 @@ final class SubjectConfirmationData extends AbstractSamlElement
         }
         if ($this->Address !== null) {
             $e->setAttribute('Address', $this->Address);
+        }
+
+        foreach ($this->getAttributesNS() as $attr) {
+            $e->setAttributeNS($attr['namespaceURI'], $attr['qualifiedName'], $attr['value']);
         }
 
         foreach ($this->info as $n) {

--- a/tests/SAML2/XML/saml/AttributeTest.php
+++ b/tests/SAML2/XML/saml/AttributeTest.php
@@ -25,7 +25,7 @@ final class AttributeTest extends TestCase
     {
         $samlNamespace = Constants::NS_SAML;
         $this->document = DOMDocumentFactory::fromString(<<<XML
-<saml:Attribute xmlns:saml="{$samlNamespace}" Name="TheName" NameFormat="TheNameFormat" FriendlyName="TheFriendlyName">
+<saml:Attribute xmlns:saml="{$samlNamespace}" Name="TheName" NameFormat="TheNameFormat" FriendlyName="TheFriendlyName" test:attr1="testval1" test:attr2="testval2" xmlns:test="urn:test">
   <saml:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xsi:type="xs:string">FirstValue</saml:AttributeValue>
   <saml:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xsi:type="xs:string">SecondValue</saml:AttributeValue>
 </saml:Attribute>
@@ -42,6 +42,11 @@ XML
      */
     public function testMarshalling(): void
     {
+        $attr1 = $this->document->createAttributeNS('urn:test', 'test:attr1');
+        $attr1->value = 'testval1';
+        $attr2 = $this->document->createAttributeNS('urn:test', 'test:attr2');
+        $attr2->value = 'testval2';
+
         $attribute = new Attribute(
             'TheName',
             'TheNameFormat',
@@ -49,12 +54,16 @@ XML
             [
                 new AttributeValue('FirstValue'),
                 new AttributeValue('SecondValue')
-            ]
+            ],
+            [$attr1, $attr2]
         );
 
         $this->assertEquals('TheName', $attribute->getName());
         $this->assertEquals('TheNameFormat', $attribute->getNameFormat());
         $this->assertEquals('TheFriendlyName', $attribute->getFriendlyName());
+
+        $this->assertEquals('testval1', $attribute->getAttributeNS('urn:test', 'attr1'));
+        $this->assertEquals('testval2', $attribute->getAttributeNS('urn:test', 'attr2'));
 
         $values = $attribute->getAttributeValues();
         $this->assertCount(2, $values);
@@ -84,6 +93,24 @@ XML
         $this->assertCount(2, $attribute->getAttributeValues());
         $this->assertEquals('FirstValue', $attribute->getAttributeValues()[0]->getString());
         $this->assertEquals('SecondValue', $attribute->getAttributeValues()[1]->getString());
+
+        $this->assertEquals(
+            [
+                '{urn:test}attr1' => [
+                    'qualifiedName' => 'test:attr1',
+                    'namespaceURI' => 'urn:test',
+                    'value' => 'testval1'
+                ],
+                '{urn:test}attr2' => [
+                    'qualifiedName' => 'test:attr2',
+                    'namespaceURI' => 'urn:test',
+                    'value' => 'testval2'
+                ]
+            ],
+            $attribute->getAttributesNS()
+        );
+        $this->assertEquals('testval1', $attribute->getAttributeNS('urn:test', 'attr1'));
+        $this->assertEquals('testval2', $attribute->getAttributeNS('urn:test', 'attr2'));
     }
 
 


### PR DESCRIPTION
According to the specs these elements can contain
`<anyAttribute namespace="##other" processContents="lax"/>`