### PR TITLE
Reintroduce container instantiation

### DIFF
--- a/src/SAML2/Compat/ContainerSingleton.php
+++ b/src/SAML2/Compat/ContainerSingleton.php
@@ -17,6 +17,9 @@ class ContainerSingleton
      */
     public static function getInstance(): AbstractContainer
     {
+        if (!isset(self::$container)) {
+            self::$container = self::initSspContainer();
+        }
         Assert::notNull(self::$container, 'No container set.');
         return self::$container;
     }
@@ -30,5 +33,14 @@ class ContainerSingleton
     public static function setContainer(AbstractContainer $container): void
     {
         self::$container = $container;
+    }
+
+
+    /**
+     * @return \SAML2\Compat\SspContainer
+     */
+    public static function initSspContainer() : SspContainer
+    {
+        return new SspContainer();
     }
 }


### PR DESCRIPTION
It was removed when moving from previous version,
but without it exception is always thrown because `ContainerSingleton` is never instantiated.

I was working on Drupal 10 integration of simplesaml and I had to make a custom patch to resolve saml2 container issue.
Link to `drupal/simplesamlphp_auth` D10 update issue https://www.drupal.org/project/simplesamlphp_auth/issues/3349278
