### PR TITLE
Implement schema validation for alg-namespace

### DIFF
--- a/schemas/sstc-saml-metadata-algsupport-v1.0.xsd
+++ b/schemas/sstc-saml-metadata-algsupport-v1.0.xsd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+    SAML v2.0 Metadata Profile for Algorithm Support Version 1.0
+    Committee Specification 01
+    21 February 2011
+    Copyright (c) OASIS Open 2011.   All rights reserved.
+    Source: http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-metadata-algsupport-v1.0-cs01.xsd
+
+-->
+
+<schema 
+  targetNamespace="urn:oasis:names:tc:SAML:metadata:algsupport"
+  xmlns="http://www.w3.org/2001/XMLSchema"
+  xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport"
+  elementFormDefault="unqualified"
+  attributeFormDefault="unqualified"
+  blockDefault="substitution"
+  version="1.0">
+
+  <annotation>
+    <documentation>
+      Document title: Metadata Extension Schema for SAML V2.0 Metadata Profile for Algorithm Support Version 1.0
+      Document identifier: sstc-saml-metadata-algsupport.xsd
+      Location: http://docs.oasis-open.org/security/saml/Post2.0/
+      Revision history:
+      V1.0 (June 2010):
+        Initial version.
+      (October 2010):
+        Add processContents="lax" to wildcards.
+    </documentation>
+  </annotation>
+
+  <element name="DigestMethod" type="alg:DigestMethodType"/>
+  <complexType name="DigestMethodType">
+    <sequence>
+      <any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/>
+  </complexType>
+
+  <element name="SigningMethod" type="alg:SigningMethodType"/>
+  <complexType name="SigningMethodType">
+    <sequence>
+      <any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/>
+    <attribute name="MinKeySize" type="positiveInteger"/>
+    <attribute name="MaxKeySize" type="positiveInteger"/>
+  </complexType>
+
+</schema>
+

--- a/tests/SAML2/XML/alg/DigestMethodTest.php
+++ b/tests/SAML2/XML/alg/DigestMethodTest.php
@@ -10,9 +10,10 @@ use SimpleSAML\SAML2\XML\alg\DigestMethod;
 use SimpleSAML\SAML2\Utils;
 use SimpleSAML\Test\XML\SerializableElementTestTrait;
 use SimpleSAML\Test\XML\SchemaValidationTestTrait;
+use SimpleSAML\Test\SAML2\Constants as C;
+use SimpleSAML\XML\Chunk;
 use SimpleSAML\XML\DOMDocumentFactory;
 use SimpleSAML\XML\Exception\MissingAttributeException;
-use SimpleSAML\XMLSecurity\Constants as C;
 
 use function dirname;
 use function strval;
@@ -49,11 +50,16 @@ final class DigestMethodTest extends TestCase
      */
     public function testMarshalling(): void
     {
-        $digestMethod = new DigestMethod(C::DIGEST_SHA256);
+        $digestMethod = new DigestMethod(
+            C::DIGEST_SHA256,
+            [new Chunk(DOMDocumentFactory::fromString(
+                '<ssp:Chunk xmlns:ssp="urn:x-simplesamlphp:namespace">Some</ssp:Chunk>')->documentElement)
+            ],
+        );
 
         $this->assertEquals(
             $this->xmlRepresentation->saveXML($this->xmlRepresentation->documentElement),
-            strval($digestMethod)
+            strval($digestMethod),
         );
     }
 
@@ -65,6 +71,13 @@ final class DigestMethodTest extends TestCase
         $digestMethod = DigestMethod::fromXML($this->xmlRepresentation->documentElement);
 
         $this->assertEquals(C::DIGEST_SHA256, $digestMethod->getAlgorithm());
+
+        $elements = $digestMethod->getElements();
+        $this->assertCount(1, $elements);
+        $this->assertEquals('Chunk', $elements[0]->getLocalName());
+        $this->assertEquals('ssp', $elements[0]->getPrefix());
+        $this->assertEquals(C::NAMESPACE, $elements[0]->getNamespaceURI());
+        $this->assertEquals('Some', $elements[0]->getXML()->textContent);
     }
 
 

--- a/tests/SAML2/XML/alg/DigestMethodTest.php
+++ b/tests/SAML2/XML/alg/DigestMethodTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use SimpleSAML\SAML2\XML\alg\DigestMethod;
 use SimpleSAML\SAML2\Utils;
 use SimpleSAML\Test\XML\SerializableElementTestTrait;
+use SimpleSAML\Test\XML\SchemaValidationTestTrait;
 use SimpleSAML\XML\DOMDocumentFactory;
 use SimpleSAML\XML\Exception\MissingAttributeException;
 use SimpleSAML\XMLSecurity\Constants as C;
@@ -27,12 +28,15 @@ use function strval;
 final class DigestMethodTest extends TestCase
 {
     use SerializableElementTestTrait;
+    use SchemaValidationTestTrait;
 
 
     /**
      */
     protected function setUp(): void
     {
+        $this->schema = dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/schemas/sstc-saml-metadata-algsupport-v1.0.xsd';
+
         $this->testedClass = DigestMethod::class;
 
         $this->xmlRepresentation = DOMDocumentFactory::fromFile(

--- a/tests/SAML2/XML/alg/SigningMethodTest.php
+++ b/tests/SAML2/XML/alg/SigningMethodTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use SimpleSAML\SAML2\XML\alg\SigningMethod;
 use SimpleSAML\SAML2\Utils;
 use SimpleSAML\Test\XML\SerializableElementTestTrait;
+use SimpleSAML\Test\XML\SchemaValidationTestTrait;
 use SimpleSAML\XML\DOMDocumentFactory;
 use SimpleSAML\XML\Exception\MissingAttributeException;
 use SimpleSAML\XMLSecurity\Constants as C;
@@ -27,12 +28,15 @@ use function strval;
 final class SigningMethodTest extends TestCase
 {
     use SerializableElementTestTrait;
+    use SchemaValidationTestTrait;
 
 
     /**
      */
     protected function setUp(): void
     {
+        $this->schema = dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/schemas/sstc-saml-metadata-algsupport-v1.0.xsd';
+
         $this->testedClass = SigningMethod::class;
 
         $this->xmlRepresentation = DOMDocumentFactory::fromFile(

--- a/tests/SAML2/XML/md/EncryptionMethodTest.php
+++ b/tests/SAML2/XML/md/EncryptionMethodTest.php
@@ -89,7 +89,7 @@ final class EncryptionMethodTest extends TestCase
     public function testMarshallingElementOrdering(): void
     {
         $alg = C::KEY_TRANSPORT_OAEP_MGF1P;
-        $chunkXml = DOMDocumentFactory::fromString('<other:Element xmlns:other="urn:other:elt">Value</other:Element>');
+        $chunkXml = DOMDocumentFactory::fromString('<ssp:Chunk xmlns:ssp="urn:x-simplesamlphp:namespace">Value</ssp:Chunk>');
         $chunk = Chunk::fromXML($chunkXml->documentElement);
 
         $em = new EncryptionMethod($alg, 10, '9lWu3Q==', [$chunk]);
@@ -109,7 +109,7 @@ final class EncryptionMethodTest extends TestCase
 
         $this->assertCount(2, $emElements);
         $this->assertEquals('xenc:OAEPparams', $emElements[0]->tagName);
-        $this->assertEquals('other:Element', $emElements[1]->tagName);
+        $this->assertEquals('ssp:Chunk', $emElements[1]->tagName);
     }
 
 
@@ -127,8 +127,6 @@ final class EncryptionMethodTest extends TestCase
         $this->assertEquals($alg, $em->getAlgorithm());
         $this->assertEquals(10, $em->getKeySize());
         $this->assertEquals('9lWu3Q==', $em->getOAEPParams());
-        $this->assertCount(1, $em->getChildren());
-        $this->assertInstanceOf(Chunk::class, $em->getChildren()[0]);
     }
 
 

--- a/tests/resources/schemas/simplesamlphp.xsd
+++ b/tests/resources/schemas/simplesamlphp.xsd
@@ -18,41 +18,22 @@
         targetNamespace="urn:x-simplesamlphp:namespace"
         version="0.1" elementFormDefault="qualified"> 
 
+<include schemaLocation='../../../vendor/simplesamlphp/xml-common/tests/resources/schemas/simplesamlphp.xsd'/>
 <import namespace='urn:oasis:names:tc:SAML:2.0:metadata'
-          schemaLocation='../../../schemas/saml-schema-metadata-2.0.xsd'/>
-
-<!-- Start ExtendableElement -->
-
-<element name="ExtendableElement" type="ssp:ExtendableElementType"/>
-<complexType name="ExtendableElementType">
-  <sequence> 
-    <element ref="ssp:Chunk"/> 
-    <any namespace="##other" processContents="lax"/>
-    <!-- (1,1) elements from (1,1) external namespace -->
-  </sequence>  
-</complexType>
-
-<!-- End ExtendableElement -->
-
-<!-- Start Chunk -->
-
-<element name="Chunk" type="string"/>
-
-<!-- End Chunk -->
+        schemaLocation='../../../schemas/saml-schema-metadata-2.0.xsd'/>
 
 <!-- Start SomeRoleDescriptor -->
 
 <element name="SomeRoleDescriptor" type="ssp:SomeRoleDescriptorType"/>
-
-    <complexType name="SomeRoleDescriptorType">
-        <complexContent>
-            <extension base="md:RoleDescriptorType">
-                <sequence>
-                    <element ref="ssp:Chunk" maxOccurs="unbounded"/>
-                </sequence>
-            </extension>
-        </complexContent>
-    </complexType>
+<complexType name="SomeRoleDescriptorType">
+  <complexContent>
+    <extension base="md:RoleDescriptorType">
+      <sequence>
+        <element ref="ssp:Chunk" maxOccurs="unbounded"/>
+      </sequence>
+    </extension>
+  </complexContent>
+</complexType>
 
 <!-- End SomeRoleDescriptor -->
 

--- a/tests/resources/xml/alg_DigestMethod.xml
+++ b/tests/resources/xml/alg_DigestMethod.xml
@@ -1,1 +1,3 @@
-<alg:DigestMethod xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport" Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+<alg:DigestMethod xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport" Algorithm="http://www.w3.org/2001/04/xmlenc#sha256">
+  <ssp:Chunk xmlns:ssp="urn:x-simplesamlphp:namespace">Some</ssp:Chunk>
+</alg:DigestMethod>

--- a/tests/resources/xml/alg_SigningMethod.xml
+++ b/tests/resources/xml/alg_SigningMethod.xml
@@ -1,1 +1,3 @@
-<alg:SigningMethod xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport" Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" MinKeySize="1024" MaxKeySize="4096" />
+<alg:SigningMethod xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport" Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" MinKeySize="1024" MaxKeySize="4096">
+  <ssp:Chunk xmlns:ssp="urn:x-simplesamlphp:namespace">Some</ssp:Chunk>
+</alg:SigningMethod>


### PR DESCRIPTION
This also includes some fixes to the classes. They didn't implement the full schema (<xs:any element>)