### PR TITLE
Widen semver range for psr/log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-dom": "*",
         "ext-zlib": "*",
 
-        "psr/log": "~1.1",
+        "psr/log": "~1.1 || ^2.0 || ^3.0",
         "simplesamlphp/xml-security": "^0.4.3",
         "simplesamlphp/assert": "^0.2.13"
     },


### PR DESCRIPTION
> hmm... on retrospect there doesn't seem to be a psr/log > 1.0.0?
> _Originally posted by @relaxnow in https://github.com/simplesamlphp/saml2/issues/25#issuecomment-63123866_

Hmm... there is now 😉  However, there are no real BC - just types: https://github.com/php-fig/log/compare/1.1.0...3.0.0

Thanks!