### PR TITLE
Do not create an "invalid" key when Org elements are empty.

### DIFF
--- a/src/SAML2/XML/md/Organization.php
+++ b/src/SAML2/XML/md/Organization.php
@@ -63,23 +63,14 @@ class Organization
         $this->Extensions = Extensions::getList($xml);
 
         $this->OrganizationName = Utils::extractLocalizedStrings($xml, Constants::NS_MD, 'OrganizationName');
-        if (empty($this->OrganizationName)) {
-            $this->OrganizationName = ['invalid' => ''];
-        }
 
         $this->OrganizationDisplayName = Utils::extractLocalizedStrings(
             $xml,
             Constants::NS_MD,
             'OrganizationDisplayName'
         );
-        if (empty($this->OrganizationDisplayName)) {
-            $this->OrganizationDisplayName = ['invalid' => ''];
-        }
 
         $this->OrganizationURL = Utils::extractLocalizedStrings($xml, Constants::NS_MD, 'OrganizationURL');
-        if (empty($this->OrganizationURL)) {
-            $this->OrganizationURL = ['invalid' => ''];
-        }
     }
 
 


### PR DESCRIPTION
This has been present since the initial commit. However it seems nothing handles 'invalid' keys after that or does anything with it. It's unclear what the meaning was or at least is. It does produce these keys in parsing metadata in SimpleSAML without (some) org elements.