### PR TITLE
trim decrypted xml to avoid exception

### DIFF
--- a/src/SAML2/Utils.php
+++ b/src/SAML2/Utils.php
@@ -496,7 +496,7 @@ class Utils
          */
         $xml = '<root xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" '.
                         'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'.
-            $decrypted.
+            trim($decrypted).
             '</root>';
 
         try {


### PR DESCRIPTION


when the assertion xml is start with a "\n",  $newDoc->firstChild->firstChild got a DOMText but not DOMElement, trim xml will fix this