### PR TITLE
Fix bindings

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,6 +11,7 @@ on:  # yamllint disable-line rule:truthy
     branches: [master, release-*]
     paths:
       - '**.md'
+  workflow_dispatch:
 
 jobs:
   quality:

--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -13,6 +13,7 @@ on:  # yamllint disable-line rule:truthy
     paths-ignore:
       - '**.md'
       - '**.yml'
+  workflow_dispatch:
 
 jobs:
   edugain:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -285,8 +285,8 @@ jobs:
     runs-on: [ubuntu-latest]
     if: |
       always() &&
-      needs.coverage.result == 'success' &&
-      (needs.unit-tests-linux == 'success' || needs.coverage == 'skipped')
+      needs.coverage.result == 'success' ||
+      (needs.unit-tests-linux == 'success' && needs.coverage == 'skipped')
 
     steps:
       - uses: geekyeggo/delete-artifact@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ on:  # yamllint disable-line rule:truthy
     branches: [master, release-*]
     paths-ignore:
       - '**.md'
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   linter:

--- a/src/SAML2/Binding.php
+++ b/src/SAML2/Binding.php
@@ -26,6 +26,13 @@ use function var_export;
 abstract class Binding
 {
     /**
+     * The RelayState associated with the message.
+     *
+     * @var string|null
+     */
+    protected ?string $relayState = null;
+
+    /**
      * The destination of messages.
      *
      * This can be null, in which case the destination in the message is used.
@@ -146,6 +153,28 @@ abstract class Binding
     public function getDestination(): ?string
     {
         return $this->destination;
+    }
+
+
+    /**
+     * Set the RelayState associated with he message.
+     *
+     * @param string|null $relayState The RelayState.
+     */
+    public function setRelayState(string $relayState = null): void
+    {
+        $this->relayState = $relayState;
+    }
+
+
+    /**
+     * Get the RelayState associated with the message.
+     *
+     * @return string|null The RelayState.
+     */
+    public function getRelayState(): ?string
+    {
+        return $this->relayState;
     }
 
 

--- a/src/SAML2/HTTPArtifact.php
+++ b/src/SAML2/HTTPArtifact.php
@@ -85,7 +85,7 @@ class HTTPArtifact extends Binding
 
         $params = ['SAMLart' => $artifact];
 
-        $relayState = $message->getRelayState();
+        $relayState = $this->getRelayState();
         if ($relayState !== null) {
             $params['RelayState'] = $relayState;
         }
@@ -194,7 +194,7 @@ class HTTPArtifact extends Binding
         $samlResponse->addValidator([get_class($this), 'validateSignature'], $artifactResponse);
 
         if (isset($query['RelayState'])) {
-            $samlResponse->setRelayState($query['RelayState']);
+            $this->setRelayState($query['RelayState']);
         }
 
         return $samlResponse;

--- a/src/SAML2/HTTPPost.php
+++ b/src/SAML2/HTTPPost.php
@@ -43,7 +43,7 @@ class HTTPPost extends Binding
         } else {
             $destination = $this->destination;
         }
-        $relayState = $message->getRelayState();
+        $relayState = $this->getRelayState();
 
         $msgStr = $message->toXML();
 
@@ -110,7 +110,7 @@ class HTTPPost extends Binding
         }
 
         if (array_key_exists('RelayState', $query)) {
-            $msg->setRelayState($query['RelayState']);
+            $this->setRelayState($query['RelayState']);
         }
 
         return $msg;

--- a/src/SAML2/HTTPRedirect.php
+++ b/src/SAML2/HTTPRedirect.php
@@ -56,7 +56,7 @@ class HTTPRedirect extends Binding
             $destination = $this->destination;
         }
 
-        $relayState = $message->getRelayState();
+        $relayState = $this->getRelayState();
         $msgStr = $message->toXML();
 
         Utils::getContainer()->debugMessage($msgStr, 'out');
@@ -152,7 +152,7 @@ class HTTPRedirect extends Binding
 
         $msg = MessageFactory::fromXML($document->documentElement);
         if (array_key_exists('RelayState', $query)) {
-            $msg->setRelayState($query['RelayState']);
+            $this->setRelayState($query['RelayState']);
         }
         return $msg;
     }

--- a/src/SAML2/XML/samlp/AbstractMessage.php
+++ b/src/SAML2/XML/samlp/AbstractMessage.php
@@ -42,13 +42,6 @@ abstract class AbstractMessage extends AbstractSamlpElement implements SignableE
 
 
     /**
-     * The RelayState associated with this message.
-     *
-     * @var string|null
-     */
-    protected ?string $relayState = null;
-
-    /**
      * The \DOMDocument we are currently building.
      *
      * This variable is used while generating XML from this message. It holds the
@@ -80,7 +73,6 @@ abstract class AbstractMessage extends AbstractSamlpElement implements SignableE
      * @param string|null $destination
      * @param string|null $consent
      * @param \SimpleSAML\SAML2\XML\samlp\Extensions $extensions
-     * @param string|null $relayState
      *
      * @throws \Exception
      */
@@ -92,7 +84,6 @@ abstract class AbstractMessage extends AbstractSamlpElement implements SignableE
         protected ?string $destination = null,
         protected ?string $consent = null,
         ?Extensions $extensions = null,
-        ?string $relayState = null,
     ) {
         Assert::nullOrSame($issueInstant?->getTimeZone()->getName(), 'Z', ProtocolViolationException::class);
         Assert::nullOrValidNCName($id); // Covers the empty string
@@ -100,7 +91,6 @@ abstract class AbstractMessage extends AbstractSamlpElement implements SignableE
         Assert::nullOrValidURI($consent); // Covers the empty string
 
         $this->setExtensions($extensions);
-        $this->setRelayState($relayState);
     }
 
 
@@ -188,30 +178,6 @@ abstract class AbstractMessage extends AbstractSamlpElement implements SignableE
     public function isMessageConstructedWithSignature(): bool
     {
         return $this->messageContainedSignatureUponConstruction;
-    }
-
-
-    /**
-     * Retrieve the RelayState associated with this message.
-     *
-     * @return string|null The RelayState, or NULL if no RelayState is given
-     */
-    public function getRelayState(): ?string
-    {
-        return $this->relayState;
-    }
-
-
-    /**
-     * Set the RelayState associated with this message.
-     *
-     * @param string|null $relayState The new RelayState
-     */
-    public function setRelayState(string $relayState = null): void
-    {
-        Assert::nullOrNotWhitespaceOnly($relayState);
-
-        $this->relayState = $relayState;
     }
 
 

--- a/src/SAML2/XML/samlp/AbstractStatusResponse.php
+++ b/src/SAML2/XML/samlp/AbstractStatusResponse.php
@@ -34,7 +34,6 @@ abstract class AbstractStatusResponse extends AbstractMessage
      * @param string|null $destination
      * @param string|null $consent
      * @param \SimpleSAML\SAML2\XML\samlp\Extensions|null $extensions
-     * @param string|null $relayState
      *
      * @throws \Exception
      */
@@ -48,11 +47,10 @@ abstract class AbstractStatusResponse extends AbstractMessage
         ?string $destination = null,
         ?string $consent = null,
         ?Extensions $extensions = null,
-        ?string $relayState = null,
     ) {
         Assert::nullOrValidNCName($inResponseTo); // Covers the empty string
 
-        parent::__construct($issuer, $id, $version, $issueInstant, $destination, $consent, $extensions, $relayState);
+        parent::__construct($issuer, $id, $version, $issueInstant, $destination, $consent, $extensions);
     }
 
 

--- a/src/SAML2/XML/samlp/LogoutResponse.php
+++ b/src/SAML2/XML/samlp/LogoutResponse.php
@@ -37,7 +37,6 @@ final class LogoutResponse extends AbstractStatusResponse
      * @param string|null $destination
      * @param string|null $consent
      * @param \SimpleSAML\SAML2\XML\samlp\Extensions|null $extensions
-     * @param string|null $relayState
      *
      * @throws \Exception
      */
@@ -51,7 +50,6 @@ final class LogoutResponse extends AbstractStatusResponse
         ?string $destination = null,
         ?string $consent = null,
         ?Extensions $extensions = null,
-        ?string $relayState = null,
     ) {
         parent::__construct(
             $status,
@@ -63,7 +61,6 @@ final class LogoutResponse extends AbstractStatusResponse
             $destination,
             $consent,
             $extensions,
-            $relayState,
         );
     }
 

--- a/tests/SAML2/HTTPPostTest.php
+++ b/tests/SAML2/HTTPPostTest.php
@@ -78,7 +78,7 @@ final class HTTPPostTest extends TestCase
         $this->assertInstanceOf(Response::class, $response);
         $issuer = $response->getIssuer();
         $this->assertEquals('https://engine.test.surfconext.nl/authentication/idp/metadata', $issuer->getContent());
-        $relay = $response->getRelayState();
+        $relay = $hp->getRelayState();
         $this->assertEquals('relaystate001', $relay);
     }
 
@@ -161,7 +161,6 @@ final class HTTPPostTest extends TestCase
             issuer: $issuer,
             destination: 'http://example.org/login?success=yes',
         );
-        $response->setRelayState('http://example.org');
         $signer = (new SignatureAlgorithmFactory())->getAlgorithm(
             C::SIG_RSA_SHA256,
             PEMCertificatesMock::getPrivateKey(PEMCertificatesMock::SELFSIGNED_PRIVATE_KEY),
@@ -169,6 +168,7 @@ final class HTTPPostTest extends TestCase
         $response->sign($signer);
 
         $hr = new HTTPPost();
+        $hr->setRelayState('http://example.org');
         $hr->send($response);
     }
 }

--- a/tests/SAML2/HTTPRedirectTest.php
+++ b/tests/SAML2/HTTPRedirectTest.php
@@ -235,25 +235,6 @@ final class HTTPRedirectTest extends TestCase
 
 
     /**
-     */
-    public function testNoSigAlgSpecified(): void
-    {
-        $q = [
-            'SAMLRequest' => 'nVLBauMwEP0Vo7sjW7FpKpJA2rBsoNuGOruHXhZFHm8EsuRqxtv27yvbWWgvYelFgjfvzbx5zBJVazu56enkHuG5B6TktbUO5VhYsT446RUalE61gJK0rDY/7qSYZbILnrz2ln2QXFYoRAhkvGPJbrtiv7VoygJEoTJ9LOusXDSFuJ4vdH6cxwoIEGUjsrqoFUt+QcCoXLHYKMoRe9g5JOUoQlleprlI8/yQz6W4ksXiiSXbuI1xikbViahDyfkRSM2wD40DmjnL0bSdhcE6Hx7BTd3xqnqoIPw1GmbdqWPJNx80jCGtGIUeWLL5t8mtd9i3EM78n493/zWr9XVvx+58mj39IlUaR/QmKOPq4Dtkyf4c9E1EjPtzOePjREL5/XDYp/uH6sDWy6G3HDML66+5ayO7VlHx2dySf2y9nM7pPprabffeGv02ZNcquux5QEydNiNVUlAODTiKMVvrX24DKIJz8nw9jfx8tOt3',
-            'RelayState' => 'https://beta.surfnet.nl/simplesaml/module.php/core/authenticate.php?as=Braindrops',
-            'Signature' => 'b+qe/XGgICOrEL1v9dwuoy0RJtJ/GNAr7gJGYSJzLG0riPKwo7v5CH8GPC2P9IRikaeaNeQrnhBAaf8FCWrO0cLFw4qR6msK9bxRBGk+hIaTUYCh54ETrVCyGlmBneMgC5/iCRvtEW3ESPXCCqt8Ncu98yZmv9LIVyHSl67Se+fbB9sDw3/fzwYIHRMqK2aS8jnsnqlgnBGGOXqIqN3+d/2dwtCfz14s/9odoYzSUv32qfNPiPez6PSNqwhwH7dWE3TlO/jZmz0DnOeQ2ft6qdZEi5ZN5KCV6VmNKpkrLMq6DDPnuwPm/8oCAoT88R2jG7uf9QZB+ArWJKMEhDLsCA==',
-        ];
-        $request = new ServerRequest('GET', 'http://tnyholm.se');
-        $request = $request->withQueryParams($q);
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Missing signature algorithm');
-        $hr = new HTTPRedirect();
-        $hr->receive($request);
-    }
-
-
-    /**
      * test handling of non-deflated data in samlrequest
      */
     public function testInvalidRequestData(): void

--- a/tests/SAML2/HTTPRedirectTest.php
+++ b/tests/SAML2/HTTPRedirectTest.php
@@ -117,7 +117,7 @@ final class HTTPRedirectTest extends TestCase
         $hr = new HTTPRedirect();
         $samlrequest = $hr->receive($request);
         $this->assertInstanceOf(AbstractRequest::class, $samlrequest);
-        $relaystate = $samlrequest->getRelayState();
+        $relaystate = $hr->getRelayState();
         $this->assertEquals('https://profile.surfconext.nl/', $relaystate);
     }
 
@@ -140,7 +140,7 @@ final class HTTPRedirectTest extends TestCase
         $hr = new HTTPRedirect();
         $samlrequest = $hr->receive($request);
         $this->assertInstanceOf(AbstractRequest::class, $samlrequest);
-        $relaystate = $samlrequest->getRelayState();
+        $relaystate = $hr->getRelayState();
         $this->assertEquals(
             'https://demo.moo-archive.nl/module.php/admin/test/default-sp',
             $relaystate,
@@ -163,6 +163,7 @@ final class HTTPRedirectTest extends TestCase
         $request = $request->withQueryParams($q);
 
         $hr = new HTTPRedirect();
+        $hr->setRelayState(urlencode($q['RelayState']));
         $samlrequest = $hr->receive($request);
 
         // validate with the correct certificate, should verify
@@ -308,8 +309,9 @@ final class HTTPRedirectTest extends TestCase
             issuer: $issuer,
             destination: 'http://example.org/login?success=yes',
         );
-        $response->setRelayState('http://example.org');
+
         $hr = new HTTPRedirect();
+        $hr->setRelayState('http://example.org');
         $hr->send($response);
     }
 


### PR DESCRIPTION
- We cannot sign messages without knowledge of the keys. Leave it up to the implementation.
- Move RelayState from messages to bindings