### PR TITLE
Refactor BaseID/NameIDTypeBaseidtype

### DIFF
--- a/src/SAML2/XML/saml/AbstractBaseID.php
+++ b/src/SAML2/XML/saml/AbstractBaseID.php
@@ -11,7 +11,6 @@ use SimpleSAML\SAML2\Constants as C;
 use SimpleSAML\SAML2\Utils;
 use SimpleSAML\SAML2\XML\ExtensionPointInterface;
 use SimpleSAML\SAML2\XML\ExtensionPointTrait;
-use SimpleSAML\SAML2\XML\IDNameQualifiersTrait;
 use SimpleSAML\XML\Chunk;
 use SimpleSAML\XML\Exception\InvalidDOMElementException;
 use SimpleSAML\XML\Exception\SchemaViolationException;
@@ -27,14 +26,12 @@ use function explode;
  *
  * @package simplesamlphp/saml2
  */
-abstract class AbstractBaseID extends AbstractSamlElement implements
-     BaseIdentifierInterface,
+abstract class AbstractBaseID extends AbstractBaseIDType implements
      EncryptableElementInterface,
      ExtensionPointInterface
 {
     use EncryptableElementTrait;
     use ExtensionPointTrait;
-    use IDNameQualifiersTrait;
 
     /** @var string */
     public const LOCALNAME = 'BaseID';
@@ -55,9 +52,8 @@ abstract class AbstractBaseID extends AbstractSamlElement implements
         ?string $NameQualifier = null,
         ?string $SPNameQualifier = null
     ) {
+        parent::__construct($NameQualifier, $SPNameQualifier);
         $this->type = $type;
-        $this->setNameQualifier($NameQualifier);
-        $this->setSPNameQualifier($SPNameQualifier);
     }
 
 
@@ -67,21 +63,6 @@ abstract class AbstractBaseID extends AbstractSamlElement implements
     public function getXsiType(): string
     {
         return $this->type;
-    }
-
-
-    public function getBlacklistedAlgorithms(): ?array
-    {
-        $container = ContainerSingleton::getInstance();
-        return $container->getBlacklistedEncryptionAlgorithms();
-    }
-
-
-    public function getEncryptionBackend(): ?EncryptionBackend
-    {
-        // return the encryption backend you want to use,
-        // or null if you are fine with the default
-        return null;
     }
 
 
@@ -146,7 +127,7 @@ abstract class AbstractBaseID extends AbstractSamlElement implements
      */
     public function toXML(DOMElement $parent = null): DOMElement
     {
-        $e = $this->instantiateParentElement($parent);
+        $e = parent::toXML($parent);
         $e->setAttribute('xmlns:' . static::getXsiTypePrefix(), static::getXsiTypeNamespaceURI());
         $e->setAttributeNS(C::NS_XSI, 'xsi:type', $this->getXsiType());
 
@@ -159,5 +140,19 @@ abstract class AbstractBaseID extends AbstractSamlElement implements
         }
 
         return $e;
+    }
+
+    public function getBlacklistedAlgorithms(): ?array
+    {
+        $container = ContainerSingleton::getInstance();
+        return $container->getBlacklistedEncryptionAlgorithms();
+    }
+
+
+    public function getEncryptionBackend(): ?EncryptionBackend
+    {
+        // return the encryption backend you want to use,
+        // or null if you are fine with the default
+        return null;
     }
 }

--- a/src/SAML2/XML/saml/AbstractBaseID.php
+++ b/src/SAML2/XML/saml/AbstractBaseID.php
@@ -128,8 +128,12 @@ abstract class AbstractBaseID extends AbstractBaseIDType implements
     public function toXML(DOMElement $parent = null): DOMElement
     {
         $e = parent::toXML($parent);
+
+        $xsiType = $e->ownerDocument->createAttributeNS(C::NS_XSI, 'xsi:type');
+        $xsiType->value = $this->getXsiType();
+        $e->setAttributeNodeNS($xsiType);
+
         $e->setAttribute('xmlns:' . static::getXsiTypePrefix(), static::getXsiTypeNamespaceURI());
-        $e->setAttributeNS(C::NS_XSI, 'xsi:type', $this->getXsiType());
 
         if ($this->getNameQualifier() !== null) {
             $e->setAttribute('NameQualifier', $this->getNameQualifier());

--- a/src/SAML2/XML/saml/AbstractBaseIDType.php
+++ b/src/SAML2/XML/saml/AbstractBaseIDType.php
@@ -2,16 +2,17 @@
 
 declare(strict_types=1);
 
-namespace SimpleSAML\SAML2\XML;
+namespace SimpleSAML\SAML2\XML\saml;
 
+use DOMElement;
 use SimpleSAML\Assert\Assert;
 
 /**
- * Trait grouping common functionality for elements implementing BaseIDAbstractType and NameIDType.
+ * SAML BaseID data type.
  *
  * @package simplesamlphp/saml2
  */
-trait IDNameQualifiersTrait
+abstract class AbstractBaseIDType extends AbstractSamlElement implements BaseIdentifierInterface
 {
     /**
      * The security or administrative domain that qualifies the identifier.
@@ -32,6 +33,21 @@ trait IDNameQualifiersTrait
      * @var string|null
      */
     protected ?string $SPNameQualifier = null;
+
+
+    /**
+     * Initialize a saml:BaseIDAbstractType from scratch
+     *
+     * @param string|null $NameQualifier
+     * @param string|null $SPNameQualifier
+     */
+    protected function __construct(
+        ?string $NameQualifier = null,
+        ?string $SPNameQualifier = null
+    ) {
+        $this->setNameQualifier($NameQualifier);
+        $this->setSPNameQualifier($SPNameQualifier);
+    }
 
 
     /**
@@ -76,5 +92,27 @@ trait IDNameQualifiersTrait
     {
         Assert::nullOrNotWhitespaceOnly($spNameQualifier);
         $this->SPNameQualifier = $spNameQualifier;
+    }
+
+
+    /**
+     * Convert this BaseID to XML.
+     *
+     * @param \DOMElement $parent The element we are converting to XML.
+     * @return \DOMElement The XML element after adding the data corresponding to this BaseID.
+     */
+    public function toXML(DOMElement $parent = null): DOMElement
+    {
+        $e = $this->instantiateParentElement($parent);
+
+        if ($this->NameQualifier !== null) {
+            $e->setAttribute('NameQualifier', $this->NameQualifier);
+        }
+
+        if ($this->SPNameQualifier !== null) {
+            $e->setAttribute('SPNameQualifier', $this->SPNameQualifier);
+        }
+
+        return $e;
     }
 }

--- a/src/SAML2/XML/saml/EncryptedID.php
+++ b/src/SAML2/XML/saml/EncryptedID.php
@@ -62,7 +62,7 @@ class EncryptedID extends AbstractSamlElement implements EncryptedElementInterfa
             case AbstractBaseID::NS . ':BaseID':
                 return AbstractBaseID::fromXML($xml);
             default:
-              // Fall thru
+                // Fall thru
         }
         throw new InvalidArgumentException('Unknown or unsupported encrypted identifier.');
     }

--- a/src/SAML2/XML/saml/NameID.php
+++ b/src/SAML2/XML/saml/NameID.php
@@ -6,15 +6,21 @@ namespace SimpleSAML\SAML2\XML\saml;
 
 use DOMElement;
 use SimpleSAML\Assert\Assert;
+use SimpleSAML\SAML2\Compat\ContainerSingleton;
 use SimpleSAML\XML\Exception\InvalidDOMElementException;
+use SimpleSAML\XMLSecurity\Backend\EncryptionBackend;
+use SimpleSAML\XMLSecurity\XML\EncryptableElementInterface;
+use SimpleSAML\XMLSecurity\XML\EncryptableElementTrait;
 
 /**
  * Class representing the saml:NameID element.
  *
  * @package simplesamlphp/saml2
  */
-final class NameID extends NameIDType
+final class NameID extends NameIDType implements EncryptableElementInterface
 {
+    use EncryptableElementTrait;
+
     /**
      * Initialize a saml:NameID
      *
@@ -55,5 +61,20 @@ final class NameID extends NameIDType
         $SPProvidedID = self::getAttribute($xml, 'SPProvidedID', null);
 
         return new static($xml->textContent, $NameQualifier, $SPNameQualifier, $Format, $SPProvidedID);
+    }
+
+
+    public function getBlacklistedAlgorithms(): ?array
+    {
+        $container = ContainerSingleton::getInstance();
+        return $container->getBlacklistedEncryptionAlgorithms();
+    }
+
+
+    public function getEncryptionBackend(): ?EncryptionBackend
+    {
+        // return the encryption backend you want to use,
+        // or null if you are fine with the default
+        return null;
     }
 }

--- a/src/SAML2/XML/saml/NameIDType.php
+++ b/src/SAML2/XML/saml/NameIDType.php
@@ -10,8 +10,6 @@ use SimpleSAML\SAML2\Compat\ContainerSingleton;
 use SimpleSAML\XML\StringElementTrait;
 use SimpleSAML\XMLSecurity\Backend\EncryptionBackend;
 use SimpleSAML\XMLSecurity\Constants as C;
-use SimpleSAML\XMLSecurity\XML\EncryptableElementInterface;
-use SimpleSAML\XMLSecurity\XML\EncryptableElementTrait;
 
 /**
  * SAML NameIDType abstract data type.
@@ -19,7 +17,7 @@ use SimpleSAML\XMLSecurity\XML\EncryptableElementTrait;
  * @package simplesamlphp/saml2
  */
 
-abstract class NameIDType extends AbstractBaseIDType implements  EncryptableElementInterface
+abstract class NameIDType extends AbstractBaseIDType
 {
     use StringElementTrait;
     use EncryptableElementTrait;
@@ -159,20 +157,5 @@ abstract class NameIDType extends AbstractBaseIDType implements  EncryptableElem
 
         $element->textContent = $this->getContent();
         return $element;
-    }
-
-
-    public function getBlacklistedAlgorithms(): ?array
-    {
-        $container = ContainerSingleton::getInstance();
-        return $container->getBlacklistedEncryptionAlgorithms();
-    }
-
-
-    public function getEncryptionBackend(): ?EncryptionBackend
-    {
-        // return the encryption backend you want to use,
-        // or null if you are fine with the default
-        return null;
     }
 }

--- a/src/SAML2/XML/saml/NameIDType.php
+++ b/src/SAML2/XML/saml/NameIDType.php
@@ -20,7 +20,6 @@ use SimpleSAML\XMLSecurity\Constants as C;
 abstract class NameIDType extends AbstractBaseIDType
 {
     use StringElementTrait;
-    use EncryptableElementTrait;
 
     /**
      * A URI reference representing the classification of string-based identifier information. See Section 8.3 for the

--- a/src/SAML2/XML/saml/NameIDType.php
+++ b/src/SAML2/XML/saml/NameIDType.php
@@ -147,14 +147,14 @@ abstract class NameIDType extends AbstractBaseIDType
         $e = parent::toXML($parent);
 
         if ($this->getFormat() !== null) {
-            $element->setAttribute('Format', $this->getFormat());
+            $e->setAttribute('Format', $this->getFormat());
         }
 
         if ($this->getSPProvidedID() !== null) {
-            $element->setAttribute('SPProvidedID', $this->getSPProvidedID());
+            $e->setAttribute('SPProvidedID', $this->getSPProvidedID());
         }
 
-        $element->textContent = $this->getContent();
-        return $element;
+        $e->textContent = $this->getContent();
+        return $e;
     }
 }

--- a/src/SAML2/XML/saml/NameIDType.php
+++ b/src/SAML2/XML/saml/NameIDType.php
@@ -7,7 +7,6 @@ namespace SimpleSAML\SAML2\XML\saml;
 use DOMElement;
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\SAML2\Compat\ContainerSingleton;
-use SimpleSAML\SAML2\XML\IDNameQualifiersTrait;
 use SimpleSAML\XML\StringElementTrait;
 use SimpleSAML\XMLSecurity\Backend\EncryptionBackend;
 use SimpleSAML\XMLSecurity\Constants as C;
@@ -20,9 +19,8 @@ use SimpleSAML\XMLSecurity\XML\EncryptableElementTrait;
  * @package simplesamlphp/saml2
  */
 
-abstract class NameIDType extends AbstractSamlElement implements BaseIdentifierInterface, EncryptableElementInterface
+abstract class NameIDType extends AbstractBaseIDType implements  EncryptableElementInterface
 {
-    use IDNameQualifiersTrait;
     use StringElementTrait;
     use EncryptableElementTrait;
 
@@ -73,11 +71,10 @@ abstract class NameIDType extends AbstractSamlElement implements BaseIdentifierI
         ?string $Format = null,
         ?string $SPProvidedID = null
     ) {
+        parent::__construct($NameQualifier, $SPNameQualifier);
         $this->dataType = C::XMLENC_ELEMENT;
 
         $this->setContent($value);
-        $this->setNameQualifier($NameQualifier);
-        $this->setSPNameQualifier($SPNameQualifier);
         $this->setFormat($Format);
         $this->setSPProvidedID($SPProvidedID);
     }
@@ -150,16 +147,7 @@ abstract class NameIDType extends AbstractSamlElement implements BaseIdentifierI
      */
     public function toXML(DOMElement $parent = null): DOMElement
     {
-        /** @psalm-var \DOMDocument $element->ownerDocument */
-        $element = $this->instantiateParentElement($parent);
-
-        if ($this->getNameQualifier() !== null) {
-            $element->setAttribute('NameQualifier', $this->getNameQualifier());
-        }
-
-        if ($this->getSPNameQualifier() !== null) {
-            $element->setAttribute('SPNameQualifier', $this->getSPNameQualifier());
-        }
+        $e = parent::toXML($parent);
 
         if ($this->getFormat() !== null) {
             $element->setAttribute('Format', $this->getFormat());

--- a/tests/SAML2/CustomBaseID.php
+++ b/tests/SAML2/CustomBaseID.php
@@ -35,15 +35,13 @@ final class CustomBaseID extends AbstractBaseID
     /**
      * CustomBaseID constructor.
      *
-     * @param \SimpleSAML\XML\Chunk $xml
+     * @param \SimpleSAML\SAML2\XML\saml\Audience[] $audience
      * @param string|null $NameQualifier
      * @param string|null $SPNameQualifier
      */
-    public function __construct(Chunk $xml, string $NameQualifier = null, string $SPNameQualifier = null)
+    public function __construct(array $audience, string $NameQualifier = null, string $SPNameQualifier = null)
     {
         parent::__construct(self::XSI_TYPE_PREFIX . ':' . self::XSI_TYPE_NAME, $NameQualifier, $SPNameQualifier);
-
-        $audience = Audience::getChildrenOfClass($xml->toXML());
         $this->setAudience($audience);
     }
 
@@ -90,7 +88,7 @@ final class CustomBaseID extends AbstractBaseID
         $nameQualifier = self::getAttribute($xml, 'NameQualifier', null);
         $spNameQualifier = self::getAttribute($xml, 'SPNameQualifier', null);
 
-        return new static(new Chunk($xml), $nameQualifier, $spNameQualifier);
+        return new static(Audience::getChildrenOfClass($xml), $nameQualifier, $spNameQualifier);
     }
 
 

--- a/tests/SAML2/CustomBaseID.php
+++ b/tests/SAML2/CustomBaseID.php
@@ -74,7 +74,6 @@ final class CustomBaseID extends AbstractBaseID
     public static function fromXML(DOMElement $xml): static
     {
         Assert::same($xml->localName, 'BaseID', InvalidDOMElementException::class);
-        Assert::notNull($xml->namespaceURI, InvalidDOMElementException::class);
         Assert::same($xml->namespaceURI, AbstractBaseID::NS, InvalidDOMElementException::class);
         Assert::true(
             $xml->hasAttributeNS(C::NS_XSI, 'type'),

--- a/tests/SAML2/CustomBaseID.php
+++ b/tests/SAML2/CustomBaseID.php
@@ -9,6 +9,7 @@ use SimpleSAML\Assert\Assert;
 use SimpleSAML\SAML2\XML\saml\Audience;
 use SimpleSAML\SAML2\XML\saml\AbstractBaseID;
 use SimpleSAML\Test\SAML2\Constants as C;
+use SimpleSAML\XML\Chunk;
 use SimpleSAML\XML\Exception\InvalidDOMElementException;
 
 /**
@@ -34,13 +35,15 @@ final class CustomBaseID extends AbstractBaseID
     /**
      * CustomBaseID constructor.
      *
-     * @param \SimpleSAML\SAML2\XML\saml\Audience[] $audience
+     * @param \SimpleSAML\XML\Chunk $xml
      * @param string|null $NameQualifier
      * @param string|null $SPNameQualifier
      */
-    public function __construct(array $audience, string $NameQualifier = null, string $SPNameQualifier = null)
+    public function __construct(Chunk $xml, string $NameQualifier = null, string $SPNameQualifier = null)
     {
         parent::__construct(self::XSI_TYPE_PREFIX . ':' . self::XSI_TYPE_NAME, $NameQualifier, $SPNameQualifier);
+
+        $audience = Audience::getChildrenOfClass($xml->toXML());
         $this->setAudience($audience);
     }
 
@@ -87,9 +90,7 @@ final class CustomBaseID extends AbstractBaseID
         $nameQualifier = self::getAttribute($xml, 'NameQualifier', null);
         $spNameQualifier = self::getAttribute($xml, 'SPNameQualifier', null);
 
-        $audience = Audience::getChildrenOfClass($xml);
-
-        return new static($audience, $nameQualifier, $spNameQualifier);
+        return new static(new Chunk($xml), $nameQualifier, $spNameQualifier);
     }
 
 

--- a/tests/SAML2/XML/mdui/LogoTest.php
+++ b/tests/SAML2/XML/mdui/LogoTest.php
@@ -108,6 +108,21 @@ IMG;
 
 
     /**
+     * Unmarshalling of a logo tag with a language
+     */
+    public function testUnmarshallingWithoutLanguage(): void
+    {
+        $xmlRepresentation = $this->xmlRepresentation->documentElement;
+        $xmlRepresentation->removeAttribute('xml:lang');
+        $logo = Logo::fromXML($xmlRepresentation);
+        $this->assertNull($logo->getLanguage());
+        $this->assertEquals(200, $logo->getHeight());
+        $this->assertEquals(300, $logo->getWidth());
+        $this->assertEquals($this->url, $logo->getContent());
+    }
+
+
+    /**
      * Unmarshalling of a logo tag with a data: URL
      */
     public function testUnmarshallingDataURL(): void

--- a/tests/SAML2/XML/mdui/LogoTest.php
+++ b/tests/SAML2/XML/mdui/LogoTest.php
@@ -108,21 +108,6 @@ IMG;
 
 
     /**
-     * Unmarshalling of a logo tag with a language
-     */
-    public function testUnmarshallingWithoutLanguage(): void
-    {
-        $xmlRepresentation = $this->xmlRepresentation->documentElement;
-        $xmlRepresentation->removeAttribute('xml:lang');
-        $logo = Logo::fromXML($xmlRepresentation);
-        $this->assertNull($logo->getLanguage());
-        $this->assertEquals(200, $logo->getHeight());
-        $this->assertEquals(300, $logo->getWidth());
-        $this->assertEquals($this->url, $logo->getContent());
-    }
-
-
-    /**
      * Unmarshalling of a logo tag with a data: URL
      */
     public function testUnmarshallingDataURL(): void

--- a/tests/SAML2/XML/saml/BaseIDTest.php
+++ b/tests/SAML2/XML/saml/BaseIDTest.php
@@ -60,7 +60,7 @@ final class BaseIDTest extends TestCase
     public function testMarshalling(): void
     {
         $baseId = new CustomBaseID(
-            new Chunk($this->xmlRepresentation->documentElement),
+            [new Audience('urn:some:audience')],
             'TheNameQualifier',
             'TheSPNameQualifier',
         );

--- a/tests/SAML2/XML/saml/BaseIDTest.php
+++ b/tests/SAML2/XML/saml/BaseIDTest.php
@@ -63,7 +63,7 @@ final class BaseIDTest extends TestCase
             'TheNameQualifier',
             'TheSPNameQualifier'
         );
-
+var_dump($baseId->toXML()->ownerDocument->saveXML());
         $this->assertEquals(
             $this->xmlRepresentation->saveXML($this->xmlRepresentation->documentElement),
             strval($baseId)

--- a/tests/SAML2/XML/saml/BaseIDTest.php
+++ b/tests/SAML2/XML/saml/BaseIDTest.php
@@ -14,6 +14,7 @@ use SimpleSAML\Test\SAML2\Constants as C;
 use SimpleSAML\Test\SAML2\CustomBaseID;
 use SimpleSAML\Test\XML\SchemaValidationTestTrait;
 use SimpleSAML\Test\XML\SerializableElementTestTrait;
+use SimpleSAML\XML\Chunk;
 use SimpleSAML\XML\DOMDocumentFactory;
 
 use function dirname;
@@ -59,14 +60,14 @@ final class BaseIDTest extends TestCase
     public function testMarshalling(): void
     {
         $baseId = new CustomBaseID(
-            [new Audience('urn:some:audience')],
+            new Chunk($this->xmlRepresentation->documentElement),
             'TheNameQualifier',
-            'TheSPNameQualifier'
+            'TheSPNameQualifier',
         );
-var_dump($baseId->toXML()->ownerDocument->saveXML());
+
         $this->assertEquals(
             $this->xmlRepresentation->saveXML($this->xmlRepresentation->documentElement),
-            strval($baseId)
+            strval($baseId),
         );
     }
 

--- a/tests/SAML2/XML/saml/EncryptedIDTest.php
+++ b/tests/SAML2/XML/saml/EncryptedIDTest.php
@@ -206,9 +206,7 @@ final class EncryptedIDTest extends TestCase
 
         // test a custom BaseID that's registered
         $customId = new CustomBaseID(
-            new Chunk(DOMDocumentFactory::fromFile(
-                dirname(dirname(dirname(dirname(__FILE__)))) . '/resources/xml/saml_BaseID.xml',
-            )->documentElement),
+            [new Audience('urn:some:audience')],
             'TheNameQualifier',
             'TheSPNameQualifier',
         );

--- a/tests/SAML2/XML/saml/SubjectTest.php
+++ b/tests/SAML2/XML/saml/SubjectTest.php
@@ -140,9 +140,10 @@ XML
     {
         $arbitrary = DOMDocumentFactory::fromString('<some>Arbitrary Element</some>');
 
-        $attr1 = $this->xmlRepresentation->createAttributeNS('urn:test:something', 'test:attr1');
+        $doc = DOMDocumentFactory::fromString('<root/>');
+        $attr1 = $doc->createAttributeNS('urn:test:something', 'test:attr1');
         $attr1->value = 'testval1';
-        $attr2 = $this->xmlRepresentation->createAttributeNS('urn:test:something', 'test:attr2');
+        $attr2 = $doc->createAttributeNS('urn:test:something', 'test:attr2');
         $attr2->value = 'testval2';
 
         $subjectConfirmationData = new SubjectConfirmationData(
@@ -203,9 +204,10 @@ XML
     {
         $arbitrary = DOMDocumentFactory::fromString('<some>Arbitrary Element</some>');
 
-        $attr1 = $this->xmlRepresentation->createAttributeNS('urn:test:something', 'test:attr1');
+        $doc = DOMDocumentFactory::fromString('<root/>');
+        $attr1 = $doc->createAttributeNS('urn:test:something', 'test:attr1');
         $attr1->value = 'testval1';
-        $attr2 = $this->xmlRepresentation->createAttributeNS('urn:test:something', 'test:attr2');
+        $attr2 = $doc->createAttributeNS('urn:test:something', 'test:attr2');
         $attr2->value = 'testval2';
 
         $subjectConfirmationData = new SubjectConfirmationData(
@@ -223,9 +225,7 @@ XML
 
         $subject = new Subject(
             new CustomBaseID(
-                new Chunk(DOMDocumentFactory::fromFile(
-                    dirname(dirname(dirname(dirname(__FILE__)))) . '/resources/xml/saml_Audience.xml',
-                )->documentElement),
+                [new Audience('urn:some:audience')],
                 'https://sp.example.org/authentication/sp/metadata',
             ),
             [

--- a/tests/SAML2/XML/saml/SubjectTest.php
+++ b/tests/SAML2/XML/saml/SubjectTest.php
@@ -223,8 +223,10 @@ XML
 
         $subject = new Subject(
             new CustomBaseID(
-                [new Audience('urn:some:audience')],
-                'https://sp.example.org/authentication/sp/metadata'
+                new Chunk(DOMDocumentFactory::fromFile(
+                    dirname(dirname(dirname(dirname(__FILE__)))) . '/resources/xml/saml_Audience.xml',
+                )->documentElement),
+                'https://sp.example.org/authentication/sp/metadata',
             ),
             [
                 new SubjectConfirmation(

--- a/tests/resources/xml/saml_BaseID.xml
+++ b/tests/resources/xml/saml_BaseID.xml
@@ -1,3 +1,3 @@
-<saml:BaseID xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ssp="urn:x-simplesamlphp:namespace" xsi:type="ssp:CustomBaseIDType" NameQualifier="TheNameQualifier" SPNameQualifier="TheSPNameQualifier">
+<saml:BaseID xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" NameQualifier="TheNameQualifier" SPNameQualifier="TheSPNameQualifier" xmlns:ssp="urn:x-simplesamlphp:namespace" xsi:type="ssp:CustomBaseIDType">
   <saml:Audience>urn:some:audience</saml:Audience>
 </saml:BaseID>


### PR DESCRIPTION
This PR brings back the AbstractBaseIDType that is a mutual ancestor between BaseID and NameIDType.
It also fixes the fact that we could encrypt Issuer, because encryption was implemented on the NameIDType rather than on the NameID.