### PR TITLE
Fix confusion of the root-node when validating a signature

### DIFF
--- a/src/XML/saml/Assertion.php
+++ b/src/XML/saml/Assertion.php
@@ -17,6 +17,7 @@ use SimpleSAML\SAML2\XML\CanonicalizableElementTrait;
 use SimpleSAML\SAML2\XML\EncryptableElementTrait;
 use SimpleSAML\SAML2\XML\SignableElementTrait;
 use SimpleSAML\SAML2\XML\SignedElementTrait;
+use SimpleSAML\XML\DOMDocumentFactory;
 use SimpleSAML\XML\SchemaValidatableElementInterface;
 use SimpleSAML\XML\SchemaValidatableElementTrait;
 use SimpleSAML\XMLSchema\Exception\InvalidDOMElementException;
@@ -326,7 +327,10 @@ final class Assertion extends AbstractSamlElement implements
         if (!empty($signature)) {
             $assertion->setSignature($signature[0]);
             $assertion->wasSignedAtConstruction = true;
-            $assertion->setXML($xml);
+
+            $doc = DOMDocumentFactory::create();
+            $doc->appendChild($doc->importNode($xml, true));
+            $assertion->setXML($doc->documentElement);
         }
 
         return $assertion;

--- a/tests/Vulnerabilities/GoldenSAMLResponseTest.php
+++ b/tests/Vulnerabilities/GoldenSAMLResponseTest.php
@@ -16,16 +16,19 @@ use SimpleSAML\XMLSecurity\Key\PublicKey;
 use function dirname;
 
 /**
- * CVE-2025-66475
- *
  * @package simplesamlphp/saml2
  */
 #[Group('vulnerabilities')]
 final class GoldenSAMLResponseTest extends TestCase
 {
     /**
+     * CVE-2025-66475 / Void Canonicalization ("Golden SAML Response")
+     *
+     * A relative namespace on an ancestor causes libxml2 C14N to fail.
+     * After the fix this must be treated as fatal; the signature must not
+     * be accepted (even though DigestValue is the SHA-256 of the empty string).
      */
-    public function testSignedResponseWithStrayXmlnsThrowsAnException(): void
+    public function testGoldenSAMLResponseWithRelativeXmlnsIsRejected(): void
     {
         $doc = DOMDocumentFactory::fromFile(
             dirname(__DIR__, 1) . '/resources/xml/vulnerabilities/CVE-2025-66475.xml',
@@ -33,23 +36,27 @@ final class GoldenSAMLResponseTest extends TestCase
 
         $response = Response::fromXML($doc->documentElement);
         $assertion = $response->getAssertions()[0];
-        /** @var \SimpleSAML\XMLSecurity\XML\ds\X509Data $data */
-        $data = $assertion->getSignature()->getKeyInfo()->getInfo()[0];
+
+        // Key material taken from the Signature in the fixture
+        /** @var \SimpleSAML\XMLSecurity\XML\ds\X509Data $x509Data */
+        $x509Data = $assertion->getSignature()->getKeyInfo()->getInfo()[0];
+        $cert = $x509Data->getData()[0]->getContent()->getValue();
+
+        $alg = $assertion->getSignature()
+            ->getSignedInfo()
+            ->getSignatureMethod()
+            ->getAlgorithm()
+            ->getValue();
 
         $verifier = (new SignatureAlgorithmFactory())->getAlgorithm(
-            $assertion->getSignature()->getSignedInfo()->getSignatureMethod()->getAlgorithm()->getValue(),
+            $alg,
             new PublicKey(
-                new PEM(
-                    PEM::TYPE_PUBLIC_KEY,
-                    $data->getData()[0]->getContent()->getValue(),
-                ),
+                new PEM(PEM::TYPE_PUBLIC_KEY, $cert),
             ),
         );
 
         $this->expectException(CanonicalizationFailedException::class);
 
-        // When PHP 8.5 becomes the minimum:
-        // (void)@$assertion->verify($verifier);
         @$assertion->verify($verifier);
     }
 }


### PR DESCRIPTION
When unmarshalling an unsigned response containing a signed assertion, the validation of the assertion's signature fails.
This is because of the document we pull in this line of code:
https://github.com/simplesamlphp/xml-security/blob/master/src/XML/SignedElementTrait.php#L139

.. and because of what we pass to `Assertion::setXML()`.
Before this change we would pass the entire Response instead of just the Assertion. And because the Response is unsigned, the XPath-query `child::ds:Signature` yields no result, failing to pass the minCount-assertion.

Verified this using `var_dump($xml->ownerDocument->documentElement->localName);` after the referenced line 139. Before this change it returned `Response` and after it shows `Assertion`