### PR TITLE
Call Utils/HTTP non-statically.

### DIFF
--- a/src/SAML2/Compat/Ssp/Container.php
+++ b/src/SAML2/Compat/Ssp/Container.php
@@ -19,6 +19,25 @@ class Container extends AbstractContainer
      */
     protected $logger;
 
+    /**
+     * @var \SimpleSAML\Utils\HTTP
+     */
+    protected $utilsHttp;
+
+    /**
+     * @var \SimpleSAML\Utils\Random
+     */
+    protected $utilsRandom;
+
+    /**
+     * @var \SimpleSAML\Utils\System
+     */
+    protected $utilsSystem;
+
+    /**
+     * @var \SimpleSAML\Utils\XML
+     */
+    protected $utilsXml;
 
     /**
      * Create a new SimpleSAMLphp compatible container.
@@ -26,6 +45,10 @@ class Container extends AbstractContainer
     public function __construct()
     {
         $this->logger = new Logger();
+        $this->utilsHttp = new HTTP();
+        $this->utilsRandom = new Random();
+        $this->utilsSystem = new System();
+        $this->utilsXml = new XML();
     }
 
 
@@ -45,8 +68,7 @@ class Container extends AbstractContainer
      */
     public function generateId() : string
     {
-        /** @psalm-suppress UndefinedClass */
-        return Random::generateID();
+        return $this->utilsRandom->generateID();
     }
 
 
@@ -58,8 +80,7 @@ class Container extends AbstractContainer
      */
     public function debugMessage($message, string $type) : void
     {
-        /** @psalm-suppress UndefinedClass */
-        XML::debugSAMLMessage($message, $type);
+        $this->utilsXml->debugSAMLMessage($message, $type);
     }
 
 
@@ -71,8 +92,7 @@ class Container extends AbstractContainer
      */
     public function redirect(string $url, array $data = []) : void
     {
-        /** @psalm-suppress UndefinedClass */
-        HTTP::redirectTrustedURL($url, $data);
+        $this->utilsHttp->redirectTrustedURL($url, $data);
     }
 
 
@@ -84,8 +104,7 @@ class Container extends AbstractContainer
      */
     public function postRedirect(string $url, array $data = []) : void
     {
-        /** @psalm-suppress UndefinedClass */
-        HTTP::submitPOSTData($url, $data);
+        $this->utilsHttp->submitPOSTData($url, $data);
     }
 
 
@@ -95,8 +114,7 @@ class Container extends AbstractContainer
      */
     public function getTempDir() : string
     {
-        /** @psalm-suppress UndefinedClass */
-        return System::getTempDir();
+        return $this->utilsSystem->getTempDir();
     }
 
 
@@ -112,7 +130,6 @@ class Container extends AbstractContainer
         if ($mode === null) {
             $mode = 0600;
         }
-        /** @psalm-suppress UndefinedClass */
-        System::writeFile($filename, $data, $mode);
+        $this->utilsSystem->writeFile($filename, $data, $mode);
     }
 }

--- a/src/SAML2/HTTPArtifact.php
+++ b/src/SAML2/HTTPArtifact.php
@@ -66,8 +66,8 @@ class HTTPArtifact extends Binding
         if ($destination === null) {
             throw new \Exception('Cannot get redirect URL, no destination set in the message.');
         }
-        /** @psalm-suppress UndefinedClass */
-        return HTTP::addURLparameters($destination, $params);
+        $utilsHttp = new HTTP();
+        return $this->utilsHttp->addURLparameters($destination, $params);
     }
 
 


### PR DESCRIPTION
Fixes fatal error in SSP master when starting authentication:
"Using $this when not in object context in lib/SimpleSAML/Utils/HTTP.php:985"