### PR TITLE
Throw a specific exception for unsupported binding.

### DIFF
--- a/src/SAML2/Binding.php
+++ b/src/SAML2/Binding.php
@@ -6,7 +6,7 @@ namespace SimpleSAML\SAML2;
 
 use Exception;
 use SimpleSAML\SAML2\XML\samlp\AbstractMessage;
-use SimpleSAML\SAML2\Exception\UnsupportedBindingException;
+use SimpleSAML\SAML2\Exception\Protocol\UnsupportedBindingException;
 
 use function array_key_exists;
 use function array_keys;
@@ -37,7 +37,7 @@ abstract class Binding
      * Will throw an exception if it is unable to locate the binding.
      *
      * @param string $urn The URN of the binding.
-     * @throws \SimpleSAML\SAML2\Exception\UnsupportedBindingException
+     * @throws \SimpleSAML\SAML2\Exception\Protocol\UnsupportedBindingException
      * @return \SimpleSAML\SAML2\Binding The binding.
      */
     public static function getBinding(string $urn): Binding
@@ -69,7 +69,7 @@ abstract class Binding
      *
      * An exception will be thrown if it is unable to guess the binding.
      *
-     * @throws \SimpleSAML\SAML2\Exception\UnsupportedBindingException
+     * @throws \SimpleSAML\SAML2\Exception\Protocol\UnsupportedBindingException
      * @return \SimpleSAML\SAML2\Binding The binding.
      */
     public static function getCurrentBinding(): Binding

--- a/src/SAML2/Binding.php
+++ b/src/SAML2/Binding.php
@@ -6,6 +6,7 @@ namespace SimpleSAML\SAML2;
 
 use Exception;
 use SimpleSAML\SAML2\XML\samlp\AbstractMessage;
+use SimpleSAML\SAML2\Exception\UnsupportedBindingException;
 
 use function array_key_exists;
 use function array_keys;
@@ -36,7 +37,7 @@ abstract class Binding
      * Will throw an exception if it is unable to locate the binding.
      *
      * @param string $urn The URN of the binding.
-     * @throws \Exception
+     * @throws \SimpleSAML\SAML2\Exception\UnsupportedBindingException
      * @return \SimpleSAML\SAML2\Binding The binding.
      */
     public static function getBinding(string $urn): Binding
@@ -55,7 +56,7 @@ abstract class Binding
             case Constants::BINDING_PAOS:
                 return new SOAP();
             default:
-                throw new Exception('Unsupported binding: ' . var_export($urn, true));
+                throw new UnsupportedBindingException('Unsupported binding: ' . var_export($urn, true));
         }
     }
 
@@ -68,7 +69,7 @@ abstract class Binding
      *
      * An exception will be thrown if it is unable to guess the binding.
      *
-     * @throws \Exception
+     * @throws \SimpleSAML\SAML2\Exception\UnsupportedBindingException
      * @return \SimpleSAML\SAML2\Binding The binding.
      */
     public static function getCurrentBinding(): Binding
@@ -113,7 +114,7 @@ abstract class Binding
             $logger->warning('Content-Type: ' . var_export($_SERVER['CONTENT_TYPE'], true));
         }
 
-        throw new Exception('Unable to find the SAML 2 binding used for this request.');
+        throw new UnsupportedBindingException('Unable to find the SAML 2 binding used for this request.');
     }
 
 

--- a/src/SAML2/Exception/UnsupportedBindingException.php
+++ b/src/SAML2/Exception/UnsupportedBindingException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\SAML2\Exception;
+
+use Throwable;
+
+/**
+ * Named exception
+ */
+class UnsupportedBindingException extends RuntimeException implements Throwable
+{
+}

--- a/tests/SAML2/BindingTest.php
+++ b/tests/SAML2/BindingTest.php
@@ -8,6 +8,7 @@ use Exception;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\SAML2\Binding;
 use SimpleSAML\SAML2\Constants;
+use SimpleSAML\SAML2\Exception\UnsupportedBindingException;
 use SimpleSAML\SAML2\HTTPArtifact;
 use SimpleSAML\SAML2\HTTPPost;
 use SimpleSAML\SAML2\HTTPRedirect;
@@ -35,7 +36,7 @@ final class BindingTest extends TestCase
         $bind = Binding::getBinding(Constants::BINDING_PAOS);
         $this->assertInstanceOf(SOAP::class, $bind);
 
-        $this->expectException(Exception::class);
+        $this->expectException(UnsupportedBindingException::class);
         $this->expectExceptionMessage('Unsupported binding:');
         $bind = Binding::getBinding('nonsense');
     }
@@ -60,7 +61,7 @@ final class BindingTest extends TestCase
         $this->assertInstanceOf(HTTPArtifact::class, $bind);
 
         $_GET = ['aap' => 'noot'];
-        $this->expectException(Exception::class);
+        $this->expectException(UnsupportedBindingException::class);
         $this->expectExceptionMessage('Unable to find the SAML 2 binding used for this request.');
         $bind = Binding::getCurrentBinding();
     }
@@ -91,7 +92,7 @@ final class BindingTest extends TestCase
 
         $_POST = ['AAP' => 'Noot'];
         unset($_SERVER['CONTENT_TYPE']);
-        $this->expectException(Exception::class);
+        $this->expectException(UnsupportedBindingException::class);
         $this->expectExceptionMessage('Unable to find the SAML 2 binding used for this request.');
         $bind = Binding::getCurrentBinding();
     }
@@ -104,7 +105,7 @@ final class BindingTest extends TestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'PUT';
         $_SERVER['CONTENT_TYPE'] = 'text/xml';
-        $this->expectException(Exception::class);
+        $this->expectException(UnsupportedBindingException::class);
         $this->expectExceptionMessage('Unable to find the SAML 2 binding used for this request.');
         $bind = Binding::getCurrentBinding();
     }

--- a/tests/SAML2/BindingTest.php
+++ b/tests/SAML2/BindingTest.php
@@ -8,7 +8,7 @@ use Exception;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\SAML2\Binding;
 use SimpleSAML\SAML2\Constants;
-use SimpleSAML\SAML2\Exception\UnsupportedBindingException;
+use SimpleSAML\SAML2\Exception\Protocol\UnsupportedBindingException;
 use SimpleSAML\SAML2\HTTPArtifact;
 use SimpleSAML\SAML2\HTTPPost;
 use SimpleSAML\SAML2\HTTPRedirect;


### PR DESCRIPTION
Either whether there's a type specified that we don't know or if the guessing failed (the exception message will discern the two cases). This allows SimpleSAMLphp to handle this more neatly.