### PR TITLE
Support ECP from Microsoft

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -64,7 +64,7 @@ jobs:
         uses: allenevans/set-env@v1.0.0
         if: ${{ matrix.php-versions != '7.4' || matrix.operating-system != 'ubuntu-latest' }}
         with:
-          NO_COVERAGE: "--no-coverage"
+          echo "NO_COVERAGE=--no-coverage" >> $GITHUB_ENV
 
       - name: Run unit tests
         run: |

--- a/src/SAML2/Binding.php
+++ b/src/SAML2/Binding.php
@@ -87,7 +87,7 @@ abstract class Binding
                     return new HTTPPost();
                 } elseif (array_key_exists('SAMLart', $_POST)) {
                     return new HTTPArtifact();
-                } elseif ($contentType === 'text/xml') {
+                } elseif ($contentType === 'text/xml' || $contentType === 'application/soap+xml') {
                     return new SOAP();
                 }
                 break;


### PR DESCRIPTION
Add content type application/soap+xml for SOAP requests (ECP).

In our setup, Microsoft sends ECP requests with Content-type: "application/soap+xml". SimpleSAMLphp does not recognize them as SOAP requests.

There was actually a commit e5bfe333eb3bbcf295d13215ff7e9594181c642e for PR #48 which added this, but the PR was closed an replaced by #96, which did not include this content type.