### PR TITLE
Make processor aware of assertion types

### DIFF
--- a/src/SAML2/Assertion/Processor.php
+++ b/src/SAML2/Assertion/Processor.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace SAML2\Assertion;
 
 use Psr\Log\LoggerInterface;
-
 use SAML2\Assertion;
 use SAML2\Assertion\Exception\InvalidAssertionException;
 use SAML2\Assertion\Exception\InvalidSubjectConfirmationException;
@@ -15,7 +14,6 @@ use SAML2\Assertion\Validation\SubjectConfirmationValidator;
 use SAML2\Configuration\IdentityProvider;
 use SAML2\EncryptedAssertion;
 use SAML2\Response\Exception\InvalidSignatureException;
-use SAML2\Response\Exception\UnencryptedAssertionFoundException;
 use SAML2\Signature\Validator;
 use SAML2\Utilities\ArrayCollection;
 
@@ -95,7 +93,13 @@ class Processor
     {
         $decrypted = new ArrayCollection();
         foreach ($assertions->getIterator() as $assertion) {
-            $decrypted->add($this->decryptAssertion($assertion));
+            if ($assertion instanceof EncryptedAssertion) {
+                $decrypted->add($this->decryptAssertion($assertion));
+            } elseif ($assertion instanceof Assertion) {
+                $decrypted->add($assertion);
+            } else {
+                throw new InvalidAssertionException('The assertion must be of type: EncryptedAssertion or Assertion');
+            }
         }
 
         return $decrypted;

--- a/tests/SAML2/Assertion/ProcessorTest.php
+++ b/tests/SAML2/Assertion/ProcessorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SAML2\Assertion;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class ProcessorTest extends MockeryTestCase
+{
+    /**
+     * @var Processor
+     */
+    private $processor;
+
+    /**
+     * @var m\MockInterface&Decrypter
+     */
+    private $decrypter;
+
+    protected function setUp(): void
+    {
+        $this->decrypter = m::mock(Decrypter::class);
+        $validator = m::mock(\SAML2\Signature\Validator::class);
+        $assertionValidator = m::mock(\SAML2\Assertion\Validation\AssertionValidator::class);
+        $subjectConfirmationValidator = m::mock(\SAML2\Assertion\Validation\SubjectConfirmationValidator::class);
+        $transformer = m::mock(\SAML2\Assertion\Transformer\Transformer::class);
+        $identityProvider = new \SAML2\Configuration\IdentityProvider([]);
+        $logger = m::mock(\Psr\Log\LoggerInterface::class);
+
+        $this->processor = new Processor(
+            $this->decrypter,
+            $validator,
+            $assertionValidator,
+            $subjectConfirmationValidator,
+            $transformer,
+            $identityProvider,
+            $logger
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function processor_correctly_encrypts_assertions(): void
+    {
+        $testData = [
+            [new \SAML2\Assertion()],
+            [new \SAML2\EncryptedAssertion()],
+            [new \SAML2\Assertion(), new \SAML2\EncryptedAssertion(), new \SAML2\Assertion()],
+            [new \SAML2\EncryptedAssertion(), new \SAML2\EncryptedAssertion(), new \SAML2\EncryptedAssertion()],
+        ];
+
+        foreach ($testData as $assertions) {
+            $this->decrypter
+                ->shouldReceive('decrypt')
+                ->andReturn(new \SAML2\Assertion());
+
+            $collection = new \SAML2\Utilities\ArrayCollection($assertions);
+            $result = $this->processor->decryptAssertions($collection);
+            self::assertInstanceOf(\SAML2\Utilities\ArrayCollection::class, $result);
+            foreach ($result as $assertion) {
+                self::assertInstanceOf(\SAML2\Assertion::class, $assertion);
+            }
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function unsuported_assertions_are_rejected(): void
+    {
+        $this->expectException('\SAML2\Assertion\Exception\InvalidAssertionException');
+        $this->expectExceptionMessage('The assertion must be of type: EncryptedAssertion or Assertion');
+        $this->processor->decryptAssertions(new \SAML2\Utilities\ArrayCollection([new \stdClass()]));
+    }
+}


### PR DESCRIPTION
Both the Encrypted and regular Assertion classes should be passable in the decryptAssertion method. If not, you would never be able to process a SAML Response consisting of regular Assertion objects.

The test merely verifies the behavior that was changed in this commit. No additional processor tests where added. But that should be simple enough in the future.