### PR TITLE
Added explicit nullable types to satisfy PHP 8.4 deprecation

### DIFF
--- a/src/SAML2/ArtifactResolve.php
+++ b/src/SAML2/ArtifactResolve.php
@@ -25,7 +25,7 @@ class ArtifactResolve extends Request
      *
      * @param \DOMElement|null $xml The input assertion.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct('ArtifactResolve', $xml);
 

--- a/src/SAML2/ArtifactResponse.php
+++ b/src/SAML2/ArtifactResponse.php
@@ -30,7 +30,7 @@ class ArtifactResponse extends StatusResponse
      * @param \DOMElement|null $xml The input assertion.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct('ArtifactResponse', $xml);
 
@@ -54,7 +54,7 @@ class ArtifactResponse extends StatusResponse
      * @param \DOMElement|null $any
      * @return void
      */
-    public function setAny(DOMElement $any = null) : void
+    public function setAny(?DOMElement $any = null) : void
     {
         $this->any = $any;
     }

--- a/src/SAML2/Assertion.php
+++ b/src/SAML2/Assertion.php
@@ -247,7 +247,7 @@ class Assertion extends SignedElement
      * @param \DOMElement|null $xml The input assertion.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         // Create an Issuer
         $issuer = new Issuer();
@@ -771,7 +771,7 @@ class Assertion extends SignedElement
      * @param \SAML2\XML\saml\NameID|null $nameId The name identifier of the assertion.
      * @return void
      */
-    public function setNameId(NameID $nameId = null) : void
+    public function setNameId(?NameID $nameId = null) : void
     {
         $this->nameId = $nameId;
     }
@@ -937,7 +937,7 @@ class Assertion extends SignedElement
      * @param int|null $notBefore The earliest timestamp this assertion is valid.
      * @return void
      */
-    public function setNotBefore(int $notBefore = null) : void
+    public function setNotBefore(?int $notBefore = null) : void
     {
         $this->notBefore = $notBefore;
     }
@@ -965,7 +965,7 @@ class Assertion extends SignedElement
      * @param int|null $notOnOrAfter The latest timestamp this assertion is valid.
      * @return void
      */
-    public function setNotOnOrAfter(int $notOnOrAfter = null) : void
+    public function setNotOnOrAfter(?int $notOnOrAfter = null) : void
     {
         $this->notOnOrAfter = $notOnOrAfter;
     }
@@ -1015,7 +1015,7 @@ class Assertion extends SignedElement
      * @param array|null $validAudiences The allowed audiences.
      * @return void
      */
-    public function setValidAudiences(array $validAudiences = null) : void
+    public function setValidAudiences(?array $validAudiences = null) : void
     {
         $this->validAudiences = $validAudiences;
     }
@@ -1038,7 +1038,7 @@ class Assertion extends SignedElement
      * @param int|null $authnInstant Timestamp the user was authenticated, or NULL if we don't want an AuthnStatement.
      * @return void
      */
-    public function setAuthnInstant(int $authnInstant = null) : void
+    public function setAuthnInstant(?int $authnInstant = null) : void
     {
         $this->authnInstant = $authnInstant;
     }
@@ -1066,7 +1066,7 @@ class Assertion extends SignedElement
      * @param int|null $sessionNotOnOrAfter The latest timestamp this session is valid.
      * @return void
      */
-    public function setSessionNotOnOrAfter(int $sessionNotOnOrAfter = null) : void
+    public function setSessionNotOnOrAfter(?int $sessionNotOnOrAfter = null) : void
     {
         $this->sessionNotOnOrAfter = $sessionNotOnOrAfter;
     }
@@ -1092,7 +1092,7 @@ class Assertion extends SignedElement
      * @param string|null $sessionIndex The session index of the user at the IdP.
      * @return void
      */
-    public function setSessionIndex(string $sessionIndex = null) : void
+    public function setSessionIndex(?string $sessionIndex = null) : void
     {
         $this->sessionIndex = $sessionIndex;
     }
@@ -1121,7 +1121,7 @@ class Assertion extends SignedElement
      * @param string|null $authnContextClassRef The authentication method.
      * @return void
      */
-    public function setAuthnContextClassRef(string $authnContextClassRef = null) : void
+    public function setAuthnContextClassRef(?string $authnContextClassRef = null) : void
     {
         $this->authnContextClassRef = $authnContextClassRef;
     }
@@ -1144,7 +1144,7 @@ class Assertion extends SignedElement
      * @param string|null $signatureMethod
      * @return void
      */
-    public function setSignatureMethod(string $signatureMethod = null) : void
+    public function setSignatureMethod(?string $signatureMethod = null) : void
     {
         $this->signatureMethod = $signatureMethod;
     }
@@ -1190,7 +1190,7 @@ class Assertion extends SignedElement
      * @throws \Exception
      * @return void
      */
-    public function setAuthnContextDeclRef(string $authnContextDeclRef = null) : void
+    public function setAuthnContextDeclRef(?string $authnContextDeclRef = null) : void
     {
         if (!empty($this->authnContextDecl)) {
             throw new \Exception(
@@ -1274,7 +1274,7 @@ class Assertion extends SignedElement
      * @param array|null $signatureData
      * @return void
      */
-    public function setSignatureData(array $signatureData = null) : void
+    public function setSignatureData(?array $signatureData = null) : void
     {
         $this->signatureData = $signatureData;
     }
@@ -1394,7 +1394,7 @@ class Assertion extends SignedElement
      * @param XMLSecurityKey|null $signatureKey
      * @return void
      */
-    public function setSignatureKey(XMLSecurityKey $signatureKey = null) : void
+    public function setSignatureKey(?XMLSecurityKey $signatureKey = null) : void
     {
         $this->signatureKey = $signatureKey;
     }
@@ -1418,7 +1418,7 @@ class Assertion extends SignedElement
      * @param XMLSecurityKey|null $Key
      * @return void
      */
-    public function setEncryptionKey(XMLSecurityKey $Key = null) : void
+    public function setEncryptionKey(?XMLSecurityKey $Key = null) : void
     {
         $this->encryptionKey = $Key;
     }
@@ -1464,7 +1464,7 @@ class Assertion extends SignedElement
      * @param  \DOMNode|null $parentElement The DOM node the assertion should be created in.
      * @return \DOMElement   This assertion.
      */
-    public function toXML(\DOMNode $parentElement = null) : DOMElement
+    public function toXML(?\DOMNode $parentElement = null) : DOMElement
     {
         if ($parentElement === null) {
             $document = DOMDocumentFactory::create();

--- a/src/SAML2/AttributeQuery.php
+++ b/src/SAML2/AttributeQuery.php
@@ -47,7 +47,7 @@ class AttributeQuery extends SubjectQuery
      * @param \DOMElement|null $xml The input message.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct('AttributeQuery', $xml);
 

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -139,7 +139,7 @@ class AuthnRequest extends Request
      * @param \DOMElement|null $xml The input message.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct('AuthnRequest', $xml);
 
@@ -567,7 +567,7 @@ class AuthnRequest extends Request
      * @param string|null $assertionConsumerServiceURL The AssertionConsumerServiceURL attribute.
      * @return void
      */
-    public function setAssertionConsumerServiceURL(string $assertionConsumerServiceURL = null) : void
+    public function setAssertionConsumerServiceURL(?string $assertionConsumerServiceURL = null) : void
     {
         $this->assertionConsumerServiceURL = $assertionConsumerServiceURL;
     }
@@ -590,7 +590,7 @@ class AuthnRequest extends Request
      * @param string $protocolBinding The ProtocolBinding attribute.
      * @return void
      */
-    public function setProtocolBinding(string $protocolBinding = null) : void
+    public function setProtocolBinding(?string $protocolBinding = null) : void
     {
         $this->protocolBinding = $protocolBinding;
     }
@@ -613,7 +613,7 @@ class AuthnRequest extends Request
      * @param int|null $attributeConsumingServiceIndex The AttributeConsumingServiceIndex attribute.
      * @return void
      */
-    public function setAttributeConsumingServiceIndex(int $attributeConsumingServiceIndex = null) : void
+    public function setAttributeConsumingServiceIndex(?int $attributeConsumingServiceIndex = null) : void
     {
         $this->attributeConsumingServiceIndex = $attributeConsumingServiceIndex;
     }
@@ -636,7 +636,7 @@ class AuthnRequest extends Request
      * @param int|null $assertionConsumerServiceIndex The AssertionConsumerServiceIndex attribute.
      * @return void
      */
-    public function setAssertionConsumerServiceIndex(int $assertionConsumerServiceIndex = null) : void
+    public function setAssertionConsumerServiceIndex(?int $assertionConsumerServiceIndex = null) : void
     {
         $this->assertionConsumerServiceIndex = $assertionConsumerServiceIndex;
     }
@@ -659,7 +659,7 @@ class AuthnRequest extends Request
      * @param array|null $requestedAuthnContext The RequestedAuthnContext.
      * @return void
      */
-    public function setRequestedAuthnContext(array $requestedAuthnContext = null) : void
+    public function setRequestedAuthnContext(?array $requestedAuthnContext = null) : void
     {
         $this->requestedAuthnContext = $requestedAuthnContext;
     }
@@ -687,7 +687,7 @@ class AuthnRequest extends Request
      * @param \SAML2\XML\saml\NameID|null $nameId The name identifier of the assertion.
      * @return void
      */
-    public function setNameId(NameID $nameId = null) : void
+    public function setNameId(?NameID $nameId = null) : void
     {
         $this->nameId = $nameId;
     }

--- a/src/SAML2/Binding.php
+++ b/src/SAML2/Binding.php
@@ -137,7 +137,7 @@ abstract class Binding
      * @param string|null $destination The destination the message should be delivered to.
      * @return void
      */
-    public function setDestination(string $destination = null) : void
+    public function setDestination(?string $destination = null) : void
     {
         $this->destination = $destination;
     }

--- a/src/SAML2/Certificate/KeyLoader.php
+++ b/src/SAML2/Certificate/KeyLoader.php
@@ -43,7 +43,7 @@ class KeyLoader
      */
     public static function extractPublicKeys(
         CertificateProvider $config,
-        string $usage = null,
+        ?string $usage = null,
         bool $required = false
     ) : KeyCollection {
         $keyLoader = new self();
@@ -60,7 +60,7 @@ class KeyLoader
      */
     public function loadKeysFromConfiguration(
         CertificateProvider $config,
-        string $usage = null,
+        ?string $usage = null,
         bool $required = false
     ) : KeyCollection {
         $keys = $config->getKeys();
@@ -94,7 +94,7 @@ class KeyLoader
      * @param string|null $usage
      * @return void
      */
-    public function loadKeys($configuredKeys, string $usage = null) : void
+    public function loadKeys($configuredKeys, ?string $usage = null) : void
     {
         foreach ($configuredKeys as $keyData) {
             if (isset($keyData['X509Certificate'])) {

--- a/src/SAML2/Certificate/PrivateKey.php
+++ b/src/SAML2/Certificate/PrivateKey.php
@@ -14,7 +14,7 @@ class PrivateKey extends Key
      * @throws InvalidArgumentException
      * @return PrivateKey
      */
-    public static function create(string $keyContents, string $passphrase = null) : PrivateKey
+    public static function create(string $keyContents, ?string $passphrase = null) : PrivateKey
     {
         $keyData = ['PEM' => $keyContents, self::USAGE_ENCRYPTION => true];
         if ($passphrase) {

--- a/src/SAML2/Compat/AbstractContainer.php
+++ b/src/SAML2/Compat/AbstractContainer.php
@@ -80,5 +80,5 @@ abstract class AbstractContainer
      * @param int $mode The permissions to apply to the file. Defaults to 0600.
      * @return void
      */
-    abstract public function writeFile(string $filename, string $data, int $mode = null) : void;
+    abstract public function writeFile(string $filename, string $data, ?int $mode = null) : void;
 }

--- a/src/SAML2/Compat/MockContainer.php
+++ b/src/SAML2/Compat/MockContainer.php
@@ -103,7 +103,7 @@ class MockContainer extends AbstractContainer
      * @param array $data
      * @return void
      */
-    public function postRedirect(string $url = null, array $data = []) : void
+    public function postRedirect(?string $url = null, array $data = []) : void
     {
         $this->postRedirectUrl = $url;
         $this->postRedirectData = $data;
@@ -125,7 +125,7 @@ class MockContainer extends AbstractContainer
      * @param int|null $mode
      * @return void
      */
-    public function writeFile(string $filename, string $data, int $mode = null) : void
+    public function writeFile(string $filename, string $data, ?int $mode = null) : void
     {
         if ($mode === null) {
             $mode = 0600;

--- a/src/SAML2/Compat/Ssp/Container.php
+++ b/src/SAML2/Compat/Ssp/Container.php
@@ -125,7 +125,7 @@ class Container extends AbstractContainer
      * @param int|null $mode
      * @return void
      */
-    public function writeFile(string $filename, string $data, int $mode = null) : void
+    public function writeFile(string $filename, string $data, ?int $mode = null) : void
     {
         if ($mode === null) {
             $mode = 0600;

--- a/src/SAML2/Configuration/DecryptionProvider.php
+++ b/src/SAML2/Configuration/DecryptionProvider.php
@@ -24,7 +24,7 @@ interface DecryptionProvider
      *
      * @return mixed
      */
-    public function getPrivateKey(string $name, bool $required = null);
+    public function getPrivateKey(string $name, ?bool $required = null);
 
 
 

--- a/src/SAML2/Configuration/IdentityProvider.php
+++ b/src/SAML2/Configuration/IdentityProvider.php
@@ -77,7 +77,7 @@ class IdentityProvider extends ArrayAdapter implements CertificateProvider, Decr
      * @param bool $required
      * @return mixed|null
      */
-    public function getPrivateKey(string $name, bool $required = null)
+    public function getPrivateKey(string $name, ?bool $required = null)
     {
         if ($required === null) {
             $required = false;

--- a/src/SAML2/Configuration/ServiceProvider.php
+++ b/src/SAML2/Configuration/ServiceProvider.php
@@ -79,7 +79,7 @@ class ServiceProvider extends ArrayAdapter implements CertificateProvider, Decry
      * @param bool $required
      * @return mixed|null
      */
-    public function getPrivateKey(string $name, bool $required = null)
+    public function getPrivateKey(string $name, ?bool $required = null)
     {
         if ($required === null) {
             $required = false;

--- a/src/SAML2/EncryptedAssertion.php
+++ b/src/SAML2/EncryptedAssertion.php
@@ -35,7 +35,7 @@ class EncryptedAssertion
      * @param \DOMElement|null $xml The encrypted assertion XML element.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;
@@ -133,7 +133,7 @@ class EncryptedAssertion
      * @param  \DOMNode|null $parentElement The DOM node the assertion should be created in.
      * @return \DOMElement   This encrypted assertion.
      */
-    public function toXML(DOMNode $parentElement = null) : DOMElement
+    public function toXML(?DOMNode $parentElement = null) : DOMElement
     {
         if ($parentElement === null) {
             $document = DOMDocumentFactory::create();

--- a/src/SAML2/LogoutRequest.php
+++ b/src/SAML2/LogoutRequest.php
@@ -63,7 +63,7 @@ class LogoutRequest extends Request
      * @param \DOMElement|null $xml The input message.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct('LogoutRequest', $xml);
 
@@ -120,7 +120,7 @@ class LogoutRequest extends Request
      * @param int|null $notOnOrAfter The expiration time of this request.
      * @return void
      */
-    public function setNotOnOrAfter(int $notOnOrAfter = null) : void
+    public function setNotOnOrAfter(?int $notOnOrAfter = null) : void
     {
         $this->notOnOrAfter = $notOnOrAfter;
     }
@@ -295,7 +295,7 @@ class LogoutRequest extends Request
      * @param string|null $sessionIndex The sesion index of the session that should be terminated.
      * @return void
      */
-    public function setSessionIndex(string $sessionIndex = null) : void
+    public function setSessionIndex(?string $sessionIndex = null) : void
     {
         if (is_null($sessionIndex)) {
             $this->sessionIndexes = [];

--- a/src/SAML2/LogoutResponse.php
+++ b/src/SAML2/LogoutResponse.php
@@ -18,7 +18,7 @@ class LogoutResponse extends StatusResponse
      *
      * @param \DOMElement|null $xml     The input message.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct('LogoutResponse', $xml);
 

--- a/src/SAML2/Message.php
+++ b/src/SAML2/Message.php
@@ -136,7 +136,7 @@ abstract class Message extends SignedElement
      *
      * @throws \Exception
      */
-    protected function __construct(string $tagName, DOMElement $xml = null)
+    protected function __construct(string $tagName, ?DOMElement $xml = null)
     {
         $this->tagName = $tagName;
 
@@ -337,7 +337,7 @@ abstract class Message extends SignedElement
      * @param string|null $destination The new destination of this message
      * @return void
      */
-    public function setDestination(string $destination = null) : void
+    public function setDestination(?string $destination = null) : void
     {
         $this->destination = $destination;
     }
@@ -387,7 +387,7 @@ abstract class Message extends SignedElement
      * @param \SAML2\XML\saml\Issuer|null $issuer The new issuer of this message
      * @return void
      */
-    public function setIssuer(Issuer $issuer = null) : void
+    public function setIssuer(?Issuer $issuer = null) : void
     {
         $this->issuer = $issuer;
     }
@@ -421,7 +421,7 @@ abstract class Message extends SignedElement
      * @param string|null $relayState The new RelayState
      * @return void
      */
-    public function setRelayState(string $relayState = null) : void
+    public function setRelayState(?string $relayState = null) : void
     {
         $this->relayState = $relayState;
     }
@@ -520,7 +520,7 @@ abstract class Message extends SignedElement
      * @param XMLSecurityKey|null $signatureKey
      * @return void
      */
-    public function setSignatureKey(XMLSecurityKey $signatureKey = null) : void
+    public function setSignatureKey(?XMLSecurityKey $signatureKey = null) : void
     {
         $this->signatureKey = $signatureKey;
     }

--- a/src/SAML2/Response.php
+++ b/src/SAML2/Response.php
@@ -26,7 +26,7 @@ class Response extends StatusResponse
      *
      * @param \DOMElement|null $xml The input message.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct('Response', $xml);
 

--- a/src/SAML2/SOAPClient.php
+++ b/src/SAML2/SOAPClient.php
@@ -41,7 +41,7 @@ class SOAPClient
      *
      * @psalm-suppress UndefinedClass
      */
-    public function send(Message $msg, Configuration $srcMetadata, Configuration $dstMetadata = null) : Message
+    public function send(Message $msg, Configuration $srcMetadata, ?Configuration $dstMetadata = null) : Message
     {
         $issuer = $msg->getIssuer();
 

--- a/src/SAML2/SignedElement.php
+++ b/src/SAML2/SignedElement.php
@@ -85,7 +85,7 @@ abstract class SignedElement
      * @param XMLSecurityKey|null $signatureKey
      * @return void
      */
-    public function setSignatureKey(XMLSecurityKey $signatureKey = null) : void
+    public function setSignatureKey(?XMLSecurityKey $signatureKey = null) : void
     {
         $this->signatureKey = $signatureKey;
     }

--- a/src/SAML2/SignedElementHelper.php
+++ b/src/SAML2/SignedElementHelper.php
@@ -44,7 +44,7 @@ class SignedElementHelper extends SignedElement
      *
      * @param \DOMElement|null $xml The XML element which may be signed.
      */
-    protected function __construct(DOMElement $xml = null)
+    protected function __construct(?DOMElement $xml = null)
     {
         $this->certificates = [];
         $this->validators = [];
@@ -146,7 +146,7 @@ class SignedElementHelper extends SignedElement
      * @param XMLSecurityKey|null $signatureKey
      * @return void
      */
-    public function setSignatureKey(XMLSecurityKey $signatureKey = null) : void
+    public function setSignatureKey(?XMLSecurityKey $signatureKey = null) : void
     {
         $this->signatureKey = $signatureKey;
     }
@@ -225,7 +225,7 @@ class SignedElementHelper extends SignedElement
      * @param int|null $validUntil
      * @return void
      */
-    public function setValidUntil(int $validUntil = null) : void
+    public function setValidUntil(?int $validUntil = null) : void
     {
         $this->validUntil = $validUntil;
     }
@@ -248,7 +248,7 @@ class SignedElementHelper extends SignedElement
      * @param string|null $cacheDuration
      * @return void
      */
-    public function setCacheDuration(string $cacheDuration = null) : void
+    public function setCacheDuration(?string $cacheDuration = null) : void
     {
         $this->cacheDuration = $cacheDuration;
     }
@@ -261,7 +261,7 @@ class SignedElementHelper extends SignedElement
      * @param \DOMNode|null $insertBefore The element we should insert the signature node before.
      * @return \DOMElement|null
      */
-    protected function signElement(DOMElement $root, DOMNode $insertBefore = null) : ?DOMElement
+    protected function signElement(DOMElement $root, ?DOMNode $insertBefore = null) : ?DOMElement
     {
         if ($this->signatureKey === null) {
             /* We cannot sign this element. */

--- a/src/SAML2/StatusResponse.php
+++ b/src/SAML2/StatusResponse.php
@@ -52,7 +52,7 @@ abstract class StatusResponse extends Message
      * @param \DOMElement|null $xml The input message.
      * @throws \Exception
      */
-    protected function __construct(string $tagName, DOMElement $xml = null)
+    protected function __construct(string $tagName, ?DOMElement $xml = null)
     {
         parent::__construct($tagName, $xml);
 
@@ -127,7 +127,7 @@ abstract class StatusResponse extends Message
      * @param string|null $inResponseTo The ID of the request.
      * @return void
      */
-    public function setInResponseTo(string $inResponseTo = null) : void
+    public function setInResponseTo(?string $inResponseTo = null) : void
     {
         $this->inResponseTo = $inResponseTo;
     }

--- a/src/SAML2/SubjectQuery.php
+++ b/src/SAML2/SubjectQuery.php
@@ -35,7 +35,7 @@ abstract class SubjectQuery extends Request
      * @param string $tagName The tag name of the root element.
      * @param \DOMElement|null $xml The input message.
      */
-    protected function __construct(string $tagName, DOMElement $xml = null)
+    protected function __construct(string $tagName, ?DOMElement $xml = null)
     {
         parent::__construct($tagName, $xml);
 
@@ -92,7 +92,7 @@ abstract class SubjectQuery extends Request
      * @param \SAML2\XML\saml\NameID|null $nameId The name identifier of the assertion.
      * @return void
      */
-    public function setNameId(NameID $nameId = null) : void
+    public function setNameId(?NameID $nameId = null) : void
     {
         $this->nameId = $nameId;
     }

--- a/src/SAML2/Utils.php
+++ b/src/SAML2/Utils.php
@@ -120,7 +120,7 @@ class Utils
      * @param string $type Public or private key, defaults to public.
      * @return XMLSecurityKey The new key.
      */
-    public static function castKey(XMLSecurityKey $key, string $algorithm, string $type = null) : XMLSecurityKey
+    public static function castKey(XMLSecurityKey $key, string $algorithm, ?string $type = null) : XMLSecurityKey
     {
         $type = $type ?: 'public';
         Assert::oneOf($type, ["private", "public"]);
@@ -242,7 +242,7 @@ class Utils
      * @param \DOMElement|null $parent The target parent element.
      * @return \DOMElement The copied element.
      */
-    public static function copyElement(DOMElement $element, DOMElement $parent = null) : DOMElement
+    public static function copyElement(DOMElement $element, ?DOMElement $parent = null) : DOMElement
     {
         if ($parent === null) {
             $document = DOMDocumentFactory::create();
@@ -321,7 +321,7 @@ class Utils
         XMLSecurityKey $key,
         array $certificates,
         DOMElement $root,
-        DOMNode $insertBefore = null
+        ?DOMNode $insertBefore = null
     ) : void {
         $objXMLSecDSig = new XMLSecurityDSig();
         $objXMLSecDSig->setCanonicalMethod(XMLSecurityDSig::EXC_C14N);

--- a/src/SAML2/XML/Chunk.php
+++ b/src/SAML2/XML/Chunk.php
@@ -116,7 +116,7 @@ class Chunk implements Serializable
      * @param string|null $namespaceURI
      * @return void
      */
-    public function setNamespaceURI(string $namespaceURI = null) : void
+    public function setNamespaceURI(?string $namespaceURI = null) : void
     {
         $this->namespaceURI = $namespaceURI;
     }

--- a/src/SAML2/XML/alg/DigestMethod.php
+++ b/src/SAML2/XML/alg/DigestMethod.php
@@ -31,7 +31,7 @@ class DigestMethod
      *
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;

--- a/src/SAML2/XML/alg/SigningMethod.php
+++ b/src/SAML2/XML/alg/SigningMethod.php
@@ -47,7 +47,7 @@ class SigningMethod
      *
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;
@@ -108,7 +108,7 @@ class SigningMethod
      * @param int|null $minKeySize
      * @return void
      */
-    public function setMinKeySize(int $minKeySize = null) : void
+    public function setMinKeySize(?int $minKeySize = null) : void
     {
         $this->MinKeySize = $minKeySize;
     }
@@ -131,7 +131,7 @@ class SigningMethod
      * @param int|null $maxKeySize
      * @return void
      */
-    public function setMaxKeySize(int $maxKeySize = null) : void
+    public function setMaxKeySize(?int $maxKeySize = null) : void
     {
         $this->MaxKeySize = $maxKeySize;
     }

--- a/src/SAML2/XML/ds/KeyInfo.php
+++ b/src/SAML2/XML/ds/KeyInfo.php
@@ -40,7 +40,7 @@ class KeyInfo
      *
      * @param \DOMElement|null $xml The XML element we should load.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;
@@ -91,7 +91,7 @@ class KeyInfo
      * @param string|null $id
      * @return void
      */
-    public function setId(string $id = null) : void
+    public function setId(?string $id = null) : void
     {
         $this->Id = $id;
     }

--- a/src/SAML2/XML/ds/KeyName.php
+++ b/src/SAML2/XML/ds/KeyName.php
@@ -29,7 +29,7 @@ class KeyName
      *
      * @param \DOMElement|null $xml The XML element we should load.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;

--- a/src/SAML2/XML/ds/X509Certificate.php
+++ b/src/SAML2/XML/ds/X509Certificate.php
@@ -29,7 +29,7 @@ class X509Certificate
      *
      * @param \DOMElement|null $xml The XML element we should load.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;

--- a/src/SAML2/XML/ds/X509Data.php
+++ b/src/SAML2/XML/ds/X509Data.php
@@ -34,7 +34,7 @@ class X509Data
      *
      * @param \DOMElement|null $xml The XML element we should load.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;

--- a/src/SAML2/XML/ecp/Response.php
+++ b/src/SAML2/XML/ecp/Response.php
@@ -27,7 +27,7 @@ class Response
      *
      * @param \DOMElement|null $xml The XML element we should load.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;

--- a/src/SAML2/XML/md/AdditionalMetadataLocation.php
+++ b/src/SAML2/XML/md/AdditionalMetadataLocation.php
@@ -37,7 +37,7 @@ class AdditionalMetadataLocation
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;

--- a/src/SAML2/XML/md/AffiliationDescriptor.php
+++ b/src/SAML2/XML/md/AffiliationDescriptor.php
@@ -66,7 +66,7 @@ class AffiliationDescriptor extends SignedElementHelper
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct($xml);
 
@@ -145,7 +145,7 @@ class AffiliationDescriptor extends SignedElementHelper
      * @param string|null $Id
      * @return void
      */
-    public function setID(string $Id = null) : void
+    public function setID(?string $Id = null) : void
     {
         $this->ID = $Id;
     }

--- a/src/SAML2/XML/md/AttributeAuthorityDescriptor.php
+++ b/src/SAML2/XML/md/AttributeAuthorityDescriptor.php
@@ -70,7 +70,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct('md:AttributeAuthorityDescriptor', $xml);
 

--- a/src/SAML2/XML/md/AttributeConsumingService.php
+++ b/src/SAML2/XML/md/AttributeConsumingService.php
@@ -64,7 +64,7 @@ class AttributeConsumingService
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;
@@ -131,7 +131,7 @@ class AttributeConsumingService
      * @param bool|null $flag
      * @return void
      */
-    public function setIsDefault(bool $flag = null) : void
+    public function setIsDefault(?bool $flag = null) : void
     {
         $this->isDefault = $flag;
     }

--- a/src/SAML2/XML/md/AuthnAuthorityDescriptor.php
+++ b/src/SAML2/XML/md/AuthnAuthorityDescriptor.php
@@ -51,7 +51,7 @@ class AuthnAuthorityDescriptor extends RoleDescriptor
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct('md:AuthnAuthorityDescriptor', $xml);
 

--- a/src/SAML2/XML/md/ContactPerson.php
+++ b/src/SAML2/XML/md/ContactPerson.php
@@ -93,7 +93,7 @@ class ContactPerson
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;
@@ -204,7 +204,7 @@ class ContactPerson
      * @param string|null $company
      * @return void
      */
-    public function setCompany(string $company = null) : void
+    public function setCompany(?string $company = null) : void
     {
         $this->Company = $company;
     }
@@ -227,7 +227,7 @@ class ContactPerson
      * @param string|null $givenName
      * @return void
      */
-    public function setGivenName(string $givenName = null) : void
+    public function setGivenName(?string $givenName = null) : void
     {
         $this->GivenName = $givenName;
     }
@@ -250,7 +250,7 @@ class ContactPerson
      * @param string|null $surName
      * @return void
      */
-    public function setSurName(string $surName = null) : void
+    public function setSurName(?string $surName = null) : void
     {
         $this->SurName = $surName;
     }

--- a/src/SAML2/XML/md/EndpointType.php
+++ b/src/SAML2/XML/md/EndpointType.php
@@ -50,7 +50,7 @@ class EndpointType
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;
@@ -196,7 +196,7 @@ class EndpointType
      * @param string|null $location
      * @return void
      */
-    public function setLocation(string $location = null) : void
+    public function setLocation(?string $location = null) : void
     {
         $this->Location = $location;
     }
@@ -219,7 +219,7 @@ class EndpointType
      * @param string|null $responseLocation
      * @return void
      */
-    public function setResponseLocation(string $responseLocation = null) : void
+    public function setResponseLocation(?string $responseLocation = null) : void
     {
         $this->ResponseLocation = $responseLocation;
     }

--- a/src/SAML2/XML/md/EntitiesDescriptor.php
+++ b/src/SAML2/XML/md/EntitiesDescriptor.php
@@ -56,7 +56,7 @@ class EntitiesDescriptor extends SignedElementHelper
      *
      * @param \DOMElement|null $xml The XML element we should load.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct($xml);
 
@@ -107,7 +107,7 @@ class EntitiesDescriptor extends SignedElementHelper
      * @param string|null $name
      * @return void
      */
-    public function setName(string $name = null) : void
+    public function setName(?string $name = null) : void
     {
         $this->Name = $name;
     }
@@ -130,7 +130,7 @@ class EntitiesDescriptor extends SignedElementHelper
      * @param string|null $Id
      * @return void
      */
-    public function setID(string $Id = null) : void
+    public function setID(?string $Id = null) : void
     {
         $this->ID = $Id;
     }
@@ -151,7 +151,7 @@ class EntitiesDescriptor extends SignedElementHelper
      * @param int|null $validUntil
      * @return void
      */
-    public function setValidUntil(int $validUntil = null) : void
+    public function setValidUntil(?int $validUntil = null) : void
     {
         $this->validUntil = $validUntil;
     }
@@ -172,7 +172,7 @@ class EntitiesDescriptor extends SignedElementHelper
      * @param string|null $cacheDuration
      * @return void
      */
-    public function setCacheDuration(string $cacheDuration = null) : void
+    public function setCacheDuration(?string $cacheDuration = null) : void
     {
         $this->cacheDuration = $cacheDuration;
     }
@@ -255,7 +255,7 @@ class EntitiesDescriptor extends SignedElementHelper
      * @param \DOMElement|null $parent The EntitiesDescriptor we should append this EntitiesDescriptor to.
      * @return \DOMElement
      */
-    public function toXML(DOMElement $parent = null) : DOMElement
+    public function toXML(?DOMElement $parent = null) : DOMElement
     {
         if ($parent === null) {
             $doc = DOMDocumentFactory::create();

--- a/src/SAML2/XML/md/EntityDescriptor.php
+++ b/src/SAML2/XML/md/EntityDescriptor.php
@@ -86,7 +86,7 @@ class EntityDescriptor extends SignedElementHelper
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct($xml);
 
@@ -211,7 +211,7 @@ class EntityDescriptor extends SignedElementHelper
      * @param string|null $Id
      * @return void
      */
-    public function setID(string $Id = null) : void
+    public function setID(?string $Id = null) : void
     {
         $this->ID = $Id;
     }
@@ -232,7 +232,7 @@ class EntityDescriptor extends SignedElementHelper
      * @param int|null $validUntil
      * @return void
      */
-    public function setValidUntil(int $validUntil = null) : void
+    public function setValidUntil(?int $validUntil = null) : void
     {
         $this->validUntil = $validUntil;
     }
@@ -253,7 +253,7 @@ class EntityDescriptor extends SignedElementHelper
      * @param string|null $cacheDuration
      * @return void
      */
-    public function setCacheDuration(string $cacheDuration = null) : void
+    public function setCacheDuration(?string $cacheDuration = null) : void
     {
         $this->cacheDuration = $cacheDuration;
     }
@@ -346,7 +346,7 @@ class EntityDescriptor extends SignedElementHelper
      * @param \SAML2\XML\md\AffiliationDescriptor|null $affiliationDescriptor
      * @return void
      */
-    public function setAffiliationDescriptor(AffiliationDescriptor $affiliationDescriptor = null) : void
+    public function setAffiliationDescriptor(?AffiliationDescriptor $affiliationDescriptor = null) : void
     {
         $this->AffiliationDescriptor = $affiliationDescriptor;
     }
@@ -369,7 +369,7 @@ class EntityDescriptor extends SignedElementHelper
      * @param \SAML2\XML\md\Organization|null $organization
      * @return void
      */
-    public function setOrganization(Organization $organization = null) : void
+    public function setOrganization(?Organization $organization = null) : void
     {
         $this->Organization = $organization;
     }
@@ -451,7 +451,7 @@ class EntityDescriptor extends SignedElementHelper
      * @param \DOMElement|null $parent The EntitiesDescriptor we should append this EntityDescriptor to.
      * @return \DOMElement
      */
-    public function toXML(DOMElement $parent = null) : DOMElement
+    public function toXML(?DOMElement $parent = null) : DOMElement
     {
         if (empty($this->entityID)) {
             throw new \Exception('Cannot convert EntityDescriptor to XML without an EntityID set.');

--- a/src/SAML2/XML/md/IDPSSODescriptor.php
+++ b/src/SAML2/XML/md/IDPSSODescriptor.php
@@ -75,7 +75,7 @@ class IDPSSODescriptor extends SSODescriptorType
      *
      * @param \DOMElement|null $xml The XML element we should load.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct('md:IDPSSODescriptor', $xml);
 
@@ -126,7 +126,7 @@ class IDPSSODescriptor extends SSODescriptorType
      * @param bool|null $flag
      * @return void
      */
-    public function setWantAuthnRequestsSigned(bool $flag = null) : void
+    public function setWantAuthnRequestsSigned(?bool $flag = null) : void
     {
         $this->WantAuthnRequestsSigned = $flag;
     }

--- a/src/SAML2/XML/md/IndexedEndpointType.php
+++ b/src/SAML2/XML/md/IndexedEndpointType.php
@@ -36,7 +36,7 @@ class IndexedEndpointType extends EndpointType
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct($xml);
 
@@ -93,7 +93,7 @@ class IndexedEndpointType extends EndpointType
      * @param bool|null $flag
      * @return void
      */
-    public function setIsDefault(bool $flag = null) : void
+    public function setIsDefault(?bool $flag = null) : void
     {
         $this->isDefault = $flag;
     }

--- a/src/SAML2/XML/md/KeyDescriptor.php
+++ b/src/SAML2/XML/md/KeyDescriptor.php
@@ -51,7 +51,7 @@ class KeyDescriptor
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;
@@ -94,7 +94,7 @@ class KeyDescriptor
      * @param string|null $use
      * @return void
      */
-    public function setUse(string $use = null) : void
+    public function setUse(?string $use = null) : void
     {
         $this->use = $use;
     }

--- a/src/SAML2/XML/md/Organization.php
+++ b/src/SAML2/XML/md/Organization.php
@@ -54,7 +54,7 @@ class Organization
      *
      * @param \DOMElement|null $xml The XML element we should load.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;

--- a/src/SAML2/XML/md/PDPDescriptor.php
+++ b/src/SAML2/XML/md/PDPDescriptor.php
@@ -51,7 +51,7 @@ class PDPDescriptor extends RoleDescriptor
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct('md:PDPDescriptor', $xml);
 

--- a/src/SAML2/XML/md/RequestedAttribute.php
+++ b/src/SAML2/XML/md/RequestedAttribute.php
@@ -30,7 +30,7 @@ class RequestedAttribute extends Attribute
      *
      * @param \DOMElement|null $xml The XML element we should load.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct($xml);
 
@@ -59,7 +59,7 @@ class RequestedAttribute extends Attribute
      * @param bool|null $flag
      * @return void
      */
-    public function setIsRequired(bool $flag = null) : void
+    public function setIsRequired(?bool $flag = null) : void
     {
         $this->isRequired = $flag;
     }

--- a/src/SAML2/XML/md/RoleDescriptor.php
+++ b/src/SAML2/XML/md/RoleDescriptor.php
@@ -88,7 +88,7 @@ class RoleDescriptor extends SignedElementHelper
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    protected function __construct(string $elementName, DOMElement $xml = null)
+    protected function __construct(string $elementName, ?DOMElement $xml = null)
     {
         parent::__construct($xml);
         $this->elementName = $elementName;
@@ -155,7 +155,7 @@ class RoleDescriptor extends SignedElementHelper
      * @param string|null $Id
      * @return void
      */
-    public function setID(string $Id = null) : void
+    public function setID(?string $Id = null) : void
     {
         $this->ID = $Id;
     }
@@ -176,7 +176,7 @@ class RoleDescriptor extends SignedElementHelper
      * @param int|null $validUntil
      * @return void
      */
-    public function setValidUntil(int $validUntil = null) : void
+    public function setValidUntil(?int $validUntil = null) : void
     {
         $this->validUntil = $validUntil;
     }
@@ -197,7 +197,7 @@ class RoleDescriptor extends SignedElementHelper
      * @param string|null $cacheDuration
      * @return void
      */
-    public function setCacheDuration(string $cacheDuration = null) : void
+    public function setCacheDuration(?string $cacheDuration = null) : void
     {
         $this->cacheDuration = $cacheDuration;
     }
@@ -244,7 +244,7 @@ class RoleDescriptor extends SignedElementHelper
      * @param string|null $errorURL
      * @return void
      */
-    public function setErrorURL(string $errorURL = null) : void
+    public function setErrorURL(?string $errorURL = null) : void
     {
         if (!is_null($errorURL) && !filter_var($errorURL, FILTER_VALIDATE_URL)) {
             throw new \InvalidArgumentException('RoleDescriptor errorURL is not a valid URL.');
@@ -316,7 +316,7 @@ class RoleDescriptor extends SignedElementHelper
      * @param \SAML2\XML\md\Organization|null $organization
      * @return void
      */
-    public function setOrganization(Organization $organization = null) : void
+    public function setOrganization(?Organization $organization = null) : void
     {
         $this->Organization = $organization;
     }

--- a/src/SAML2/XML/md/SPSSODescriptor.php
+++ b/src/SAML2/XML/md/SPSSODescriptor.php
@@ -53,7 +53,7 @@ class SPSSODescriptor extends SSODescriptorType
      *
      * @param \DOMElement|null $xml The XML element we should load.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         parent::__construct('md:SPSSODescriptor', $xml);
 
@@ -93,7 +93,7 @@ class SPSSODescriptor extends SSODescriptorType
      * @param bool|null $flag
      * @return void
      */
-    public function setAuthnRequestsSigned(bool $flag = null) : void
+    public function setAuthnRequestsSigned(?bool $flag = null) : void
     {
         $this->AuthnRequestsSigned = $flag;
     }
@@ -116,7 +116,7 @@ class SPSSODescriptor extends SSODescriptorType
      * @param bool|null $flag
      * @return void
      */
-    public function setWantAssertionsSigned(bool $flag = null) : void
+    public function setWantAssertionsSigned(?bool $flag = null) : void
     {
         $this->WantAssertionsSigned = $flag;
     }

--- a/src/SAML2/XML/md/SSODescriptorType.php
+++ b/src/SAML2/XML/md/SSODescriptorType.php
@@ -59,7 +59,7 @@ abstract class SSODescriptorType extends RoleDescriptor
      * @param string $elementName The name of this element.
      * @param \DOMElement|null $xml The XML element we should load.
      */
-    protected function __construct(string $elementName, DOMElement $xml = null)
+    protected function __construct(string $elementName, ?DOMElement $xml = null)
     {
         parent::__construct($elementName, $xml);
 

--- a/src/SAML2/XML/mdattr/EntityAttributes.php
+++ b/src/SAML2/XML/mdattr/EntityAttributes.php
@@ -39,7 +39,7 @@ class EntityAttributes
      *
      * @param \DOMElement|null $xml The XML element we should load.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;

--- a/src/SAML2/XML/mdrpi/PublicationInfo.php
+++ b/src/SAML2/XML/mdrpi/PublicationInfo.php
@@ -54,7 +54,7 @@ class PublicationInfo
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;
@@ -139,7 +139,7 @@ class PublicationInfo
      * @param int|null $creationInstant
      * @return void
      */
-    public function setCreationInstant(int $creationInstant = null) : void
+    public function setCreationInstant(?int $creationInstant = null) : void
     {
         $this->creationInstant = $creationInstant;
     }
@@ -151,7 +151,7 @@ class PublicationInfo
      * @param string|null $publicationId
      * @return void
      */
-    public function setPublicationId(string $publicationId = null) : void
+    public function setPublicationId(?string $publicationId = null) : void
     {
         $this->publicationId = $publicationId;
     }

--- a/src/SAML2/XML/mdrpi/RegistrationInfo.php
+++ b/src/SAML2/XML/mdrpi/RegistrationInfo.php
@@ -46,7 +46,7 @@ class RegistrationInfo
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;
@@ -107,7 +107,7 @@ class RegistrationInfo
      * @param int|null $registrationInstant
      * @return void
      */
-    public function setRegistrationInstant(int $registrationInstant = null) : void
+    public function setRegistrationInstant(?int $registrationInstant = null) : void
     {
         $this->registrationInstant = $registrationInstant;
     }

--- a/src/SAML2/XML/mdui/DiscoHints.php
+++ b/src/SAML2/XML/mdui/DiscoHints.php
@@ -53,7 +53,7 @@ class DiscoHints
      *
      * @param \DOMElement|null $xml The XML element we should load.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;

--- a/src/SAML2/XML/mdui/Keywords.php
+++ b/src/SAML2/XML/mdui/Keywords.php
@@ -38,7 +38,7 @@ class Keywords
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;

--- a/src/SAML2/XML/mdui/Logo.php
+++ b/src/SAML2/XML/mdui/Logo.php
@@ -49,7 +49,7 @@ class Logo
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;

--- a/src/SAML2/XML/mdui/UIInfo.php
+++ b/src/SAML2/XML/mdui/UIInfo.php
@@ -74,7 +74,7 @@ class UIInfo
      *
      * @param \DOMElement|null $xml The XML element we should load.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;

--- a/src/SAML2/XML/saml/Attribute.php
+++ b/src/SAML2/XML/saml/Attribute.php
@@ -53,7 +53,7 @@ class Attribute
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;
@@ -118,7 +118,7 @@ class Attribute
      * @param string|null $nameFormat
      * @return void
      */
-    public function setNameFormat(string $nameFormat = null) : void
+    public function setNameFormat(?string $nameFormat = null) : void
     {
         $this->NameFormat = $nameFormat;
     }
@@ -141,7 +141,7 @@ class Attribute
      * @param string|null $friendlyName
      * @return void
      */
-    public function setFriendlyName(string $friendlyName = null) : void
+    public function setFriendlyName(?string $friendlyName = null) : void
     {
         $this->FriendlyName = $friendlyName;
     }

--- a/src/SAML2/XML/saml/BaseIDType.php
+++ b/src/SAML2/XML/saml/BaseIDType.php
@@ -35,7 +35,7 @@ abstract class BaseIDType
      *
      * @param \DOMElement|null $xml The XML element we should load, if any.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;
@@ -57,7 +57,7 @@ abstract class BaseIDType
      * @param \DOMElement $parent The element we are converting to XML.
      * @return \DOMElement The XML element after adding the data corresponding to this BaseID.
      */
-    public function toXML(DOMElement $parent = null) : DOMElement
+    public function toXML(?DOMElement $parent = null) : DOMElement
     {
         if ($parent === null) {
             $parent = DOMDocumentFactory::create();

--- a/src/SAML2/XML/saml/IDNameQualifiersTrait.php
+++ b/src/SAML2/XML/saml/IDNameQualifiersTrait.php
@@ -50,7 +50,7 @@ trait IDNameQualifiersTrait
      * @param string|null $nameQualifier
      * @return void
      */
-    public function setNameQualifier(string $nameQualifier = null) : void
+    public function setNameQualifier(?string $nameQualifier = null) : void
     {
         $this->NameQualifier = $nameQualifier;
     }
@@ -73,7 +73,7 @@ trait IDNameQualifiersTrait
      * @param string|null $spNameQualifier
      * @return void
      */
-    public function setSPNameQualifier(string $spNameQualifier = null) : void
+    public function setSPNameQualifier(?string $spNameQualifier = null) : void
     {
         $this->SPNameQualifier = $spNameQualifier;
     }

--- a/src/SAML2/XML/saml/Issuer.php
+++ b/src/SAML2/XML/saml/Issuer.php
@@ -42,7 +42,7 @@ class Issuer extends NameIDType
      *
      * @param \DOMElement|null $xml The XML element we should load, if any.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         /**
          * The format of this NameIDType.
@@ -99,7 +99,7 @@ class Issuer extends NameIDType
      * @param \DOMElement|null $parent The element we should append to.
      * @return \DOMElement The current Issuer object converted into a \DOMElement.
      */
-    public function toXML(DOMElement $parent = null) : DOMElement
+    public function toXML(?DOMElement $parent = null) : DOMElement
     {
         if (($this->Saml2IssuerShowAll && ($this->Format === Constants::NAMEID_ENTITY))
             || ($this->Format !== Constants::NAMEID_ENTITY)

--- a/src/SAML2/XML/saml/NameIDType.php
+++ b/src/SAML2/XML/saml/NameIDType.php
@@ -63,7 +63,7 @@ abstract class NameIDType implements Serializable
      *
      * @param \DOMElement|null $xml The XML element we should load, if any.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;
@@ -106,7 +106,7 @@ abstract class NameIDType implements Serializable
      * @param string|null $format
      * @return void
      */
-    public function setFormat(string $format = null) : void
+    public function setFormat(?string $format = null) : void
     {
         $this->Format = $format;
     }
@@ -152,7 +152,7 @@ abstract class NameIDType implements Serializable
      * @param string|null $spProvidedID
      * @return void
      */
-    public function setSPProvidedID(string $spProvidedID = null) : void
+    public function setSPProvidedID(?string $spProvidedID = null) : void
     {
         $this->SPProvidedID = $spProvidedID;
     }
@@ -164,7 +164,7 @@ abstract class NameIDType implements Serializable
      * @param \DOMElement $parent The element we are converting to XML.
      * @return \DOMElement The XML element after adding the data corresponding to this NameIDType.
      */
-    public function toXML(DOMElement $parent = null) : DOMElement
+    public function toXML(?DOMElement $parent = null) : DOMElement
     {
         if ($parent === null) {
             $parent = DOMDocumentFactory::create();

--- a/src/SAML2/XML/saml/SubjectConfirmation.php
+++ b/src/SAML2/XML/saml/SubjectConfirmation.php
@@ -45,7 +45,7 @@ class SubjectConfirmation
      * @param \DOMElement|null $xml The XML element we should load.
      * @throws \Exception
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;
@@ -114,7 +114,7 @@ class SubjectConfirmation
      * @param \SAML2\XML\saml\NameID $nameId
      * @return void
      */
-    public function setNameID(NameID $nameId = null) : void
+    public function setNameID(?NameID $nameId = null) : void
     {
         $this->NameID = $nameId;
     }
@@ -137,7 +137,7 @@ class SubjectConfirmation
      * @param \SAML2\XML\saml\SubjectConfirmationData|null $subjectConfirmationData
      * @return void
      */
-    public function setSubjectConfirmationData(SubjectConfirmationData $subjectConfirmationData = null) : void
+    public function setSubjectConfirmationData(?SubjectConfirmationData $subjectConfirmationData = null) : void
     {
         $this->SubjectConfirmationData = $subjectConfirmationData;
     }

--- a/src/SAML2/XML/saml/SubjectConfirmationData.php
+++ b/src/SAML2/XML/saml/SubjectConfirmationData.php
@@ -83,7 +83,7 @@ class SubjectConfirmationData
      * @param int|null $notBefore
      * @return void
      */
-    public function setNotBefore(int $notBefore = null) : void
+    public function setNotBefore(?int $notBefore = null) : void
     {
         $this->NotBefore = $notBefore;
     }
@@ -106,7 +106,7 @@ class SubjectConfirmationData
      * @param int|null $notOnOrAfter
      * @return void
      */
-    public function setNotOnOrAfter(int $notOnOrAfter = null) : void
+    public function setNotOnOrAfter(?int $notOnOrAfter = null) : void
     {
         $this->NotOnOrAfter = $notOnOrAfter;
     }
@@ -129,7 +129,7 @@ class SubjectConfirmationData
      * @param string|null $recipient
      * @return void
      */
-    public function setRecipient(string $recipient = null) : void
+    public function setRecipient(?string $recipient = null) : void
     {
         $this->Recipient = $recipient;
     }
@@ -152,7 +152,7 @@ class SubjectConfirmationData
      * @param string|null $inResponseTo
      * @return void
      */
-    public function setInResponseTo(string $inResponseTo = null) : void
+    public function setInResponseTo(?string $inResponseTo = null) : void
     {
         $this->InResponseTo = $inResponseTo;
     }
@@ -175,7 +175,7 @@ class SubjectConfirmationData
      * @param string|null $address
      * @return void
      */
-    public function setAddress(string $address = null) : void
+    public function setAddress(?string $address = null) : void
     {
         if (!is_null($address) && !filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6)) {
             Utils::getContainer()->getLogger()->warning(sprintf('Provided argument (%s) is not a valid IP address.', $address));
@@ -225,7 +225,7 @@ class SubjectConfirmationData
      *
      * @param \DOMElement|null $xml The XML element we should load.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;

--- a/src/SAML2/XML/shibmd/Scope.php
+++ b/src/SAML2/XML/shibmd/Scope.php
@@ -42,7 +42,7 @@ class Scope
      *
      * @param \DOMElement|null $xml The XML element we should load.
      */
-    public function __construct(DOMElement $xml = null)
+    public function __construct(?DOMElement $xml = null)
     {
         if ($xml === null) {
             return;


### PR DESCRIPTION
This PR fixes a variety of deprecation warnings found when running in PHP 8.4. 

In particular it fixes "Implicitly nullable parameter types are now deprecated." by explicitly declaring nullable parameters.