### PR TITLE
Fix SOAP binding Content-Type and SOAPAction processing

### DIFF
--- a/src/SAML2/Binding.php
+++ b/src/SAML2/Binding.php
@@ -87,7 +87,15 @@ abstract class Binding
                     return new HTTPPost();
                 } elseif (array_key_exists('SAMLart', $_POST)) {
                     return new HTTPArtifact();
-                } elseif ($contentType === 'text/xml' || $contentType === 'application/soap+xml') {
+                } elseif (
+                    /**
+                     * The registration information for text/xml is in all respects the same
+                     * as that given for application/xml (RFC 7303 - Section 9.1)
+                     */
+                    ($contentType === 'text/xml' || $contentType === 'application/xml')
+                    // See paragraph 3.2.3 of Binding for SAML2 (OASIS)
+                    || $_SERVER['SOAPAction'] === 'http://www.oasis-open.org/committees/security')
+                {
                     return new SOAP();
                 }
                 break;

--- a/src/SAML2/Binding.php
+++ b/src/SAML2/Binding.php
@@ -94,7 +94,7 @@ abstract class Binding
                      */
                     ($contentType === 'text/xml' || $contentType === 'application/xml')
                     // See paragraph 3.2.3 of Binding for SAML2 (OASIS)
-                    || $_SERVER['HTTP_SOAPAction'] === 'http://www.oasis-open.org/committees/security')
+                    || $_SERVER['HTTP_SOAPACTION'] === 'http://www.oasis-open.org/committees/security')
                 {
                     return new SOAP();
                 }

--- a/src/SAML2/Binding.php
+++ b/src/SAML2/Binding.php
@@ -94,7 +94,7 @@ abstract class Binding
                      */
                     ($contentType === 'text/xml' || $contentType === 'application/xml')
                     // See paragraph 3.2.3 of Binding for SAML2 (OASIS)
-                    || $_SERVER['SOAPAction'] === 'http://www.oasis-open.org/committees/security')
+                    || $_SERVER['HTTP_SOAPAction'] === 'http://www.oasis-open.org/committees/security')
                 {
                     return new SOAP();
                 }

--- a/src/SAML2/Binding.php
+++ b/src/SAML2/Binding.php
@@ -94,7 +94,7 @@ abstract class Binding
                      */
                     ($contentType === 'text/xml' || $contentType === 'application/xml')
                     // See paragraph 3.2.3 of Binding for SAML2 (OASIS)
-                    || $_SERVER['HTTP_SOAPACTION'] === 'http://www.oasis-open.org/committees/security')
+                    || (isset($_SERVER['HTTP_SOAPACTION']) && $_SERVER['HTTP_SOAPACTION'] === 'http://www.oasis-open.org/committees/security'))
                 {
                     return new SOAP();
                 }

--- a/tests/SAML2/BindingTest.php
+++ b/tests/SAML2/BindingTest.php
@@ -78,12 +78,21 @@ class BindingTest extends \PHPUnit\Framework\TestCase
         $bind = Binding::getCurrentBinding();
         $this->assertInstanceOf(SOAP::class, $bind);
 
+        $_SERVER['CONTENT_TYPE'] = 'application/xml';
+        $bind = Binding::getCurrentBinding();
+        $this->assertInstanceOf(SOAP::class, $bind);
+
+        unset($_SERVER['CONTENT_TYPE']);
+        $_SERVER['HTTP_SOAPACTION'] = 'http://www.oasis-open.org/committees/security';
+        $bind = Binding::getCurrentBinding();
+        $this->assertInstanceOf(SOAP::class, $bind);
+        unset($_SERVER['HTTP_SOAPACTION']);
+
         $_POST = ['SAMLart' => 'AAQAAI4sWYpfoDDYJrHzsMnG+jyNM94p5ejn49a+nZ0s3ylY7knQ6tkLMDE='];
         $bind = Binding::getCurrentBinding();
         $this->assertInstanceOf(HTTPArtifact::class, $bind);
 
         $_POST = ['AAP' => 'Noot'];
-        unset($_SERVER['CONTENT_TYPE']);
         $this->expectException(UnsupportedBindingException::class, 'Unable to find the current binding.');
         $bind = Binding::getCurrentBinding();
     }


### PR DESCRIPTION
Removed incorrect application/soap+xml;  this is SOAP 1.2 specific and SAML2 doesn't support that